### PR TITLE
feat(container): ship reconcile_grounding.py + numpy into prod image — G8 enable prereq (t/3213)

### DIFF
--- a/taxonomy-editor/Dockerfile
+++ b/taxonomy-editor/Dockerfile
@@ -205,6 +205,20 @@ COPY --chown=aitriad:aitriad --from=builder /build/taxonomy-editor/THIRD-PARTY-N
 # 5. PTY broker script (Python, not compiled by tsc — copy to where config.ts expects it)
 COPY --chown=aitriad:aitriad taxonomy-editor/src/main/pty-broker.py ./src/main/pty-broker.py
 
+# 5b. Grounding reconciler (Python, G8 enable prereq — t/3213). The G8a inline write-hook
+#     (groundingReconcileHook.ts) and the G8b full sweep (groundingSweepScheduler.ts) shell out
+#     to this at RECONCILE_SCRIPT (config.ts:402 = /app/research/comp-linguist/scripts/
+#     reconcile_grounding.py; PROJECT_ROOT=/app). Without it every sweep would ENOENT/
+#     ModuleNotFoundError — dead-on-arrival as shipped (t/3172#4). The script is stdlib + numpy;
+#     numpy is NOT in the base image, so install it via apt (python3-numpy) — debian-native, no
+#     pip/PEP-668/venv dance, into the same system python3 the server's execFile('python3', …)
+#     uses. DevOps's container smoke asserts `python3 <script> --selftest` exits 0 (t/3213 AC).
+# hadolint ignore=DL3008
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends python3-numpy
+COPY --chown=aitriad:aitriad research/comp-linguist/scripts/reconcile_grounding.py ./research/comp-linguist/scripts/reconcile_grounding.py
+
 # 6. Fallback taxonomy snapshot — baked last-known-good data for GitHub outages.
 #    CI fetches from ai-triad-data HEAD; changes on every build — LAST layer.
 #    Contains snapshot-meta.json with generation timestamp for stale-data banner.


### PR DESCRIPTION
The **Rosetta Stone Dockerfile arm** of t/3213 (per DevOps plan t/3213#3). G8a (`grounding_reconcile_inline`) and G8b (`GROUNDING_SWEEP_ENABLED`) shell out to CL's reconciler at `RECONCILE_SCRIPT` (config.ts:402 = `/app/research/comp-linguist/scripts/reconcile_grounding.py`). The slim prod image shipped **neither the script nor numpy** (a top-level `import numpy as np`), so every sweep would ENOENT/ModuleNotFoundError — dead-on-arrival as shipped (t/3172#4).

## Changes (`taxonomy-editor/Dockerfile`, runtime stage)
- **COPY** `research/comp-linguist/scripts/reconcile_grounding.py` → `/app/research/comp-linguist/scripts/` (matches `RECONCILE_SCRIPT`; `research/` is in the build context — verified not `.dockerignore`'d).
- **numpy** via `apt-get install python3-numpy` into the base image's system `python3` — the same interpreter the server's `execFile('python3', …)` uses.

## Deviation (flagged per rule)
DevOps's t/3213#3 said `RUN pip install numpy`; I used **apt `python3-numpy`** instead. The base ships python3/-pip/-venv, but PEP 668 blocks a system pip install and a venv is unwarranted for one dep; apt is debian-native + layer-minimal. Flagged in p/584#2, no objection. Functionally identical for `import numpy`.

## Verification
- `reconcile_grounding.py --selftest` exits **0** with numpy locally (hermetic: consistency, disjoint-scope, idempotence, change-detection, removal-purge, vocab-churn, scoped, lock).
- This PR's `test-container` build proves the COPY + apt-numpy layer succeed in the real image.
- **Authoritative in-image selftest is DevOps's arm** (`test-container` step + `container` path-filter add). Invited to co-land on this branch so one green run = AC → DevOps clears the G8 enable hold.

**Do not self-merge** — holding for DevOps's CI step + AC confirmation.

Commit: 074cda33

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>