### PR TITLE
fix(ps): logical_form lit-sort coercion belt + -MaxClaims cap-on-attempts (t/3215)

### DIFF
--- a/scripts/AITriad/Private/LogicalFormPass.ps1
+++ b/scripts/AITriad/Private/LogicalFormPass.ps1
@@ -28,6 +28,69 @@ $script:LogicalFormAttitudes     = @('belief', 'desire', 'intention')
 $script:LogicalFormPolarities    = @('positive', 'negative')
 $script:LogicalFormStatuses      = @('proposed', 'accepted', 'rejected')
 
+# Coercion map (t/3215#3, CL): full-DOLCE lit:/event sorts the model may still emit → the register's
+# 5-value DolceCategory. The prompt now enumerates the 5 (t/3126, 90ce0d3e), so this is a
+# defense-in-depth belt for RESIDUAL out-of-set lit:/event sorts — coerce to the nearest of the 5 and
+# WARN, NEVER drop the arg or reject the form. ent-* sorts are register-copied and never coerced.
+# Keys are lowercased; anything unmatched falls back to non-agentive-social-object (+WARN).
+$script:LogicalFormSortCoercion = @{
+    'abstract'                = 'non-agentive-social-object'
+    'quality'                 = 'non-agentive-social-object'
+    'region'                  = 'non-agentive-social-object'
+    'social-object'           = 'non-agentive-social-object'
+    'process'                 = 'perdurant'
+    'event'                   = 'perdurant'
+    'state'                   = 'perdurant'
+    'achievement'             = 'perdurant'
+    'accomplishment'          = 'perdurant'
+    'agentive-social-object'  = 'agentive-physical-object'
+    'social-group'            = 'agentive-physical-object'
+    'organization'            = 'agentive-physical-object'
+    'person'                  = 'agentive-physical-object'
+    'agent'                   = 'agentive-physical-object'
+    'physical-object'         = 'non-agentive-functional-artifact'
+    'artifact'                = 'non-agentive-functional-artifact'
+    'functional-artifact'     = 'non-agentive-functional-artifact'
+    'norm'                    = 'normative-description'
+    'law'                     = 'normative-description'
+    'regulation'              = 'normative-description'
+    'description'             = 'normative-description'
+}
+
+function ConvertTo-DolceSort {
+    <#
+    .SYNOPSIS
+        Coerce a lit:/event arg's sort to the 5-value DolceCategory (t/3215#3 belt (b)).
+    .DESCRIPTION
+        In-set sorts pass through unchanged. A residual out-of-set sort is mapped via
+        $script:LogicalFormSortCoercion (nearest of the 5); an unmapped value defaults to
+        non-agentive-social-object. Every coercion emits a WARN (fallback-path logging,
+        docs/error-handling.md) naming the original → coerced value. NEVER used for ent-* args —
+        those are register-copied (copy-not-judge) and always valid by construction.
+    .OUTPUTS
+        [string] one of the 5 DolceCategory values.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [AllowNull()]
+        [string]$Sort
+    )
+    Set-StrictMode -Version Latest
+
+    $s = if ($null -eq $Sort) { '' } else { $Sort.Trim() }
+    if ($s -in $script:LogicalFormDolceSorts) { return $s }   # already valid — no coercion
+
+    $key = $s.ToLowerInvariant()
+    if ($script:LogicalFormSortCoercion.ContainsKey($key)) {
+        $coerced = $script:LogicalFormSortCoercion[$key]
+        Write-Warning "LogicalForm: coerced out-of-set lit sort '$s' -> '$coerced' (DolceCategory belt, t/3215)."
+        return $coerced
+    }
+    Write-Warning "LogicalForm: unmapped lit sort '$s' -> 'non-agentive-social-object' (default coercion, t/3215)."
+    return 'non-agentive-social-object'
+}
+
 function Get-EntityDolceMap {
     <#
     .SYNOPSIS
@@ -265,8 +328,11 @@ function ConvertTo-GroundedLogicalForm {
                 $ml   = [string]$reg.match_level  # copied from the entity_ref
             }
             else {
-                # lit:"…" or event var — keep the model's DOLCE-lite sort / default match_level.
-                $sort = if ($a.PSObject.Properties['sort']) { [string]$a.sort } else { '' }
+                # lit:"…" or event var — the model's DOLCE-lite sort, COERCED to the 5-value set
+                # (t/3215#3 belt (b)): the prompt now constrains it, but a residual out-of-set sort is
+                # coerced (never dropped/nuked) so one bad lit sort can't reject an otherwise-good form.
+                $rawSort = if ($a.PSObject.Properties['sort']) { [string]$a.sort } else { '' }
+                $sort = ConvertTo-DolceSort -Sort $rawSort
                 $ml   = if ($a.PSObject.Properties['match_level']) { [string]$a.match_level } else { 'exact' }
             }
             $groundedArgs.Add([ordered]@{ role = $role; ref = $ref; sort = $sort; match_level = $ml })

--- a/scripts/AITriad/Public/Invoke-LogicalFormPass.ps1
+++ b/scripts/AITriad/Public/Invoke-LogicalFormPass.ps1
@@ -212,6 +212,10 @@ function Invoke-LogicalFormPass {
             }
 
             $claimsSelected++
+            # Cap on ATTEMPTS, not successes (t/3215#3 (c)): set here — right after this attempt is
+            # counted — so invalid/failed forms still consume the budget. The prior cap-on-success
+            # placement let a run of dropped forms blow past -MaxClaims (unbounded paid-spend hazard).
+            if ($MaxClaims -and $claimsSelected -ge $MaxClaims) { $capReached = $true }
 
             # Render the prompt (Get-Prompt substitutes {{...}} case-sensitively).
             $rendered = Get-Prompt -Name 'logical-form-formalization' -Replacements @{
@@ -270,8 +274,7 @@ function Invoke-LogicalFormPass {
             $fileForms++
             $formsWritten++
             if ([string]$lf.status -eq 'rejected') { $rejectedWritten++ }
-
-            if ($MaxClaims -and $claimsSelected -ge $MaxClaims) { $capReached = $true }
+            # (cap is set on attempt above, not here — a dropped/failed form still counts, t/3215#3 (c))
         }
 
         $written = $false

--- a/tests/Invoke-LogicalFormPass.Tests.ps1
+++ b/tests/Invoke-LogicalFormPass.Tests.ps1
@@ -122,6 +122,36 @@ Describe 'Invoke-LogicalFormPass — helpers (t/3215)' -Tag 'unit', 'fol' {
         }
     }
 
+    It 'ConvertTo-DolceSort maps full-DOLCE lit sorts to the 5-value set (and defaults the unknown)' {
+        InModuleScope AITriad {
+            (ConvertTo-DolceSort -Sort 'process'                -WarningAction SilentlyContinue) | Should -Be 'perdurant'
+            (ConvertTo-DolceSort -Sort 'abstract'               -WarningAction SilentlyContinue) | Should -Be 'non-agentive-social-object'
+            (ConvertTo-DolceSort -Sort 'agentive-social-object' -WarningAction SilentlyContinue) | Should -Be 'agentive-physical-object'
+            (ConvertTo-DolceSort -Sort 'law'                    -WarningAction SilentlyContinue) | Should -Be 'normative-description'
+            (ConvertTo-DolceSort -Sort 'artifact'               -WarningAction SilentlyContinue) | Should -Be 'non-agentive-functional-artifact'
+            (ConvertTo-DolceSort -Sort 'zzz-unknown'            -WarningAction SilentlyContinue) | Should -Be 'non-agentive-social-object'
+            # An already-valid sort passes through unchanged (no coercion).
+            (ConvertTo-DolceSort -Sort 'perdurant') | Should -Be 'perdurant'
+        }
+    }
+
+    It 'ConvertTo-GroundedLogicalForm coerces an out-of-set lit sort instead of dropping the arg or nuking the form' {
+        InModuleScope AITriad {
+            $raw = [pscustomobject]@{
+                predicate = 'exist'; event_ref = 'e1'
+                args = @([pscustomobject]@{ role = 'theme'; ref = 'lit:"the market"'; sort = 'social-object'; match_level = 'exact' })
+                polarity = 'positive'; modality = $null
+                temporal = [pscustomobject]@{ type = 'unspecified'; value = $null }
+                about = @(); formalization_confidence = 0.6; status = 'proposed'
+            }
+            $lf = ConvertTo-GroundedLogicalForm -Raw $raw -RefTable @() -Category 'factual' -Camp '' -WarningAction SilentlyContinue
+            @($lf.args).Count | Should -Be 1                      # arg kept, not dropped
+            $lf.args[0].sort  | Should -Be 'non-agentive-social-object'   # coerced from 'social-object'
+            # And the coerced form now passes validation (no nuke).
+            (Test-LogicalFormStructure -LogicalForm $lf -Category 'factual').Ok | Should -BeTrue
+        }
+    }
+
     It 'Test-LogicalFormStructure passes a well-formed factual form and a rejected form' {
         InModuleScope AITriad {
             $ok = [pscustomobject][ordered]@{
@@ -290,5 +320,21 @@ Describe 'Invoke-LogicalFormPass — orchestrator (t/3215)' -Tag 'unit', 'fol' {
         $r = Invoke-LogicalFormPass -EntitiesPath $script:entPath -SummariesPath $script:sumPath -MaxClaims 1
         $r.ClaimsSelected      | Should -Be 1
         $r.LogicalFormsWritten | Should -Be 1
+    }
+
+    It '-MaxClaims caps on ATTEMPTS even when every form is invalid (no unbounded spend, t/3215#3 (c))' {
+        # All responses invalid (empty predicate) -> 0 forms written. The cap must still stop at 2
+        # ATTEMPTS (2 paid calls), not run through the whole corpus (the prior cap-on-success bug).
+        Mock -ModuleName AITriad Invoke-AIByUsage {
+            [pscustomobject]@{ Text = (@{ predicate = ''; event_ref = 'e1'; args = @(); polarity = 'positive'
+                        modality = $null; temporal = @{ type = 'unspecified'; value = $null }; about = @()
+                        formalization_confidence = 0.5; status = 'proposed' } | ConvertTo-Json -Depth 6 -Compress)
+                Backend = 'test'; Model = 'test' }
+        }
+        $r = Invoke-LogicalFormPass -EntitiesPath $script:entPath -SummariesPath $script:sumPath -MaxClaims 2 -IncludeUngrounded
+        $r.ClaimsSelected      | Should -Be 2
+        $r.LogicalFormsWritten | Should -Be 0
+        $r.InvalidDropped      | Should -Be 2
+        Should -Invoke -CommandName Invoke-AIByUsage -ModuleName AITriad -Times 2 -Exactly
     }
 }


### PR DESCRIPTION
Two D3b follow-ups surfaced by the probe (CL decision t/3215#3), on top of CL's prompt fix (90ce0d3e):

- **(b) Coercion belt** — `ConvertTo-DolceSort` maps a residual out-of-set `lit:`/event sort to the nearest of the 5 `DolceCategory` values (CL's map) + WARN, and **never drops the arg or rejects the form**. `ent-*` sorts stay register-copied (never coerced).
- **(c) `-MaxClaims` cap-on-attempts** — was firing only after a *successful* form, so a run of dropped/failed forms blew past the budget (unbounded paid-spend). Now set right after each attempt is counted.

## Verification
- Re-probe over real summaries (fixed prompt + belt): **6/6 forms valid, 0 dropped** (was ~all dropped).
- Pester **17/17** (adds coercion-map, coerce-not-nuke, and cap-on-attempts-with-all-invalid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)