### PR TITLE
feat(azure): durable EMBEDDING_WORKER_OFFLOAD=1 in bicep baseEnv + config-drift gate (closes t/3165)

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -582,6 +582,7 @@ jobs:
               GITHUB_APP_PRIVATE_KEY_SECRET_NAME = '${{ vars.SYNC_GITHUB_APP_PRIVATE_KEY_SECRET_NAME }}'
               AZURE_KEYVAULT_URL                 = '${{ steps.deploy.outputs.keyVaultUri }}'
               AZURE_STORAGE_ACCOUNT_URL          = '${{ steps.deploy.outputs.storageAccountBlobUrl }}'
+              EMBEDDING_WORKER_OFFLOAD           = '1'  # t/3165 durable close — gate verifies the offload flag is deployed
             } `
             -CheckFirewall `
             -StorageAccountName '${{ steps.deploy.outputs.storageAccountName }}' `

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -564,7 +564,7 @@ jobs:
             -ExpectedTrafficRevision '${{ steps.new_revision.outputs.revision }}' `
             -ExpectedTrafficWeight 100 `
             -ExpectedEnvVars @{
-              # MANDATORY: Keep in sync with baseEnv in deploy/azure/main.bicep (lines 383-417).
+              # MANDATORY: Keep in sync with the baseEnv block in deploy/azure/main.bicep.
               # Every PR that adds/changes a Bicep env var MUST update this table in the same PR.
               # Drift here = false-red OR silently missed config check (t/2631).
               NODE_ENV                           = 'production'

--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -532,6 +532,14 @@ var baseEnv = [
   // Azure Blob Storage — user content (chats, debates) and community library.
   // Auth via managed identity (DefaultAzureCredential), no connection string needed.
   { name: 'AZURE_STORAGE_ACCOUNT_URL', value: storageAccount.properties.primaryEndpoints.blob }
+  // t/3165 DURABLE close: the worker-offload flag lives HERE (baseEnv), not a CLI --set-env-vars —
+  // a CLI value is wiped by the next full template deploy (the ephemeral-drift trap). It routes the
+  // ONNX embedding compute to the off-thread worker (t/3183) so a large novel-text batch can't starve
+  // the event loop past ACA's liveness deadline — the t/3165 fabricated-500 root cause. Requires the
+  // 2 vCPU worker floor above (t/3182). Proven: staging storm-canary GREEN + prod staged-flip AC-1/AC-3
+  // green (loop max 39.6ms under 1536 concurrent computes). MUST stay in sync with deploy-azure.yml's
+  // ExpectedEnvVars config-drift gate (Gate Co-Location — the gate verifies this value is deployed).
+  { name: 'EMBEDDING_WORKER_OFFLOAD', value: '1' }
 ]
 var envWithToken = githubTokenProvided
   ? concat(baseEnv, [ { name: 'GITHUB_TOKEN', secretRef: githubTokenSecretName } ])


### PR DESCRIPTION
## The durable t/3165 close (→ TL GV)

The worker-offload flag was flipped ON in prod via a CLI `--set-env-vars` for staged AC validation. A CLI env value is **ephemeral** — the next full `deploy-azure` template apply reconciles env from Bicep and would silently wipe it back to OFF (the exact t/3165 regression). This PR makes it **durable**.

## Change (2 files, both DevOps-scope)

1. `deploy/azure/main.bicep` `baseEnv` — `+ { name: 'EMBEDDING_WORKER_OFFLOAD', value: '1' }`. Now survives every Bicep deploy.
2. `.github/workflows/deploy-azure.yml` `ExpectedEnvVars` — `+ EMBEDDING_WORKER_OFFLOAD = '1'`. The post-deploy config-drift gate now **verifies** the flag stays deployed (Gate Co-Location — config lives at point-of-use, and the gate protects it).

Compiles clean (`az bicep build` exit 0; flag present in the compiled ARM for both prod + staging apps).

## Why it's safe (validated live)

- **Staging storm-canary GREEN**: 1536 novel computes, loop p99 20.5ms / max 31ms, zero 503.
- **Prod staged flip (25% → 100%)**: AC-3 = 1536 concurrent computes → all 200, **zero 500, zero 503**, rev `event_loop_delay` **max 39.6ms** (vs the 7–8s freezes that fabricated the original 500s). AC-1 = resolution gate passed, cache-hits fast, zero 503. Worker-engaged proven (compute-time model-load, no in-thread path under #1786).
- Requires the 2 vCPU worker floor (t/3182), landed in #1789 and already deployed to prod.

## Merge note (drift window)

Prod currently runs the flag via the ephemeral CLI value. **No `deploy-azure` run until this merges** (a deploy before merge would wipe the CLI flag). Merging promptly on your GV + green CI closes the window and makes ON the durable default → **closes t/3165 + promotes #1706's fire arm (t/3192)**.
