### PR TITLE
fix(cl): QBAF same-doc filter exempts debate-sourced instances (t/3214)

### DIFF
--- a/scripts/enrich_conflicts_qbaf.py
+++ b/scripts/enrich_conflicts_qbaf.py
@@ -140,8 +140,11 @@ def _detect_edges(instances):
     for i in range(len(instances)):
         for j in range(i + 1, len(instances)):
             a, b = instances[i], instances[j]
-            # Skip same-document instances
-            if a.get("doc_id") == b.get("doc_id"):
+            # Skip same-document instances — but not debate-sourced ones.
+            # Debate instances are independent agent positions sharing a session ID,
+            # not duplicate extractions from one text (t/3214).
+            doc_id_a = str(a.get("doc_id") or "")
+            if a.get("doc_id") == b.get("doc_id") and not doc_id_a.startswith("debate:"):
                 continue
 
             a_stance = a.get("stance", "neutral")

--- a/scripts/test_enrich_conflicts_qbaf.py
+++ b/scripts/test_enrich_conflicts_qbaf.py
@@ -67,6 +67,60 @@ def test_floor_boundary_exactly_005_is_decided():
     assert r["prevailing_claim"] == "inst-0"
 
 
+# ---------------------------------------------------------------------------
+# _detect_edges — same-doc filter behavior (t/3214)
+# ---------------------------------------------------------------------------
+
+def _inst(stance, doc_id, attack_type=None):
+    i = {"stance": stance, "doc_id": doc_id}
+    if attack_type:
+        i["attack_type"] = attack_type
+    return i
+
+
+def test_same_non_debate_doc_produces_no_edge():
+    # Two instances from the same paper — duplicates, not independent positions.
+    instances = [
+        _inst("supports", "some-paper-2026"),
+        _inst("disputes", "some-paper-2026"),
+    ]
+    assert eq._detect_edges(instances) == []
+
+
+def test_same_debate_doc_opposing_stances_produces_edge():
+    # Two instances from the same debate session — independent agent positions.
+    instances = [
+        _inst("supports", "debate:7e272d3b-4ec0-409d-8095-be4b5bf97b9a"),
+        _inst("disputes", "debate:7e272d3b-4ec0-409d-8095-be4b5bf97b9a", attack_type="rebut"),
+    ]
+    edges = eq._detect_edges(instances)
+    assert len(edges) == 1
+    assert edges[0]["type"] == "attacks"
+    assert edges[0]["attack_type"] == "rebut"
+
+
+def test_different_docs_opposing_stances_produces_edge():
+    # Cross-document conflict — always produced edges (existing behavior preserved).
+    instances = [
+        _inst("supports", "doc-a-2026"),
+        _inst("disputes", "doc-b-2026"),
+    ]
+    edges = eq._detect_edges(instances)
+    assert len(edges) == 1
+    assert edges[0]["type"] == "attacks"
+
+
+def test_same_debate_doc_same_stance_produces_support_edge():
+    # Two supporters in the same debate — count as corroborating support.
+    instances = [
+        _inst("supports", "debate:abc-123"),
+        _inst("supports", "debate:abc-123"),
+    ]
+    edges = eq._detect_edges(instances)
+    assert len(edges) == 1
+    assert edges[0]["type"] == "supports"
+
+
 if __name__ == "__main__":
     import pytest
 


### PR DESCRIPTION
## Summary

- Fixes the same-doc filter in `_detect_edges` that was blocking edge computation for 15 of 18 dispute-bearing conflicts (t/3214)
- Debate-harvested conflicts have support and dispute instances sharing a session `doc_id` (`debate:<uuid>`) — these are independent agent positions, not duplicate extractions from one text
- One-line fix: exempt pairs where `doc_id` starts with `"debate:"` from the same-doc skip; non-debate doc_ids retain the original skip behavior

## Test plan

- [x] 4 new regression tests covering all cases: same non-debate doc → no edge; same debate doc opposing → attack edge; different docs opposing → attack edge; same debate doc same stance → support edge
- [x] All 8 tests pass (4 existing + 4 new)
- [x] `verify:config` green (7/7 gates)

## Context

Discovered in the t/3152 QBAF pilot run. Without this fix, 15/18 dispute conflicts produce base-strength-only QBAF records (no propagation, no resolution verdict), making the Potyka-2021 pilot and `attack_weights` gradient validation effectively unevaluable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0147LBsmLr45eBKGnfnFGpCh