### PR TITLE
fix(main): clear 15 require-warn-on-degraded-catch-return ESLint warnings (t/3221)

### DIFF
--- a/taxonomy-editor/src/main/apiKeyStore.ts
+++ b/taxonomy-editor/src/main/apiKeyStore.ts
@@ -48,8 +48,14 @@ export function loadApiKeys(backend?: Backend): string[] {
   let decrypted: string;
   try {
     decrypted = safeStorage.decryptString(fs.readFileSync(fp));
-  } catch {
-    /* telemetry — silent by design (corrupt/unreadable key file) */
+  } catch (err) {
+    getGlobalRecorder()?.record({
+      type: 'system.error',
+      component: 'api-key-store',
+      level: 'warn',
+      message: 'loadApiKeys: safeStorage decrypt failed — returning empty key list; user must re-enter API keys',
+      error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+    });
     return [];
   }
   try {

--- a/taxonomy-editor/src/main/dataUpdateChecker.ts
+++ b/taxonomy-editor/src/main/dataUpdateChecker.ts
@@ -37,7 +37,7 @@ async function isOnline(): Promise<boolean> {
     const resp = await net.fetch('https://github.com', { method: 'HEAD' });
     return resp.ok || resp.status === 301 || resp.status === 302;
   } catch {
-    // eslint-disable-next-line local/require-warn-on-degraded-catch-return -- returning false is the correct offline signal; the caller surfaces it as { error: 'offline' } to the UI, not a silent fallback
+    /* telemetry — silent by design; returning false is the correct offline signal — caller surfaces { error: 'offline' } to the UI */
     return false;
   }
 }

--- a/taxonomy-editor/src/main/dataUpdateChecker.ts
+++ b/taxonomy-editor/src/main/dataUpdateChecker.ts
@@ -37,7 +37,7 @@ async function isOnline(): Promise<boolean> {
     const resp = await net.fetch('https://github.com', { method: 'HEAD' });
     return resp.ok || resp.status === 301 || resp.status === 302;
   } catch {
-    /* telemetry — silent by design */
+    // eslint-disable-next-line local/require-warn-on-degraded-catch-return -- returning false is the correct offline signal; the caller surfaces it as { error: 'offline' } to the UI, not a silent fallback
     return false;
   }
 }
@@ -111,8 +111,14 @@ export async function getChangedFiles(): Promise<ChangedFileInfo[]> {
       const [status, ...pathParts] = line.split('\t');
       return { path: pathParts.join('\t'), status: status.charAt(0) };
     }).filter(f => !IGNORED_PATH_PREFIXES.some(p => f.path.startsWith(p)));
-  } catch {
-    /* telemetry — silent by design */
+  } catch (err) {
+    getGlobalRecorder()?.record({
+      type: 'system.error',
+      component: 'data-update-checker',
+      level: 'warn',
+      message: 'getChangedFiles: git diff failed — returning empty file list (UI will show no pending changes)',
+      error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+    });
     return [];
   }
 }

--- a/taxonomy-editor/src/main/fileIO.ts
+++ b/taxonomy-editor/src/main/fileIO.ts
@@ -107,8 +107,14 @@ export function isDataAvailable(): boolean {
   try {
     const taxDir = resolveDataPath(loadDataConfig().taxonomy_dir);
     return fs.existsSync(taxDir) && fs.readdirSync(taxDir).some(f => f.endsWith('.json') && f !== 'embeddings.json' && f !== 'edges.json');
-  } catch {
-    /* telemetry — silent by design */
+  } catch (err) {
+    getGlobalRecorder()?.record({
+      type: 'system.error',
+      component: 'file-io',
+      level: 'warn',
+      message: 'isDataAvailable: config or directory read failed — returning false (app will show data-unavailable UI)',
+      error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+    });
     return false;
   }
 }
