### PR TITLE
refine(eslint): degraded-return predicate → []/{}/null/undefined only (t/3200 GV) [GATED: TL GV]

### DIFF
--- a/lib/eslint-rules/require-warn-on-degraded-catch-return.js
+++ b/lib/eslint-rules/require-warn-on-degraded-catch-return.js
@@ -1,10 +1,13 @@
 // Custom ESLint rule (t/3200, Fallback-Path Logging — follow-up to t/3169).
 //
-// A `catch` that returns a DEGRADED default (a `Literal` / `[]` / `{}`) FROM A DATA/COMPUTE/IO PATH
-// is a fallback by definition (the t/3165 genus: cache-miss→recompute, primary→secondary,
-// retry-exhausted→default, ADR-001 graceful-empty), so it must record at WARN or ERROR stating what
-// fell back and why. Info-level and the `/* silent by design */` escape-hatch do NOT satisfy it —
-// those were the two gaps the base `require-flight-recorder-in-catch` rule left open (t/3169#2).
+// A `catch` that returns a SILENT empty/no-data default (`[]` / `{}` / `null` / `undefined`) FROM A
+// DATA/COMPUTE/IO PATH is a fallback by definition (the t/3165 genus: cache-miss→recompute,
+// primary→secondary, retry-exhausted→default, ADR-001 graceful-empty), so it must record at WARN or
+// ERROR stating what fell back and why. Info-level and the `/* silent by design */` escape-hatch do
+// NOT satisfy it — those were the two gaps the base `require-flight-recorder-in-catch` rule left open
+// (t/3169#2). The predicate is deliberately NARROW (TL t/3200 GV, p/342): boolean/number/string guard
+// returns (`return false/0/''`) and NON-EMPTY / observable objects (`{ ok:false, reason }`, `{ error }`)
+// are EXCLUDED — their failure is visible in the return shape, so it isn't silent. See isSilentEmptyReturn.
 //
 // This is a SEPARATE rule from the base one on purpose: ESLint severity is per-rule-id, so keeping
 // the strict degraded-return check as its own rule lets it ship at `warn` (non-blocking visibility)
@@ -15,7 +18,24 @@
 // flagged, which keeps the gate low-noise.
 
 const FUNCTION_TYPES = new Set(['FunctionDeclaration', 'FunctionExpression', 'ArrowFunctionExpression']);
-const DEGRADED_ARG_TYPES = new Set(['Literal', 'ArrayExpression', 'ObjectExpression']);
+/**
+ * Is this return argument a SILENT no-data/empty default — the ADR-001 graceful-empty class (TL
+ * t/3200 GV predicate, p/342)? FLAG `[]` / `{}` / `null` / `undefined`: each is indistinguishable
+ * from success-with-no-data, so a silent failure hides in an otherwise-normal return. EXCLUDE:
+ *   - boolean/number/string guard returns (`return false` / `0` / `''`) — control-flow, not data;
+ *   - NON-EMPTY / observable objects & arrays (`{ ok:false, reason }`, `{ error }`, `[x]`) — the
+ *     failure is visible in the returned shape, so it is NOT silent.
+ * Bare `return;` (implicit undefined) is deliberately NOT flagged: without type info it's
+ * indistinguishable from a void function's early-exit control-flow (over-flag risk).
+ */
+function isSilentEmptyReturn(arg) {
+  if (!arg) return false;                                          // bare `return;` — see above
+  if (arg.type === 'ArrayExpression') return arg.elements.length === 0;    // [] only
+  if (arg.type === 'ObjectExpression') return arg.properties.length === 0; // {} only
+  if (arg.type === 'Literal') return arg.value === null;                   // null (not false/0/'')
+  if (arg.type === 'Identifier') return arg.name === 'undefined';          // explicit `return undefined`
+  return false;
+}
 
 // Data/compute/IO signal in the try block. localStorage/sessionStorage are deliberately EXCLUDED —
 // a UI-local default is not the t/3165 class. False negatives (a helper that hides its IO behind a
