### PR TITLE
fix(analytics): warn on listDates readdir failure instead of silent []

### DIFF
--- a/taxonomy-editor/src/server/community/analytics.ts
+++ b/taxonomy-editor/src/server/community/analytics.ts
@@ -118,7 +118,10 @@ class FsAnalyticsBackend implements AnalyticsBackend {
       return fs.readdirSync(this.dir)
         .filter(f => f.endsWith('.ndjson'))
         .map(f => f.replace('.ndjson', ''));
-    } catch { /* telemetry — silent by design */ return []; }
+    } catch (err) {
+      log.analytics.warn({ err, dir: this.dir }, 'analytics: listDates readdir failed — treated as no dates');
+      return [];
+    }
   }
 
   async prune(cutoffDate: string): Promise<void> {


### PR DESCRIPTION
## Summary

- `FsAnalyticsBackend.listDates()` was swallowing IO errors silently (`return []`), making a broken analytics dir invisible — flagged by `local/require-warn-on-degraded-catch-return`
- The constructor already `mkdirSync`s the dir, so any `readdirSync` failure is a genuine IO error worth surfacing
- Added `log.analytics.warn({ err, dir })` in the catch; removed the stale `/* telemetry — silent by design */` comment (the log satisfies the base rule)

Clears the 5th non-storage degraded-catch-return warning; gates the t/3205 error-flip (ServerAPI PR #1797 clears the other 4).

## Self-cert

Self-certifying under /trivial-change.
Change: add WARN log to listDates() catch in FsAnalyticsBackend
Files: taxonomy-editor/src/server/community/analytics.ts
Lines changed: 4 additions, 1 deletion
ESLint: passed (0 require-warn-on-degraded violations, 2 pre-existing complexity warnings)
Verify gate: CI (worktree lib/ deps unavailable locally; main tsc confirmed clean pre-change)
Deviations: none

## Test plan

- [ ] CI verify gate passes (tsc + eslint + vitest)
- [ ] `npx eslint src/server/community/analytics.ts | grep require-warn-on-degraded` → 0
