### PR TITLE
feat(server): G8b scheduled grounding sweep (t/3172)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/groundingSweep.test.ts
+++ b/taxonomy-editor/src/server/__tests__/groundingSweep.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment node
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3172 (G8b) — scheduled full-taxonomy grounding sweep. The headline proof is the TWO GV ARMS the
+// ticket requires: a stale-hash tree reconciles (nodes_reconciled >= 1) and a clean tree does not
+// (nodes_reconciled == 0). The other three lock the contract: an overlapping tick SKIPS rather than
+// stacking a 2nd child, a child failure is caught + recorded and NEVER rethrown (must not crash the
+// host), and the flag gate leaves the timer un-armed when GROUNDING_SWEEP_ENABLED is OFF (default).
+//
+// The reconciler child is injected via __setSweepRunnerForTest, so no python is spawned; the flag
+// only gates timer-arming in startGroundingSweep, so the arm tests drive runSweep directly.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { records } = vi.hoisted(() => ({
+  records: [] as Array<{ type?: string; level?: string; message?: string; data?: Record<string, unknown> }>,
+}));
+
+// Capture FR records so the grounding.sweep events are assertable.
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({
+  getGlobalRecorder: () => ({ record: (r: unknown) => { records.push(r as { type?: string }); } }),
+  setGlobalRecorder: vi.fn(),
+}));
+
+import {
+  startGroundingSweep,
+  stopGroundingSweep,
+  __setSweepRunnerForTest,
+  __runSweepOnceForTest,
+  __resetSweepForTest,
+  __stateForTest,
+} from '../groundingSweepScheduler.js';
+import type { ReconcilerStats } from '../groundingReconcileHook.js';
+
+/** All grounding-sweep FR events captured this test. FR EventType has no 'grounding.sweep' member
+ *  (closed Shared-Lib union) — the component tag is the greppable identity, per G8a precedent. */
+function sweepEvents(): typeof records {
+  return records.filter((r) => (r as { component?: string }).component === 'grounding-sweep');
+}
+
+const ORIG_FLAG = process.env.GROUNDING_SWEEP_ENABLED;
+
+describe('G8b groundingSweepScheduler (t/3172)', () => {
+  beforeEach(() => {
+    records.length = 0;
+    __resetSweepForTest();
+    __setSweepRunnerForTest(null); // restore default; individual tests inject their own
+    delete process.env.GROUNDING_SWEEP_ENABLED;
+  });
+  afterEach(() => {
+    stopGroundingSweep();
+    __resetSweepForTest();
+    __setSweepRunnerForTest(null);
+    if (ORIG_FLAG === undefined) delete process.env.GROUNDING_SWEEP_ENABLED;
+    else process.env.GROUNDING_SWEEP_ENABLED = ORIG_FLAG;
+  });
+
+  // ── GV FAIL ARM: a stale-hash node reconciles ────────────────────────────────
+  it('GV/stale: a stale-hash tree reconciles → FR grounding.sweep with nodes_reconciled >= 1', async () => {
+    const stats: ReconcilerStats = { changed: 2, skipped: 4140, removed: 0 };
+    __setSweepRunnerForTest(async () => stats);
+
+    await __runSweepOnceForTest();
+
+    const done = sweepEvents().find((e) => e.data?.skipped === false && e.level === 'info');
+    expect(done).toBeDefined();
+    expect(done?.data?.nodes_reconciled).toBe(2);
+    expect(done?.data?.nodes_reconciled as number).toBeGreaterThanOrEqual(1);
+    expect(done?.data?.nodes_checked).toBe(2 + 4140 + 0); // changed + skipped + removed
+    expect(__stateForTest().inFlight).toBe(false); // flag cleared after the run
+  });
+
+  // ── GV CLEAN ARM: an up-to-date tree does zero reconciles ────────────────────
+  it('GV/clean: a fully up-to-date tree → FR grounding.sweep with nodes_reconciled == 0 (hash gate)', async () => {
+    const stats: ReconcilerStats = { changed: 0, skipped: 4144, removed: 0 };
+    __setSweepRunnerForTest(async () => stats);
+
+    await __runSweepOnceForTest();
+
+    const done = sweepEvents().find((e) => e.data?.skipped === false && e.level === 'info');
+    expect(done).toBeDefined();
+    expect(done?.data?.nodes_reconciled).toBe(0);
+    expect(done?.data?.nodes_checked).toBe(4144);
+    // No error/warn event on a clean run.
+    expect(sweepEvents().some((e) => e.level === 'error' || e.level === 'warn')).toBe(false);
+  });
+
+  // ── Non-overlapping: a 2nd tick while one is in flight SKIPS, does not stack ──
+  it('overlap: a concurrent tick is skipped (warn, skipped:true) and does not run the reconciler twice', async () => {
+    let releaseFirst!: () => void;
+    let calls = 0;
+    __setSweepRunnerForTest(() => {
+      calls++;
+      return new Promise<ReconcilerStats>((resolve) => {
+        releaseFirst = () => resolve({ changed: 1, skipped: 0, removed: 0 });
+      });
+    });
+
+    const first = __runSweepOnceForTest();  // enters, sets inFlight, awaits the held runner
+    await Promise.resolve();                // let the first microtask reach the await
+    expect(__stateForTest().inFlight).toBe(true);
+
+    await __runSweepOnceForTest();          // second tick — must skip immediately
+    const skip = sweepEvents().find((e) => e.level === 'warn' && e.data?.skipped === true);
+    expect(skip).toBeDefined();
+    expect(calls).toBe(1);                  // runner NOT invoked a second time
+
+    releaseFirst();
+    await first;
+    expect(__stateForTest().inFlight).toBe(false);
+    expect(calls).toBe(1);
+  });
+
+  // ── Failure containment: a child failure is recorded and NEVER rethrown ──────
+  it('failure: reconciler rejection is caught (no throw), recorded as error, inFlight cleared', async () => {
+    __setSweepRunnerForTest(async () => { throw new Error('reconcile_grounding.py exited 1: boom'); });
+
+    // Must resolve, not reject — an unhandled rejection on the bare setInterval would crash the host.
+    await expect(__runSweepOnceForTest()).resolves.toBeUndefined();
+
+    const err = sweepEvents().find((e) => e.level === 'error');
+    expect(err).toBeDefined();
+    expect(err?.data?.skipped).toBe(false);
+    expect(String(err?.message)).toMatch(/failed/i);
+    expect(__stateForTest().inFlight).toBe(false); // reset in finally → next tick can run
+  });
+
+  // ── Flag gate: default OFF → timer never armed ───────────────────────────────
+  it('flag OFF (default): startGroundingSweep does not arm the timer and returns a callable stop fn', () => {
+    delete process.env.GROUNDING_SWEEP_ENABLED;
+    const stop = startGroundingSweep(50);
+    expect(__stateForTest().armed).toBe(false);
+    expect(typeof stop).toBe('function');
+    stop(); // no-op, must not throw
+    expect(__stateForTest().armed).toBe(false);
+  });
+
+  it('flag ON: startGroundingSweep arms the timer; stop disarms it; a 2nd start is idempotent', () => {
+    process.env.GROUNDING_SWEEP_ENABLED = '1';
+    const stop = startGroundingSweep(50);
+    expect(__stateForTest().armed).toBe(true);
+    startGroundingSweep(50); // idempotent — still one timer
+    expect(__stateForTest().armed).toBe(true);
+    stop();
+    expect(__stateForTest().armed).toBe(false);
+  });
+});

