### PR TITLE
ci(deps): swap Dependabot heal credential from GitHub App to fine-gra…

### DIFF
--- a/.github/workflows/dependabot-lockfile-heal.yml
+++ b/.github/workflows/dependabot-lockfile-heal.yml
@@ -14,40 +14,44 @@
 #             only when the PR diff actually touches taxonomy-editor/package.json
 #             (the "Scope guard" step). An unrelated PR produces ZERO commits —
 #             this is the GV arm-2 property the prior version failed.
-#          2. CREDENTIAL GUARD: if the DEPENDABOT_HEAL_APP_ID secret is absent the
-#             job SUCCEEDS as a no-op (never fails the mint step).
+#          2. CREDENTIAL GUARD: if the DEPENDABOT_HEAL_PAT secret is absent the
+#             job SUCCEEDS as a no-op (drift detected but push skipped, never red).
 #
 # SECURITY (do not refactor without re-reading e/127#2):
-#   * App token minted AFTER every dependency-touching step, referenced ONLY by
-#     the push step (step ordering IS the security boundary — see marked step).
+#   * The PAT is referenced ONLY by the push step, AFTER every dependency-touching
+#     step (step ordering IS the security boundary — see marked step). No mint step
+#     is needed for a static secret, but the ordering discipline is unchanged.
 #   * `--lockfile-only` (inside sync-standalone-lockfile.mjs) + `--ignore-scripts`
 #     belt → no registry lifecycle script executes during a resolve.
 #   * Guard requires actor == dependabot[bot] AND same-repo head → forks excluded.
-#   * The App-token push (unlike GITHUB_TOKEN) DOES retrigger CI so the heal
-#     commit gets fresh checks. Do not "simplify" to the default token.
+#   * The PAT push (unlike GITHUB_TOKEN) DOES retrigger CI so the heal commit gets
+#     fresh checks. Do not "simplify" to the default token.
 #   * Auth is passed via http.extraheader (not the remote URL) so the token is
 #     never materialized in a URL or log line.
 #
-# CREDENTIAL (owner/admin, provisioned 2026-08-31): a GitHub App with
-#   contents:write on this repo, installed, App ID + private key stored as
-#   DEPENDABOT secrets (Dependabot-triggered runs read the Dependabot secret
-#   store, not the Actions store):
-#     - DEPENDABOT_HEAL_APP_ID
-#     - DEPENDABOT_HEAL_APP_PRIVATE_KEY
+# CREDENTIAL (owner/admin): a fine-grained Personal Access Token scoped to THIS repo
+#   only, with Contents: read+write, stored as a DEPENDABOT secret named
+#   DEPENDABOT_HEAL_PAT (Dependabot-triggered runs read the Dependabot secret store,
+#   not the Actions store). Owner chose the PAT over the GitHub App (jsnover via
+#   PM p/33#79); the PAT was the e/127#2-documented acceptable fallback. NOTE:
+#   GitHub reserves the `GITHUB_` prefix for secret names, so the secret CANNOT be
+#   named GITHUB_PAT — DEPENDABOT_HEAL_PAT is the valid name. Rotate on the PAT's
+#   90-day expiry (a longer-lived credential than the App's per-run token — the
+#   tradeoff of choosing the PAT).
 #
 # NOTE: lib/debate is NOT healed here — its root-workspace importer is empty (the
 #   root entry never bumps it); its standalone lockfile is managed by the
 #   /lib/debate Dependabot entry. Extend sync-standalone-lockfile.mjs + this scope
 #   guard if that ever changes.
 #
-# POST-MERGE WATCH-ITEM (GV condition, t/3134): the App-token push retriggering CI
-#   is only observable once this workflow is on main (a pull_request workflow runs
+# POST-MERGE WATCH-ITEM (GV condition, t/3134): the PAT push retriggering CI is
+#   only observable once this workflow is on main (a pull_request workflow runs
 #   from the BASE branch). VERIFY on the FIRST taxonomy-editor-touching Dependabot
-#   npm PR after merge: the heal commits → the App-token push retriggers CI → the
-#   PR goes GREEN including this heal job. If instead it loops/reds (e.g. the push
-#   fails to retrigger, or an empty commit), REVERT immediately per #1674 and
-#   re-open t/3134. Offline both-arms were proven at GV (#1676 evidence); this is
-#   the one arm only main can exercise.
+#   npm PR after merge: the heal commits → the PAT push retriggers CI → the PR goes
+#   GREEN including this heal job. If instead it loops/reds (e.g. the push fails to
+#   retrigger, or an empty commit), REVERT immediately per #1674 and re-open t/3134.
+#   Offline both-arms were proven at GV (#1676 evidence); the PAT-push retrigger is
+#   the one arm only main can exercise (identical retrigger property to the App token).
 
 name: Dependabot Lockfile Heal
 
@@ -149,35 +153,32 @@ jobs:
             echo "Already in sync — nothing to heal."
           fi
 