@@ -632,7 +638,16 @@ export function loadSummary(docId: string): unknown | null {
   if (!fs.existsSync(filePath)) return null;
   try {
     return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-  } catch { /* telemetry — silent by design */ return null; }
+  } catch (err) {
+    getGlobalRecorder()?.record({
+      type: 'system.error',
+      component: 'file-io',
+      level: 'warn',
+      message: `loadSummary: failed to read/parse summary for ${docId} — returning null`,
+      error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+    });
+    return null;
+  }
 }
 
 export function loadSnapshot(sourceId: string): string | null {
@@ -642,7 +657,16 @@ export function loadSnapshot(sourceId: string): string | null {
   if (!fs.existsSync(filePath)) return null;
   try {
     return fs.readFileSync(filePath, 'utf-8');
-  } catch { /* telemetry — silent by design */ return null; }
+  } catch (err) {
+    getGlobalRecorder()?.record({
+      type: 'system.error',
+      component: 'file-io',
+      level: 'warn',
+      message: `loadSnapshot: failed to read snapshot for ${sourceId} — returning null`,
+      error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+    });
+    return null;
+  }
 }
 
 // ── Source document resolution ──

--- a/taxonomy-editor/src/main/ipc/aiHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/aiHandlers.ts
@@ -48,8 +48,14 @@ export function registerAiHandlers(): void {
       const configPath = path.join(PROJECT_ROOT, 'ai-models.json');
       const raw = fs.readFileSync(configPath, 'utf-8');
       return JSON.parse(raw);
-    } catch {
-      /* telemetry — silent by design */
+    } catch (err) {
+      getGlobalRecorder()?.record({
+        type: 'system.error',
+        component: 'ipc-handlers',
+        level: 'warn',
+        message: 'load-ai-models: failed to read/parse ai-models.json — returning null (AI features will be unavailable)',
+        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+      });
       return null;
     }
   });
@@ -362,8 +368,14 @@ export function registerAiHandlers(): void {
       };
 
       return { current, history };
-    } catch {
-      /* telemetry — silent by design */
+    } catch (err) {
+      getGlobalRecorder()?.record({
+        type: 'system.error',
+        component: 'ipc-handlers',
+        level: 'warn',
+        message: 'get-calibration-params: failed to load calibration params — returning nulls (debate engine will use hardcoded defaults)',
+        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+      });
       return { current: null, history: [] };
     }
   });
@@ -389,8 +401,14 @@ export function registerAiHandlers(): void {
       }
 
       return { entries, validationReport };
-    } catch {
-      /* telemetry — silent by design */
+    } catch (err) {
+      getGlobalRecorder()?.record({
+        type: 'system.error',
+        component: 'ipc-handlers',
+        level: 'warn',
+        message: 'get-calibration-log: failed to read calibration log — returning empty log',
+        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+      });
       return { entries: [], validationReport: null };
     }
   });

--- a/taxonomy-editor/src/main/ipc/briefExportHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/briefExportHandlers.ts
@@ -114,6 +114,7 @@ const INDEX_FILE = '_index.json';
 
 function readIndex(): BriefRecord[] {
   try { return JSON.parse(fs.readFileSync(path.join(exportsDir(), INDEX_FILE), 'utf-8')) as BriefRecord[]; }
+  // eslint-disable-next-line local/require-warn-on-degraded-catch-return -- ENOENT on first run is normal new-user state; [] is the correct baseline, not a degraded fallback
   catch { /* no index yet / unreadable → empty list — silent by design (ADR-003) */ return []; }
 }
 function writeIndex(recs: BriefRecord[]): void {
@@ -148,6 +149,7 @@ function listExports(debateId?: string): BriefRecord[] {
 
 function loadArtifact(exportId: string, name: BriefArtifactName): Uint8Array | null {
   const p = path.join(exportDir(exportId), name);
+  // eslint-disable-next-line local/require-warn-on-degraded-catch-return -- ENOENT means the artifact is absent; the IPC handler surfaces 404 to the renderer, so null is the correct route outcome
   try { return fs.readFileSync(p); } catch { /* artifact absent → null (route surfaces not-found) — silent by design (ADR-003) */ return null; }
 }
 

--- a/taxonomy-editor/src/main/ipc/sourceHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/sourceHandlers.ts
@@ -61,7 +61,16 @@ export function registerSourceHandlers(): void {
       if (!fs.existsSync(indexPath)) return null;
       _evidenceIndex = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
       return _evidenceIndex;
-    } catch { /* telemetry — silent by design */ return null; }
+    } catch (err) {
+      getGlobalRecorder()?.record({
+        type: 'system.error',
+        component: 'ipc-handlers',
+        level: 'warn',
+        message: 'loadEvidenceIndex: failed to read source_evidence_index.json — returning null (source evidence will be unavailable)',
+        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+      });
+      return null;
+    }
   }
 
   /** Build doc_id → metadata map from source metadata.json files (best-effort). */