@@ -23,14 +43,14 @@ const DEGRADED_ARG_TYPES = new Set(['Literal', 'ArrayExpression', 'ObjectExpress
 const DATA_IO_SIGNAL_RE = /\b(await|fs|fsp|readFile|readFileSync|writeFile|writeFileSync|readdir|createReadStream|fetch|https?|axios|got|request|backend|readDataFile|writeDataFile|getBackend|db|query|pool|exec|execSync|spawn|embed|computeEmbedding|onnx)\b/;
 
 /**
- * Does this subtree contain a `return <Literal | [] | {}>` that belongs to THIS catch (not inside a
- * nested function, whose returns are a different scope)? Descends control-flow blocks, stops at
- * function boundaries.
+ * Does this subtree contain a SILENT empty/no-data return (`[]` / `{}` / `null` / `undefined` — see
+ * {@link isSilentEmptyReturn}) that belongs to THIS catch (not inside a nested function, whose
+ * returns are a different scope)? Descends control-flow blocks, stops at function boundaries.
  */
 function containsDegradedReturn(node) {
   if (!node || typeof node.type !== 'string') return false;
   if (node.type === 'ReturnStatement') {
-    return !!node.argument && DEGRADED_ARG_TYPES.has(node.argument.type);
+    return isSilentEmptyReturn(node.argument);
   }
   if (FUNCTION_TYPES.has(node.type)) return false;
   for (const key of Object.keys(node)) {
@@ -70,7 +90,7 @@ export default {
     },
     messages: {
       degradedReturnNeedsWarn:
-        'Catch on a data/IO path returns a degraded default (a literal / [] / {}) — that is a FALLBACK and must record at WARN or ERROR (getGlobalRecorder().record({ level: \'warn\' }) or log.*.warn/error()) stating what fell back and why. Info-level and the /* silent by design */ escape-hatch do NOT satisfy this (Fallback-Path Logging, t/3200/t/3169).',
+        'Catch on a data/IO path returns a SILENT empty/no-data default ([] / {} / null / undefined) — that is a FALLBACK and must record at WARN or ERROR (getGlobalRecorder().record({ level: \'warn\' }) or log.*.warn/error()) stating what fell back and why. Info-level and the /* silent by design */ escape-hatch do NOT satisfy this. (Boolean/number/string guards and observable objects like {ok:false,reason} are excluded — not silent.) Fallback-Path Logging, t/3200/t/3169.',
     },
     schema: [],
   },

--- a/taxonomy-editor/eslint-rules/__tests__/require-warn-on-degraded-catch-return.test.ts
+++ b/taxonomy-editor/eslint-rules/__tests__/require-warn-on-degraded-catch-return.test.ts
@@ -26,11 +26,18 @@ rt.run('require-warn-on-degraded-catch-return', rule, {
     h("try { f(); } catch (e) { /* telemetry — silent by design */ }"),
     h("try { f(); } catch (e) { doCleanup(); }"), // non-degraded, no recording → base rule's concern, not this one
 
-    // ── Degraded return FROM A DATA/IO PATH with adequate WARN/ERROR recording (both transports) ──
+    // ── Silent empty return FROM A DATA/IO PATH with adequate WARN/ERROR recording (both transports) ──
     h("try { await load(); } catch (e) { log.server.warn('fell back to empty'); return []; }"),
     h("try { const d = await fs.readFile(p); } catch (e) { log.ai.error('recompute failed'); return null; }"),
     h("try { await fetch(u); } catch (e) { getGlobalRecorder()?.record({ level: 'warn', message: 'empty' }); return {}; }"),
-    h("try { const r = await backend.readFile(p); } catch (e) { log.server.warn('x'); return 0; }"),
+    h("try { const r = await backend.readFile(p); } catch (e) { log.server.warn('x'); return []; }"),
+
+    // ── EXCLUDED by the refined predicate (NOT silent, TL t/3200 GV) — silent even w/o a recorder ──
+    h("try { await isReachable(); } catch (e) { return false; }"),                        // boolean guard, not data
+    h("try { await compute(); } catch (e) { return 0; }"),                                 // numeric guard
+    h("try { await fetch(u); } catch (e) { return { ok: false, reason: 'network' }; }"),   // observable Result object
+    h("try { const r = await backend.get(k); } catch (e) { return { error: 'x' }; }"),     // observable {error}
+    h("try { const a = [await one()]; return a; } catch (e) { return [fallbackItem]; }"),  // NON-EMPTY array, observable
 
     // ── NARROWING: benign UI/local default (no data/IO signal) is NOT the strict class ──
     h("try { return JSON.parse(localStorage.getItem('k')); } catch (e) { return []; }"),
@@ -56,9 +63,14 @@ rt.run('require-warn-on-degraded-catch-return', rule, {
       code: h("try { await fetch(u); } catch (e) { getGlobalRecorder()?.record({ level: 'info' }); return {}; }"),
       errors: [{ messageId: 'degradedReturnNeedsWarn' }],
     },
-    // Degraded return from an IO path with nothing at all.
+    // Silent empty return from an IO path with nothing at all.
     {
       code: h("try { await load(); } catch (e) { return null; }"),
+      errors: [{ messageId: 'degradedReturnNeedsWarn' }],
+    },
+    // Explicit `return undefined` from an IO path — silent no-data (TL predicate includes undefined).
+    {
+      code: h("try { await load(); } catch (e) { return undefined; }"),
       errors: [{ messageId: 'degradedReturnNeedsWarn' }],
     },
   ],


### PR DESCRIPTION
Refines `local/require-warn-on-degraded-catch-return` per TL's GV predicate (p/342) — TL approved + expedited. Fixes a drift from t/3200#2: the shipped rule flagged ALL `Literal`/`Object` returns, so it also flagged boolean guards (`return false`) and observable Result objects (`{ok:false,reason}`), inflating the live t/3219–t/3223 cleanup by ~half.

**Predicate now:** FLAG catch→ `[]` / `{}` / `null` / `undefined` (silent no-data / ADR-001 graceful-empty). EXCLUDE boolean/number/string guards AND non-empty/observable objects & arrays (failure visible in the shape → not silent). Bare `return;` excluded (indistinguishable from void control-flow w/o type info). Rationale co-located in the rule.

**Test:** both-arms RuleTester **20/20** — FIRES on `return []`/`null`/`{}`/`undefined` (IO, no recorder); SILENT on `return false`, `return {ok:false,reason}`, non-empty arrays, and any catch that logs first.

**Measured on post-cleanup main (t/3219–t/3223 landed):** taxonomy-editor/src drops from 37 → **1 genuine site** (`src/main/ipc/sourceHandlers.ts:99`, a silent `return undefined` on an fs-read — ElectronMain's t/3221 has only the base-rule marker, not this rule's satisfier). Also surfaces **4 orphaned unused-disable** warnings (resilience.ts, analyticsEmitter.ts, featureFlags.ts ×2 — owners annotated FPs before TL's hold; now unnecessary). `eslint src/` exits 0 (unused-disables are warnings, under the 4256 cap) — CI-safe.

**Residuals for the t/3205 flip (separate):** (a) ElectronMain fixes sourceHandlers.ts:99 → 0 rule flags; (b) owners drop the 4 orphaned FP disables. Then flip warn→error → TL GV.

Gate-touching → draft; Main TL GV (you designed the gate). Advances t/3200/t/3205.