-      # Credential guard: no-op (success) when the secret is absent — never fail.
+      # Credential guard: no-op (success) when the PAT secret is absent — never fail.
       - name: Check heal credential
         id: cred
         if: steps.drift.outputs.changed == 'true'
         env:
-          APP_ID: ${{ secrets.DEPENDABOT_HEAL_APP_ID }}
+          HEAL_PAT: ${{ secrets.DEPENDABOT_HEAL_PAT }}
         run: |
-          if [ -n "$APP_ID" ]; then
+          if [ -n "$HEAL_PAT" ]; then
             echo "present=true" >> "$GITHUB_OUTPUT"
           else
             echo "present=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::DEPENDABOT_HEAL_APP_ID not set — drift detected but heal skipped (no-op)."
+            echo "::notice::DEPENDABOT_HEAL_PAT not set — drift detected but heal skipped (no-op)."
           fi
 
       # ── SECURITY BOUNDARY ─────────────────────────────────────────────────
-      # Mint the write credential ONLY here, AFTER every dependency/script step
-      # above. Do NOT move earlier; do NOT expose `token` to any step but push.
-      - name: Mint GitHub App token
-        id: app-token
-        if: steps.drift.outputs.changed == 'true' && steps.cred.outputs.present == 'true'
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
-        with:
-          app-id: ${{ secrets.DEPENDABOT_HEAL_APP_ID }}
-          private-key: ${{ secrets.DEPENDABOT_HEAL_APP_PRIVATE_KEY }}
-
+      # The write credential (a fine-grained PAT: contents:write, single-repo) is
+      # referenced ONLY by the push step below — AFTER every dependency/script step
+      # above. Step ordering IS the security boundary: no PR-controlled step
+      # (checkout/install/licenses) ever has the PAT in scope. Like the GitHub App
+      # token and UNLIKE the default GITHUB_TOKEN, a PAT push RETRIGGERS CI on the
+      # heal commit (load-bearing — do NOT "simplify" to the default token).
+      # (Owner chose the PAT over the GitHub App per the e/127#2 documented fallback.)
       - name: Commit and push heal
         if: steps.drift.outputs.changed == 'true' && steps.cred.outputs.present == 'true'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_HEAL_PAT }}
         run: |
           git config user.name "dependabot-heal[bot]"
           git config user.email "dependabot-heal[bot]@users.noreply.github.com"


### PR DESCRIPTION
## What

Swaps the Dependabot lockfile-heal write credential from the **GitHub App** (`create-github-app-token` + `DEPENDABOT_HEAL_APP_ID`/`_PRIVATE_KEY`) to a **fine-grained PAT** (`DEPENDABOT_HEAL_PAT`), per owner direction (jsnover via PM p/33#79). The PAT was the e/127#2-documented acceptable fallback.

## Security posture — unchanged (all e/127#2 / TL-GV'd properties preserved)

- **Boundary**: the PAT is referenced **only** by the push step, after every dependency/script step (checkout/install/`npm run licenses`). No PR-controlled code ever has the credential in scope. (No mint step needed for a static secret — the ordering discipline is unchanged.)
- **CI retrigger**: a PAT push retriggers CI on the heal commit, like the App token and unlike `GITHUB_TOKEN` (load-bearing).
- **Guards intact**: `pull_request` (not `pull_request_target`); `actor == dependabot[bot]` + same-repo head; `--ignore-scripts` belt; `http.extraheader` auth (token never in URL/logs); porcelain-diff idempotency (no-op when synced → no loop); credential-absent → no-op success.

## ⚠ Blocking prerequisites (why this is DRAFT)

1. **Owner provisions the PAT secret.** A fine-grained PAT scoped to **this repo only**, permission **Contents: read+write**, stored as a **Dependabot** secret named **`DEPENDABOT_HEAL_PAT`**.
   - **Naming**: it CANNOT be `GITHUB_PAT`/`GITHUB-PAT` — GitHub reserves the `GITHUB_` prefix for secret names (and names can't contain hyphens). `DEPENDABOT_HEAL_PAT` is the valid name.
2. **TL Gate Verification** — this changes a security-reviewed workflow (the App was the Second-Opinion-preferred choice), so TL re-verifies the boundary properties hold with the PAT before merge.

## Both-arms GV (same as the App version, now via PAT)

- **FIRE**: a taxonomy-editor-touching Dependabot bump drifts the standalone lockfile/license notices → heal commits + the **PAT push retriggers CI** → PR green.
- **CLEAN**: already-synced / non-taxonomy-editor PR → drift=false → zero commits (no loop).
- Post-merge watch-item retained (the retrigger is only observable on the first real Dependabot PR on main).

## Tradeoff (flagged for the owner)

The App credential is already provisioned and the workflow is armed + actor-guard-verified (t/3116#14). The PAT is functionally equivalent for the retrigger requirement but is a **longer-lived, broader** credential than the App's per-run installation token — needs **90-day rotation**. The now-unused `DEPENDABOT_HEAL_APP_*` Dependabot secrets can be deleted after this lands (owner).