@@ -117,7 +126,16 @@ export function registerSourceHandlers(): void {
         ?? data.nodes?.map((n) => n.node_id).filter((id): id is string => typeof id === 'string')
         ?? [];
       return { node_ids: nodeIds };
-    } catch { /* telemetry — silent by design; missing/malformed → null, renderer degrades */ return null; }
+    } catch (err) {
+      getGlobalRecorder()?.record({
+        type: 'system.error',
+        component: 'ipc-handlers',
+        level: 'warn',
+        message: 'load-greatest-hits: failed to read greatest-hits.json — returning null (debate exclusion list will be empty)',
+        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+      });
+      return null;
+    }
   });
 
   ipcMain.handle('get-source-evidence', async (_event, nodeIds: string[], pov: string) => {

--- a/taxonomy-editor/src/main/ipc/taxonomyHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/taxonomyHandlers.ts
@@ -209,8 +209,14 @@ export function registerTaxonomyHandlers(): void {
       }
 
       return { standardized, colloquial, lintViolations: [] };
-    } catch {
-      /* telemetry — silent by design */
+    } catch (err) {
+      getGlobalRecorder()?.record({
+        type: 'system.error',
+        component: 'ipc-handlers',
+        level: 'warn',
+        message: 'get-conflict-definitions: failed to load conflict definition files — returning empty lists',
+        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+      });
       return { standardized: [], colloquial: [], lintViolations: [] };
     }
   });
@@ -239,8 +245,14 @@ export function registerTaxonomyHandlers(): void {
         try {
           const data = JSON.parse(fs.readFileSync(path.join(proposalDir, f), 'utf-8'));
           return { filename: f, ...data };
-        } catch {
-          /* telemetry — silent by design */
+        } catch (err) {
+          getGlobalRecorder()?.record({
+            type: 'system.error',
+            component: 'ipc-handlers',
+            level: 'warn',
+            message: `list-proposals: failed to parse proposal file ${f} — returning error entry`,
+            error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+          });
           return { filename: f, error: 'Failed to parse' };
         }
       });


### PR DESCRIPTION
## Summary

- Adds flight-recorder WARN records to 12 catch blocks that were silently returning empty/null fallbacks, making degraded-path fallbacks visible per the fallback-path logging rule (docs/error-handling.md)
- Adds reasoned `eslint-disable-next-line` comments to 3 ENOENT-baseline sites where silence is correct (first-run absent index, absent artifact, correct offline signal)
- Clears all 15 `local/require-warn-on-degraded-catch-return` warnings across 7 files in `src/main/`

Files changed: `apiKeyStore.ts`, `dataUpdateChecker.ts`, `fileIO.ts`, `ipc/aiHandlers.ts`, `ipc/briefExportHandlers.ts`, `ipc/sourceHandlers.ts`, `ipc/taxonomyHandlers.ts`

## Test plan

- [ ] CI ESLint passes with 0 `require-warn-on-degraded-catch-return` warnings
- [ ] CI tsc passes (no new type errors)
- [ ] App builds and runs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
