### PR TITLE
fix(azure): bicep memory 2Gi->4Gi for 2 vCPU (valid ACA combo; #1771 follow-up, t/3182)

### DIFF
--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -630,11 +630,14 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
             // offload). 2 vCPU keeps the loop responsive while the worker computes.
             // Stays within the ACA Consumption plan (0.25-4 vCPU) - one-line resources
             // edit, no workload-profile/topology migration. Cost ~$0 (free grant, t/2977#4).
-            // Memory unchanged: incident RSS peaked ~650MB/2048 + ~250MB worker model
-            // copy ~= 900MB, comfortably within 2Gi (embeddings.json is NOT copied to the
-            // worker - the cache resolve stays main-thread, only miss-texts marshal).
+            // Memory MUST be 4Gi: ACA Consumption only permits FIXED cpu:memory pairs, and
+            // 2.0 vCPU is valid ONLY with 4.0Gi. ARM rejects 2.0/2Gi with
+            // ContainerAppInvalidResourceTotal (the #1771 bug — a deploy would fail the ARM
+            // step; t/3182). Headroom is ample regardless: incident RSS ~650MB/2048 + ~250MB
+            // worker model copy ~= 900MB (embeddings.json is NOT copied to the worker — the
+            // cache resolve stays main-thread, only miss-texts marshal).
             cpu: json('2.0')
-            memory: '2Gi'
+            memory: '4Gi'
           }
           env: containerEnv
           probes: [


### PR DESCRIPTION
## What

`deploy/azure/main.bicep`: container memory `2Gi` → **`4Gi`** (cpu stays `2.0`), and corrected the comment that reasoned the fix away.

## Why (the #1771 bug)

ACA Consumption permits only a **fixed set of cpu:memory pairs** — `2.0` vCPU is valid **only** with `4.0Gi`. The landed `2.0` + `2Gi` (#1771, t/3182) is `ContainerAppInvalidResourceTotal`: a `deploy-azure.yml` run would **fail at the ARM step**. No gate caught it because `az bicep build` compiles it fine (the constraint is ARM deploy-time, not bicep-syntax).

The prior comment argued "~900MB RSS fits comfortably within 2Gi" — true for RSS, but irrelevant to the ACA pairing rule. Comment now states the real constraint.

## Context — prerequisite for the t/3165 flag flip

The worker-offload canary validated loop-safety at **2 vCPU / 4Gi** (the t/3182 worker-floor: the ONNX worker needs a core separate from the event loop). **Prod is currently 1 vCPU / 2Gi.** So before `EMBEDDING_WORKER_OFFLOAD` can safely default-ON in prod, prod must deploy to 2vCPU/4Gi — which this bicep fix unblocks (the current invalid combo would fail that deploy).

Sequence to close t/3165: **(a) this PR** → (b) prod deploy 2vCPU/4Gi (human-authorized) → (c) TL go + flag flip.

## Validation

`az bicep build --file deploy/azure/main.bicep` → exit 0, `"memory": "4Gi"` in compiled output, no new errors (only pre-existing `runner.bicep` nullability warnings, untouched).

## TL gate-check (held draft)

@TL — per your ask: confirming `2.0` cpu / `4.0Gi` is the valid ACA Consumption pair (t/3182). Holding this **draft** until your confirm, then I un-draft + self-merge on green.

## Prevention follow-up

Filing a bicep **ACA cpu:memory-combo validation gate** (per your p/331#864 ask) so an invalid pair fails a PR check instead of the prod ARM step. Separate ticket → your GV.
