### PR TITLE
docs(gate): #1706 resolution-gate warn-only-by-design + both GV arms real-env-proven (t/3192)

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -521,8 +521,11 @@ jobs:
         # resolution failure on the compute path, not a dead-cache (t/3165 pattern).
         # Requires ServerAPI t/3165 PR #1704 merged (adds cacheHits/cacheMisses/corpusNodeCount
         # to compute 200 response). Script degrades gracefully (warn) if fields are absent.
-        # WARN-ONLY: continue-on-error:true until both GV arms proven on real envs. Flip-to-
-        # blocking is a separate PR per Gate Promotion Discipline (operations/devops/AGENTS.md).
+        # WARN-ONLY BY DESIGN (t/3192; both GV arms now real-env-proven, t/3192#6): kept
+        # continue-on-error:true. The FIRE arm (resolves:false → block the shift) is the WARM-GATE's
+        # job (step above, peer-blocking t/3148) — this step is a logging confirmation. Flipping THIS
+        # step to blocking would only catch a script crash (resolves:false is a handled exit-0 the
+        # warm-gate already blocks) = a flaky surface with zero new coverage (TL, t/3192#5).
         id: embeddings_resolution
         if: steps.warm_gate.outputs.warm == 'true'
         shell: pwsh

--- a/operations/devops/Invoke-EmbeddingsResolutionGateCheck.ps1
+++ b/operations/devops/Invoke-EmbeddingsResolutionGateCheck.ps1
@@ -21,12 +21,16 @@
     warm-gate blocks, this step is skipped). This gate is a logging confirmation, not an
     independent guard. Kept separate for per-step observability in CI.
 
-    WARN-ONLY: continue-on-error:true until both GV arms proven on the upgraded /readyz.
-    Flip-to-blocking is a separate Gate-Promotion PR per Gate Promotion Discipline.
+    WARN-ONLY BY DESIGN (t/3192): stays continue-on-error:true. The FIRE arm (resolves:false →
+    BLOCK the traffic-shift) is the WARM-GATE's job (Invoke-ReadyzWarmGateCheck.ps1, peer-blocking
+    t/3148); this step is a logging confirmation only. Flipping it to blocking would only catch an
+    unhandled script crash — resolves:false is a handled exit-0 the warm-gate already blocks — so it
+    adds a flaky surface with zero new signal coverage (TL, t/3192#5). Both GV arms are now REAL-ENV
+    proven (t/3192#6):
 
-    GV FIRE arm:  resolves:false on a non-resolving revision → warm-gate blocks; this step
-                  is skipped (if: warm == 'true'). FIRE arm is warm-gate's responsibility.
-    GV CLEAN arm: resolves:true after warm-gate passes → logs PASS.
+    GV FIRE arm:  a real resolves:false rev (present:true, nodeCount>0; forced via READYZ_FORCE_RESOLVES_FALSE)
+                  → /readyz 503 → warm-gate emits warm=false → deploy blocks the shift + rolls back.
+    GV CLEAN arm: resolves:true → warm-gate warm=true → shift; a healthy rev never false-blocks.
 #>
 [CmdletBinding()]
 param(


### PR DESCRIPTION
Fire-arm Gate-Promotion (t/3192), Q1=(a) per TL sign-off (t/3192#5).

**Both GV arms proven in real env** (evidence: t/3192#6) — forced-503 staging rev (READYZ_FORCE_RESOLVES_FALSE) → warm-gate emits warm=false → deploy blocks the shift + rolls back; healthy rev → warm=true; wiring at deploy-azure.yml L537 (warm==true→shift) / L632 (warm==false→rollback).

**Change: docs/comments only, zero behavior change.** Refreshes the stale 'until both arms proven' caveats in the #1706 resolution step (deploy-azure.yml) + `Invoke-EmbeddingsResolutionGateCheck.ps1` to 'warn-only BY DESIGN — both arms real-env-proven'. Per TL: the #1706 step STAYS warn-only (resolves:false is a handled exit-0 the warm-gate already blocks; flipping it adds a flaky surface with zero new coverage). → your GV.