--- a/taxonomy-editor/src/server/config.ts
+++ b/taxonomy-editor/src/server/config.ts
@@ -422,3 +422,14 @@ export function isCanaryLoopSamplerEnabled(): boolean {
   const v = process.env.CANARY_LOOP_SAMPLER?.trim().toLowerCase();
   return v === '1' || v === 'true';
 }
+
+// t/3172 (G8b): per-deploy switch for the scheduled full-taxonomy grounding sweep. DEFAULT OFF —
+// when off, startGroundingSweep() never arms its timer (zero behavior). Enable is sequenced behind
+// the reconciler tool-lock (t/3194, landed) AND the PS cmdlet lock-honoring (t/3203) with TL
+// lock-symmetry sign-off — the SAME lock-symmetry dependency as G8a's grounding_reconcile_inline
+// flag (t/3163#1); an unlocked concurrent writer could otherwise lost-update the shared grounding
+// file mid-sweep. Read per-call so the enable can be flipped via a revision env without a rebuild.
+export function isGroundingSweepEnabled(): boolean {
+  const v = process.env.GROUNDING_SWEEP_ENABLED?.trim().toLowerCase();
+  return v === '1' || v === 'true';
+}

--- a/taxonomy-editor/src/server/groundingSweepScheduler.ts
+++ b/taxonomy-editor/src/server/groundingSweepScheduler.ts
@@ -1,0 +1,182 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * G8b scheduled grounding sweep (t/3172, design e/131 + t/3163#1).
+ *
+ * A recurring, PATH-AGNOSTIC backstop for the G8a inline write-hook (groundingReconcileHook.ts):
+ * batch / PowerShell / Python writes bypass `PUT /api/taxonomy/:pov` entirely, so G8a never fires
+ * for them and their grounding silently goes stale. This timer shells out to CL's reconciler in
+ * FULL-SWEEP mode (`reconcile_grounding.py --apply`, NO `--nodes`) on a configurable interval. The
+ * reconciler is hash-gated (t/3160), so an up-to-date taxonomy does near-zero work — only nodes
+ * whose text changed since the last run actually reconcile.
+ *
+ * SAFETY (mirrors eventLoopMonitor.ts + the G8a hook):
+ *  - Non-overlapping: a `sweepInFlight` guard SKIPS (WARN) rather than stacking a 2nd child, so a
+ *    slow sweep can never pile up children that all just block on the tool-lock (process churn).
+ *  - Cross-process serialization is the reconciler's OWN `grounding_lock` (t/3194) — this module
+ *    needs no cross-process mutex, exactly as G8a (t/3163#1 ruling).
+ *  - Never crashes the host: a child failure is caught + FR/Pino logged and NEVER rethrown (a failed
+ *    grounding refresh must not take down the server — the #1737 masked-error lesson).
+ *  - `setInterval(...).unref()` — the timer never holds the process alive.
+ *
+ * ENABLE SEQUENCING: gated on `isGroundingSweepEnabled()` (env `GROUNDING_SWEEP_ENABLED`, default
+ * OFF). Stays OFF until the reconciler tool-lock (t/3194, landed) AND the PS cmdlet lock-honoring
+ * (t/3203) are confirmed with TL lock-symmetry sign-off — the SAME dependency as G8a's
+ * `grounding_reconcile_inline` flag (t/3163#1). Flag-OFF → the timer is never armed → zero behavior.
+ */
+
+import { execFile } from 'child_process';
+import { RECONCILE_SCRIPT, getProjectRoot, isGroundingSweepEnabled } from './config.js';
+import { getGlobalRecorder } from '../../../lib/flight-recorder/index.js';
+import { errorMessage } from '../../../lib/debate/errors.js';
+import { parseStats, type ReconcilerStats } from './groundingReconcileHook.js';
+import { log } from './logger.js';
+
+// Mirrors groundingReconcileHook.ts:35 / aiBackends.ts — the reconciler is a python3 script
+// (win32 dev uses `python`).
+const PYTHON = process.platform === 'win32' ? 'python' : 'python3';
+
+// ── Tunable constants (co-located) ────────────────────────────────────────────
+/** Default sweep cadence (min) per the t/3172 spec; overridable via GROUNDING_SWEEP_INTERVAL_MIN. */
+export const DEFAULT_INTERVAL_MIN = 15;
+/** A full sweep loads the dict+embeddings and walks the whole taxonomy — give it the same generous
+ *  ceiling as a scoped reconcile; the hash gate keeps the real work bounded. */
+const SWEEP_TIMEOUT_MS = 120_000;
+const SWEEP_MAX_BUFFER = 10 * 1024 * 1024;
+
+/** Resolve the configured interval (ms), floored at 1 min so a misconfig can't hot-loop the child. */
+export function resolveIntervalMs(): number {
+  const raw = parseInt(process.env.GROUNDING_SWEEP_INTERVAL_MIN || String(DEFAULT_INTERVAL_MIN), 10);
+  const min = Number.isFinite(raw) && raw >= 1 ? raw : DEFAULT_INTERVAL_MIN;
+  return min * 60_000;
+}
+
+// ── Injectable runner (testability — both GV arms drive changed/clean/failure without python) ──
+export type SweepRunner = () => Promise<ReconcilerStats>;
+
+/** Default runner: full-sweep child (`--apply`, no `--nodes` = whole taxonomy). Presence of NO
+ *  `--nodes` selects the reconciler's full mode; `--apply` persists under its own grounding_lock. */
+function defaultRunner(): Promise<ReconcilerStats> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      PYTHON,
+      [RECONCILE_SCRIPT, '--apply'],
+      { cwd: getProjectRoot(), timeout: SWEEP_TIMEOUT_MS, maxBuffer: SWEEP_MAX_BUFFER },
+      (err, stdout, stderr) => {
+        if (err) { reject(new Error(`reconcile_grounding.py (full sweep) exited non-zero/timeout: ${err.message}\n${stderr}`)); return; }
+        resolve(parseStats(stdout));
+      },
+    );
+  });
+}
+
+let _runner: SweepRunner = defaultRunner;
+
+// ── State (module singleton — one timer, at most one child in flight) ──────────
+let timer: ReturnType<typeof setInterval> | null = null;
+let sweepInFlight = false;
+
+/** Sum the reconciler's stat arms into a nodes_checked total, treating a parse-miss null as 0. */
+function checkedTotal(s: ReconcilerStats): number {
+  return (s.changed ?? 0) + (s.skipped ?? 0) + (s.removed ?? 0);
+}
+
+/** One sweep tick: skip-if-overlapping, run the full reconcile, record the outcome. Never throws. */
+async function runSweep(): Promise<void> {
+  if (sweepInFlight) {
+    // Overlap: a prior sweep is still running. Skip (do NOT stack) and make the skip visible — a
+    // sweep that never completes would otherwise look identical to one that never ran.
+    getGlobalRecorder()?.record({
+      // FR EventType is a closed union (Shared Lib) — no 'grounding.sweep' member; mirror G8a's
+      // grounding-reconcile precedent: system.info/system.error carry the level, `component`
+      // ('grounding-sweep') is the greppable identity, `data.skipped` distinguishes the overlap case.
+      type: 'system.error', component: 'grounding-sweep', level: 'warn',
+      message: 'Grounding sweep skipped — prior run still in flight',
+      data: { skipped: true, nodes_checked: 0, nodes_reconciled: 0, nodes_removed: 0, duration_ms: 0 },
+    });
+    log.server.warn({ component: 'grounding-sweep' }, 'Grounding sweep skipped — prior run in flight');
+    return;
+  }
+  sweepInFlight = true;
+  const startedMs = Date.now();
+  // Routine start — Pino only; emitting a start event to the capacity-bounded FR ring every 15 min
+  // would evict real events (same rationale as eventLoopMonitor's info gauge).
+  log.server.info({ component: 'grounding-sweep' }, 'Grounding sweep started');
+  try {
+    const stats = await _runner();
+    const duration_ms = Date.now() - startedMs;
+    const nodes_reconciled = stats.changed ?? 0;
+    getGlobalRecorder()?.record({
+      type: 'system.info', component: 'grounding-sweep', level: 'info',
+      message: `Grounding sweep: ${nodes_reconciled} reconciled, ${stats.skipped ?? '?'} skipped, ${stats.removed ?? 0} removed`,
+      data: {
+        skipped: false,
+        nodes_checked: checkedTotal(stats),
+        nodes_reconciled,
+        nodes_removed: stats.removed ?? 0,
+        duration_ms,
+      },
+    });
+    log.server.info(
+      { component: 'grounding-sweep', nodes_reconciled, skipped: stats.skipped, removed: stats.removed, duration_ms },
+      'Grounding sweep complete',
+    );
+  } catch (err) {
+    // Fallback-Path Logging: a failed sweep leaves grounding stale until the next tick — that must
+    // be visible (silent degradation is invisible). WARN-level FR + Pino, but NEVER rethrow: this
+    // runs on a bare setInterval, so an unhandled rejection here would crash the host process.
+    const duration_ms = Date.now() - startedMs;
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'grounding-sweep', level: 'error',
+      message: `Grounding sweep FAILED — grounding may be stale until the next sweep: ${errorMessage(err)}`,
+      data: { skipped: false, nodes_checked: 0, nodes_reconciled: 0, nodes_removed: 0, duration_ms },
+      error: { name: (err as Error)?.name ?? 'Error', message: errorMessage(err), stack: (err as Error)?.stack },
+    });
+    log.server.error({ component: 'grounding-sweep', err: errorMessage(err), duration_ms }, 'Grounding sweep failed (non-fatal)');
+  } finally {
+    sweepInFlight = false;
+  }
+}
+
+/**
+ * Start the recurring grounding sweep. Idempotent (a second call is a no-op while running). The
+ * interval is `unref()`d so it never keeps the process alive. Returns the stop fn.
+ *
+ * Gated on `isGroundingSweepEnabled()`: when the flag is OFF the timer is NEVER armed — the sweep is
+ * completely inert (this is the default, pending the sequenced enable). Returns a no-op stop fn in
+ * that case so the caller contract is identical either way.
+ */
+export function startGroundingSweep(intervalMs: number = resolveIntervalMs()): () => void {
+  if (!isGroundingSweepEnabled()) {
+    // Log-once so an operator can see the sweep is present-but-disabled (vs. silently absent).
+    log.server.info({ component: 'grounding-sweep' }, 'Grounding sweep disabled (GROUNDING_SWEEP_ENABLED off) — timer not armed');
+    return () => { /* no-op: nothing was armed */ };
+  }
+  if (timer) return stopGroundingSweep;
+  log.server.info({ component: 'grounding-sweep', intervalMs }, 'Grounding sweep enabled — arming timer');
+  timer = setInterval(() => { void runSweep(); }, intervalMs);
+  timer.unref();
+  return stopGroundingSweep;
+}
+
+/** Stop the sweep timer (idempotent). Does not interrupt an in-flight child — it finishes and clears
+ *  the sweepInFlight flag on its own. */
+export function stopGroundingSweep(): void {
+  if (timer) { clearInterval(timer); timer = null; }
+}
+
+// ── Test hooks (underscore-prefixed — not part of the caller contract) ─────────
+/** Inject a fake sweep runner; pass null to restore the real execFile-based runner. */
+export function __setSweepRunnerForTest(r: SweepRunner | null): void { _runner = r ?? defaultRunner; }
+/** Run a single sweep tick directly (bypasses the timer) so tests assert one run deterministically. */
+export function __runSweepOnceForTest(): Promise<void> { return runSweep(); }
+/** Reset module state between tests (timer, in-flight flag). */
+export function __resetSweepForTest(): void {
+  if (timer) { clearInterval(timer); timer = null; }
+  sweepInFlight = false;
+}
+/** Introspection for tests. */
+export function __stateForTest(): { armed: boolean; inFlight: boolean } {
+  return { armed: timer !== null, inFlight: sweepInFlight };
+}

