### PR TITLE
fix(storage): add WARN logs to all degraded-catch returns (t/3219)

### DIFF
--- a/taxonomy-editor/src/server/storage/fileIO.ts
+++ b/taxonomy-editor/src/server/storage/fileIO.ts
@@ -143,8 +143,12 @@ export async function getTaxonomyDirs(): Promise<string[]> {
       }
     }
     return dirs;
-  } catch {
-    /* telemetry — silent by design */
+  } catch (err: unknown) {
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'file-io', level: 'warn',
+      message: 'getTaxonomyDirs: listing failed, returning []',
+      data: { error: String(err) },
+    });
     return [];
   }
 }
@@ -695,8 +699,12 @@ export async function readEdgesFile(): Promise<unknown | null> {
     const raw = await backend.readFile(getEdgesPath());
     if (raw === null) return null;
     return JSON.parse(raw);
-  } catch {
-    /* telemetry — silent by design */
+  } catch (err: unknown) {
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'file-io', level: 'warn',
+      message: 'readEdgesFile: read/parse failed, returning null',
+      data: { error: String(err) },
+    });
     return null;
   }
 }
@@ -969,8 +977,12 @@ export async function listProposals(): Promise<unknown[]> {
       }
     }
     return proposals;
-  } catch {
-    /* telemetry — silent by design */
+  } catch (err: unknown) {
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'file-io', level: 'warn',
+      message: 'listProposals: listing failed, returning []',
+      data: { error: String(err) },
+    });
     return [];
   }
 }
@@ -1397,8 +1409,12 @@ export async function readPsPrompt(promptName: string, dir = 'ps'): Promise<{ te
   const filePath = path.join(promptsDir, `${promptName}.prompt`);
   try {
     return { text: await fs.readFile(filePath, 'utf-8') };
-  } catch {
-    /* telemetry — silent by design */
+  } catch (err: unknown) {
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'file-io', level: 'warn',
+      message: `readPsPrompt: prompt file not found or unreadable, returning error result: ${promptName}`,
+      data: { filePath, error: String(err) },
+    });
     return { text: null, error: `Prompt not found: ${promptName}` };
   }
 }
@@ -1410,8 +1426,12 @@ export async function listPsPrompts(): Promise<string[]> {
     return entries
       .filter(f => f.endsWith('.prompt'))
       .map(f => f.replace('.prompt', ''));
-  } catch {
-    /* telemetry — silent by design */
+  } catch (err: unknown) {
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'file-io', level: 'warn',
+      message: 'listPsPrompts: directory listing failed, returning []',
+      data: { promptsDir, error: String(err) },
+    });
     return [];
   }
 }
@@ -1422,8 +1442,12 @@ export async function loadAIModels(): Promise<unknown> {
   const configPath = path.join(getProjectRoot(), 'ai-models.json');
   try {
     return JSON.parse(await fs.readFile(configPath, 'utf-8'));
-  } catch {
-    /* telemetry — silent by design */
+  } catch (err: unknown) {
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'file-io', level: 'warn',
+      message: 'loadAIModels: failed to load ai-models.json, returning empty config',
+      data: { configPath, error: String(err) },
+    });
     return { backends: [], models: [], defaults: {} };
   }
 }

--- a/taxonomy-editor/src/server/storage/filesystemBackend.ts
+++ b/taxonomy-editor/src/server/storage/filesystemBackend.ts
@@ -100,8 +100,14 @@ export class FilesystemBackend implements StorageBackend {
     try {
       await fs.access(filePath);
       return true;
-    } catch {
-      /* telemetry — silent by design */
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        getGlobalRecorder()?.record({
+          type: 'system.error', component: 'filesystem-backend', level: 'warn',
+          message: 'fileExists: unexpected error from fs.access, treating file as absent',
+          data: { filePath, error: String(err) },
+        });
+      }
       return false;
     }
   }

--- a/taxonomy-editor/src/server/storage/githubAPIBackend.ts
+++ b/taxonomy-editor/src/server/storage/githubAPIBackend.ts
@@ -1302,8 +1302,12 @@ export class GitHubAPIBackend implements StorageBackend {
     const diskPath = path.join(this.cacheDir, repoPath);
     try {
       return await fs.readFile(diskPath, 'utf-8');
-    } catch {
-      /* telemetry — silent by design */
+    } catch (err: unknown) {
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'github-api-backend', level: 'warn',
+        message: 'readFromDiskCache: cache file unreadable, returning null (cache miss)',
+        data: { repoPath, diskPath, error: String(err) },
+      });
       return null;
     }
   }

--- a/taxonomy-editor/src/server/storage/sessionBranchManager.ts
+++ b/taxonomy-editor/src/server/storage/sessionBranchManager.ts
@@ -554,8 +554,12 @@ export class SessionBranchManager {
         },
       });
       return res.ok;
-    } catch {
-      /* telemetry — silent by design */
+    } catch (err: unknown) {
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'session-branch-manager', level: 'warn',
+        message: 'branch existence check failed (network error), treating as absent',
+        data: { url, error: String(err) },
+      });
       return false;
     }
   }


### PR DESCRIPTION
## Summary

- Clears all 9 `local/require-warn-on-degraded-catch-return` ESLint warnings across `fileIO.ts` (×6), `filesystemBackend.ts` (×1), `githubAPIBackend.ts` (×1), `sessionBranchManager.ts` (×1)
- Each catch block now calls `getGlobalRecorder()?.record({ level: 'warn' })` so fallbacks are observable in the flight recorder
- `fileExists` uses a conditional WARN (fires only on non-ENOENT errors — ENOENT→false is the expected contract)
- `readPsPrompt` gets an unconditional WARN before its `{ text: null, error }` return
- `readFromDiskCache` (githubAPIBackend) gets WARN on cache file unreadable
- branch existence check (sessionBranchManager) gets WARN on network error

## Test plan
- [ ] `npx eslint src/server/storage/` shows 0 `require-warn-on-degraded-catch-return` warnings
- [ ] `npx vitest run src/server/__tests__/` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)