### PR TITLE
fix(main): WARN on loadDocTitles outer catch — last require-warn-on-degraded-catch-return residual (t/3221, gates t/3205)

### DIFF
--- a/taxonomy-editor/src/main/ipc/sourceHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/sourceHandlers.ts
@@ -96,7 +96,16 @@ export function registerSourceHandlers(): void {
       _docTitles = Object.keys(metaMap).length > 0 ? metaMap as unknown as DocTitleMap : undefined;
       if (_docTitles) console.log(`[evidence] Loaded ${Object.keys(metaMap).length} document metadata entries`);
       return _docTitles;
-    } catch { /* telemetry — silent by design */ return undefined; }
+    } catch (err) {
+      getGlobalRecorder()?.record({
+        type: 'system.error',
+        component: 'ipc-handlers',
+        level: 'warn',
+        message: 'loadDocTitles: failed to read sources directory — returning undefined (source evidence will have no title labels)',
+        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+      });
+      return undefined;
+    }
   }
 
   ipcMain.handle('load-source-evidence-index', () => loadEvidenceIndex());


### PR DESCRIPTION
## Summary

Clears the last `local/require-warn-on-degraded-catch-return` site in `src/main/` missed by #1804 — `loadDocTitles` outer catch in `sourceHandlers.ts:99` returning `undefined` with only the base-rule silent marker.

Added a flight-recorder WARN record so a sources-directory read failure is visible in the flight recorder (doc title labels will be absent from source evidence, but the debate continues).

Gates the `local/require-warn-on-degraded-catch-return` → error flip in t/3205.

## Test plan

- [ ] CI ESLint: 0 `require-warn-on-degraded-catch-return` warnings in `src/main/`
- [ ] CI tsc passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
