### PR TITLE
fix(server): clear degraded-catch-return warns in featureFlags + sources (t/3220)

### DIFF
--- a/taxonomy-editor/src/server/featureFlags.ts
+++ b/taxonomy-editor/src/server/featureFlags.ts
@@ -205,8 +205,9 @@ function currentFlagsHash(): string {
     const fd = fs.openSync(flagsPath(), 'r');
     try { return crypto.createHash('sha256').update(fs.readFileSync(fd)).digest('hex'); }
     finally { fs.closeSync(fd); }
+    // eslint-disable-next-line local/require-warn-on-degraded-catch-return -- ENOENT is the expected no-flags-file baseline (→ '' hash), not a degradation; all other errors re-throw
   } catch (err) {
-    // ENOENT (no flags file yet) → '' hash; any other error re-throws to the recording caller. telemetry — silent by design for the ENOENT path.
+    /* telemetry — silent by design: only ENOENT returns the '' baseline (expected, not an error); every other error re-throws to the recording caller */
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') return '';
     throw err;
   }
@@ -221,8 +222,9 @@ function readFreshFlags(): { config: FlagsConfig; hash: string } {
       const data = JSON.parse(buf.toString('utf-8')) as Partial<FlagsConfig>;
       return { config: { flags: { ...SEED_FLAGS, ...(data.flags ?? {}) } }, hash: crypto.createHash('sha256').update(buf).digest('hex') };
     } finally { fs.closeSync(fd); }
+    // eslint-disable-next-line local/require-warn-on-degraded-catch-return -- ENOENT is the expected no-flags-file baseline (→ seed flags), not a degradation; all other errors re-throw
   } catch (err) {
-    // ENOENT (no flags file yet) → seed baseline; any other error re-throws to the recording caller. telemetry — silent by design for the ENOENT path.
+    /* telemetry — silent by design: only ENOENT returns the seed baseline (expected, not an error); every other error re-throws to the recording caller */
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') return { config: { flags: { ...SEED_FLAGS } }, hash: '' };
     throw err;
   }

--- a/taxonomy-editor/src/server/routes/sources.ts
+++ b/taxonomy-editor/src/server/routes/sources.ts
@@ -52,7 +52,19 @@ async function loadEvidenceIndex(): Promise<SourceEvidenceIndex | null> {
     const buf = await readDataFile(relPath);
     _evidenceIndex = JSON.parse(buf.toString('utf-8')) as SourceEvidenceIndex;
     return _evidenceIndex;
-  } catch { /* telemetry — silent by design */ return null; }
+  } catch (err) {
+    // Fallback-Path Logging (t/3200/t/3169): the source-evidence index failed to load/parse →
+    // evidence-backed source features degrade to null. Cached above, so this warns at most once per
+    // process until a load succeeds; the error distinguishes absent from malformed.
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'sources-routes', level: 'warn',
+      message: `source_evidence_index load failed — evidence features degraded to null: ${String(err)}`,
+      data: { fallback: 'evidence-index-null' },
+      error: { name: (err as Error)?.name ?? 'Error', message: String(err), stack: (err as Error)?.stack },
+    });
+    log.server.warn({ component: 'sources-routes', err: String(err) }, 'source_evidence_index load failed — evidence features degraded to null');
+    return null;
+  }
 }
 
 type DocMetaMap = import('../../../../lib/debate/evidenceFromSummaries.js').DocMetaMap;
@@ -139,7 +151,19 @@ export async function loadGreatestHitsNodeIds(): Promise<{ node_ids: string[] } 
         : [];
     const node_ids = raw.filter((id): id is string => typeof id === 'string');
     return { node_ids };
-  } catch { /* telemetry — silent by design: absent/malformed → null (graceful no-op) */ return null; }
+  } catch (err) {
+    // Fallback-Path Logging (t/3200/t/3169): the greatest-hits asset failed to load/parse →
+    // GET /api/greatest-hits degrades to null (client shows no curated set). Warn so a missing or
+    // corrupt asset is visible instead of a silent empty; the error distinguishes absent from malformed.
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'sources-routes', level: 'warn',
+      message: `greatest-hits asset load failed — degraded to null: ${String(err)}`,
+      data: { fallback: 'greatest-hits-null' },
+      error: { name: (err as Error)?.name ?? 'Error', message: String(err), stack: (err as Error)?.stack },
+    });
+    log.server.warn({ component: 'sources-routes', err: String(err) }, 'greatest-hits asset load failed — degraded to null');
+    return null;
+  }
 }
 
 export function registerSourcesRoutes(r: Router, _ctx: ServerCtx): void {


### PR DESCRIPTION
## t/3220 — clear 4 of 5 non-storage `require-warn-on-degraded-catch-return` warnings

Condition 2 for the t/3205 error-flip (zero-noise). Self-cert: **/trivial-change** — mechanical Fallback-Path Logging cleanup, follows the established pattern, no new API/schema. Ticket created by Shared Lib (no TL design gate).

### Changes
- **routes/sources.ts** (`loadEvidenceIndex`, `loadGreatestHitsNodeIds`): catch-all `return null` was a genuine silent fallback → **WARN** (FR record + Pino) naming what degraded + why. Evidence-index is cached (warns ~once/proc); greatest-hits warns per failed read so a missing/corrupt asset is visible.
- **featureFlags.ts** (`currentFlagsHash`, `readFreshFlags`): the degraded return fires ONLY for **ENOENT** (the expected no-flags-file baseline, not a degradation) — every other error **re-throws** to the recording caller. Reasoned `eslint-disable` for the degraded-return rule (option b: benign+observable) + kept the base `require-flight-recorder-in-catch` silent-by-design marker for the ENOENT path. **No behavior change.**

### Scope note
The 5th warning (`community/analytics.ts:121`) is **Server Community** scope (resolve_owner) → routed as a child ticket, not included here. t/3220 stays open until both land (the t/3205 flip needs all non-storage → 0).

### Verify
- eslint: **0 errors + 0 require-warn** on both files (both the degraded-return and base catch rules pass).
- `tsc -p tsconfig.server.json` clean; `greatestHitsRoute.test.ts` **8/8**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)