### PR TITLE
fix(packaging): expand asarUnpack for embedding worker transitive closure (t/3218)

### DIFF
--- a/taxonomy-editor/electron-builder.yml
+++ b/taxonomy-editor/electron-builder.yml
@@ -21,8 +21,14 @@ asarUnpack:
   - "node_modules/node-pty/**"
   # worker_threads.Worker() cannot load scripts from inside an asar archive — Electron's
   # asar layer patches fs/require but NOT the worker URL loader (t/3184 C4 exit criterion).
-  # embeddingWorker.js is emitted by tsc (rootDir="../") as dist/main/lib/embeddings/embeddingWorker.js.
-  - "dist/main/lib/embeddings/embeddingWorker.js"
+  # The embedding worker's transitive import closure spans lib/embeddings/, lib/debate/
+  # (ActionableError), and lib/flight-recorder/ — unpack the whole lib/ tree so every
+  # import the worker resolves at runtime is available outside the asar.
+  - "dist/main/lib/**"
+  # onnxruntime-node is auto-unpacked by electron-builder (native .node binary), but its
+  # pure-JS peer dep onnxruntime-common stays inside the asar. Workers can't reach inside
+  # the asar, so unpack the whole onnxruntime-* family explicitly.
+  - "node_modules/onnxruntime-*/**"
 
 extraResources:
   - from: "../ai-models.json"


### PR DESCRIPTION
fix(packaging): expand asarUnpack to cover embedding worker's transitive import closure (t/3218)

C4 packaged-build verification discovered two gaps in the original asarUnpack entry
(which listed only `dist/main/lib/embeddings/embeddingWorker.js`):

1. The worker's transitive imports span the whole lib/ tree:
   - lib/embeddings/onnxEmbedding.js (loaded by the worker entry)
   - lib/debate/errors.js (ActionableError, imported by onnxEmbedding)
   - lib/flight-recorder/*.js (imported by offThreadEmbedding)
   worker_threads.Worker() bypasses Electron's asar fs-patch, so every module the
   worker imports must be outside the asar. Expand to `dist/main/lib/**`.

2. onnxruntime-node is auto-unpacked (native .node binary), but its pure-JS peer dep
   onnxruntime-common stays inside the asar — the worker can't reach it. Add
   `node_modules/onnxruntime-*/**` to cover the full onnxruntime family.

C4 evidence (packaged win-unpacked, EMBEDDING_WORKER_OFFLOAD=1):
  getEmbeddingInfo() -> { backend: 'onnx-worker' }
  computeQueryEmbedding('AI safety') -> 384-dim vector, no asar errors

Co-Authored-By: ElectronMain (Orca) <main.taxonomy-editor-src-main@ai-triad-research.orca.local>


## Summary
- Expand sarUnpack from single entry file to dist/main/lib/** (covers onnxEmbedding, debate/errors, flight-recorder — all transitively imported by the worker)
- Add 
ode_modules/onnxruntime-*/** so onnxruntime-common (pure-JS peer of the auto-unpacked native onnxruntime-node) is also outside the asar

## C4 Evidence
Packaged win-unpacked, EMBEDDING_WORKER_OFFLOAD=1:
- getEmbeddingInfo() → { backend: 'onnx-worker' } — flag active, worker routing confirmed
- computeQueryEmbedding('AI safety') → 384-dim float vector — worker loaded and computed correctly, no asar errors

## Test plan
- [ ] CI passes (single yml change, no new code)
- [ ] Human merge when green

🤖 Generated with [Claude Code](https://claude.com/claude-code)