--- a/taxonomy-editor/src/server/server.ts
+++ b/taxonomy-editor/src/server/server.ts
@@ -22,6 +22,7 @@ import { getGlobalRecorder, setGlobalRecorder } from '../../../lib/flight-record
 import { warmup as warmupEmbeddings } from '../../../lib/embeddings/onnxEmbedding.js';
 import { prewarmEmbeddingsCache, getEmbeddingsCacheStatus } from './ai/aiBackends.js';
 import { startEventLoopMonitor } from './eventLoopMonitor.js';
+import { startGroundingSweep } from './groundingSweepScheduler.js';
 
 const require = createRequire(import.meta.url);
 
@@ -1304,6 +1305,10 @@ server.listen(PORT, BIND_HOST, () => {
   // so a starvation event (t/3165: 7–8s in-process ONNX froze the loop → ingress-fabricated
   // 500) is directly greppable instead of inferred. Unref'd interval — never holds the process.
   startEventLoopMonitor();
+  // t/3172 (G8b): scheduled full-taxonomy grounding sweep — path-agnostic correctness backstop for
+  // batch/PS/Python writes that bypass the inline G8a hook. Gated on GROUNDING_SWEEP_ENABLED
+  // (default OFF): inert until the sequenced enable (t/3203 + TL lock-symmetry sign-off). Unref'd.
+  startGroundingSweep();
   void warmupEmbeddings().catch((err: unknown) => {
     log.server.error({ err: String(err) }, 'ONNX embedding warmup failed at boot');
     getGlobalRecorder()?.record({ type: 'system.error', component: 'server', level: 'error', message: 'ONNX embedding warmup failed at boot', error: { name: (err as Error)?.name ?? 'Error', message: String(err), stack: (err as Error)?.stack } });


### PR DESCRIPTION
## t/3172 (G8b) — scheduled full-taxonomy grounding sweep → **Main (TL) + Main (DevOps) GV**

Path-agnostic backstop for the G8a inline hook (t/3171): batch/PS/Python writes bypass `PUT /api/taxonomy/:pov`, so G8a never fires for them. This timer runs CL's reconciler in **full-sweep mode** (`reconcile_grounding.py --apply`, no `--nodes`) on a configurable interval; the reconciler is hash-gated so a clean tree does ~0 work.

### Files
- **`groundingSweepScheduler.ts`** (new) — mirrors `eventLoopMonitor.ts`: idempotent `startGroundingSweep()` on an `unref()`d `setInterval`; `sweepInFlight` guard (non-overlapping — skip+WARN, never stack); child failure caught + FR/Pino recorded, **never rethrown**; injectable runner for the GV arms.
- **`config.ts`** — `isGroundingSweepEnabled()` (env `GROUNDING_SWEEP_ENABLED`, default OFF), mirrors `isCanaryLoopSamplerEnabled`.
- **`server.ts`** — `startGroundingSweep()` after `startEventLoopMonitor()`.
- **`__tests__/groundingSweep.test.ts`** (new) — 6 tests.

### Gate Verification (both arms — the ticket's required proof)
- **FAIL/stale arm:** stale-hash tree → FR `nodes_reconciled >= 1` ✅
- **CLEAN arm:** up-to-date tree → FR `nodes_reconciled == 0` (hash gate) ✅
- Plus: overlap→skip (`skipped:true`, runner not called twice); child-failure→recorded+**no rethrow**; flag-OFF→timer un-armed; flag-ON→armed+idempotent.
- **6/6 green**, `tsc -p tsconfig.server.json` clean, eslint clean.

### Deviations / notes
- **FR type:** used `system.info`/`system.error` + `component:'grounding-sweep'` (NOT e/131's `type:'grounding.sweep'`) — FR `EventType` is a closed Shared-Lib union with no such member; component-tag identity matches the G8a `grounding-reconcile` precedent and avoids a cross-scope Shared-Lib change.
- **Ships flag-OFF (inert).** Enable is sequenced behind t/3203 + TL lock-symmetry sign-off — same dependency as G8a's `grounding_reconcile_inline` (t/3163#1). Draft until GV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)