### PR TITLE
fix(renderer): clear 8 degraded-catch-return warnings — gates t/3205 flip (t/3222)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/resilience.ts
+++ b/taxonomy-editor/src/renderer/bridge/resilience.ts
@@ -331,9 +331,12 @@ async function isBackpressure(res: Response): Promise<boolean> {
   try {
     const data = await res.clone().json() as { retryable?: unknown } | null;
     return data?.retryable === true;
+    // Classifier, not a degradation: a non-JSON / empty body means the response is NOT
+    // typed-backpressure (e.g. a genuinely-down 503). Returning false routes it to the
+    // real-failure path, which fails fast and trips the breaker — recorded there, not here.
+    // eslint-disable-next-line local/require-warn-on-degraded-catch-return -- classification, not a fallback; the genuine-down path is what records (t/3222)
   } catch {
-    // silent by design: a non-JSON / empty body means this is not a typed-backpressure
-    // response (e.g. a genuinely-down 503) — treat as a real failure, not backpressure.
+    /* silent by design: non-JSON / empty body = not typed-backpressure; the genuine-down path records downstream */
     return false;
   }
 }

--- a/taxonomy-editor/src/renderer/components/sync/TaxonomyDiffPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/sync/TaxonomyDiffPanel.tsx
@@ -103,7 +103,7 @@ async function fetchNodeDiff(): Promise<NodeDiffResponse | null> {
     getGlobalRecorder()?.record({
       type: 'system.error',
       component: 'taxonomy-diff-panel',
-      level: 'debug',
+      level: 'warn',
       message: 'Node-level diff unavailable',
       error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
     });

--- a/taxonomy-editor/src/renderer/lib/analyticsEmitter.ts
+++ b/taxonomy-editor/src/renderer/lib/analyticsEmitter.ts
@@ -90,6 +90,7 @@ export async function resolveAnalyticsUser(): Promise<string> {
     if (prof && prof.isAnonymous === false && prof.userId) return prof.userId;
     const me = meRes.ok ? (await meRes.json()) as { user?: string } : null;
     return me?.user || '_anonymous';
+    // eslint-disable-next-line local/require-warn-on-degraded-catch-return -- benign best-effort telemetry: identity resolution failing degrades analytics to anon-keyed (no functional impact); no recorder dependency in this low-level telemetry-id resolver (t/3222)
   } catch { /* telemetry — silent by design */ return '_anonymous'; }
 }
 

--- a/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
+++ b/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
@@ -371,6 +371,7 @@ async function _fetchSM(url: string): Promise<_SM | null> {
     if (!r.ok) { _smCache.set(key, null); return null; }
     const sm = await r.json() as _SM;
     _smCache.set(key, sm); return sm;
+    // eslint-disable-next-line local/require-warn-on-degraded-catch-return -- benign dev-only source-map fetch (import.meta.env.DEV-gated); failure caches null + returns null, callers guard; must not affect app (t/3222)
   } catch { /* telemetry — silent by design: source map fetch failures must not affect app */ _smCache.set(key, null); return null; }
 }
 
@@ -771,6 +772,7 @@ export function initFlightRecorder(): FlightRecorder {
           ...(typeof __COMPONENT_VERSIONS__ !== 'undefined' ? __COMPONENT_VERSIONS__ : {}),
         },
       };
+      // eslint-disable-next-line local/require-warn-on-degraded-catch-return -- flight-recorder init assembling its own dump metadata; cannot record to the recorder it is bootstrapping (self-reference) — Error Recording Rule FR-init exception (t/3222)
     } catch {
       /* flight recorder init — silent by design (can't log to itself) */
       return {};

--- a/taxonomy-editor/src/renderer/utils/syncApi.ts
+++ b/taxonomy-editor/src/renderer/utils/syncApi.ts
@@ -156,7 +156,7 @@ export async function listUnsynced(): Promise<UnsyncedFile[]> {
   try {
     return await getJson<UnsyncedFile[]>('/api/sync/unsynced');
   } catch (err) {
-    getGlobalRecorder()?.record({ type: 'system.error', component: 'sync-api', level: 'debug', message: 'Unsynced list unavailable', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
+    getGlobalRecorder()?.record({ type: 'system.error', component: 'sync-api', level: 'warn', message: 'Unsynced list unavailable', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
     return [];
   }
 }
@@ -168,7 +168,7 @@ export async function getFileDiff(relPath: string): Promise<string> {
     );
     return res.diff || '';
   } catch (err) {
-    getGlobalRecorder()?.record({ type: 'system.error', component: 'sync-api', level: 'debug', message: 'File diff unavailable', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
+    getGlobalRecorder()?.record({ type: 'system.error', component: 'sync-api', level: 'warn', message: 'File diff unavailable', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
     return '';
   }
 }
@@ -195,7 +195,7 @@ export async function getRebaseState(): Promise<RebaseState> {
   try {
     return await getJson<RebaseState>('/api/sync/rebase-state');
   } catch (err) {
-    getGlobalRecorder()?.record({ type: 'system.error', component: 'sync-api', level: 'debug', message: 'Rebase state unavailable', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
+    getGlobalRecorder()?.record({ type: 'system.error', component: 'sync-api', level: 'warn', message: 'Rebase state unavailable', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
     return { in_progress: false, conflict_files: [], onto_branch: null };
   }
 }


### PR DESCRIPTION
Condition 2 for the t/3205 error-flip of `local/require-warn-on-degraded-catch-return` (zero-noise in src/renderer). Clears all 8 warnings across 5 files.

## Two fix classes
**(a) genuine degradation, already recorded but at `debug` (rule rejects info/debug) → bump to `warn`:**
- `syncApi.ts` — listUnsynced / getFileDiff / getRebaseState
- `TaxonomyDiffPanel.tsx` — fetchNodeDiff  ← **Sync-owned, see below**

**(b) benign + observable → greppable reasoned `eslint-disable` + retained `silent by design` comment** (the sibling `require-flight-recorder-in-catch` still requires one):
- `resilience.ts` `isBackpressure` — a *classifier*, not a fallback; the genuine-down path fails fast + trips the breaker, recorded there.
- `analyticsEmitter.ts` `resolveAnalyticsUser` — best-effort telemetry id; degrades to anon-keyed; no recorder dependency in this low-level resolver.
- `flightRecorderInit.ts` `_fetchSM` — dev-only source-map fetch; must not affect app.
- `flightRecorderInit.ts` dump-metadata assembly — FR-init can't record to itself.

## Cross-scope
`TaxonomyDiffPanel.tsx` is **Sync-owned** (one-line `debug`→`warn` bump, identical pattern to the syncApi trio). Coordinated with Sync — **holding merge on Sync ack.**

## Verification
- Both catch rules → **0** across the 5 files; no unused-disable.
- eslint `src/`: 0 errors (under ceiling).
- All 76 tests directly exercising the 5 modules pass (resilience / analyticsEmitter / initAnalytics / FR-dump / TaxonomyDiffPanel / SaveBar / SyncDiagnosticsDialog).
- `npm run verify` in-worktree aborts at tsc on a known worktree-only `../lib` pnpm-hoist resolution artifact (pptxgenjs / decode-named-character-reference / micromark) — **0 errors in src/renderer; shared checkout renderer-tsc = 0/0.** CI resolves those deps and is authoritative.
- Left `getSyncStatus` (same file) at `debug`: not flagged (returns a named const, not an inline literal) and it's the high-frequency poll where `warn` would spam — noted as the rule's literal-only blind spot.

Commit: bb00c1a7

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>