### PR TITLE
analysis(cl): crux-grammar A/B — +undecidable has ~0 effect (t/3144 step 2)

### DIFF
--- a/research/comp-linguist/analyses/crux-grammar-ab/FINDINGS.md
+++ b/research/comp-linguist/analyses/crux-grammar-ab/FINDINGS.md
@@ -1,0 +1,37 @@
+# Crux-grammar A/B (t/3144 step 2) — findings
+
+**Question (from t/3097):** the model-facing crux-status grammar `addressed | partially_addressed | unaddressed` (`lib/debate/neutralEvaluator.ts`) lacks the `undecidable` option its structural twin (`CruxResolutionState.undecided`) has. Does that missing option distort the headline `crux_addressed_rate` — are genuinely undecidable cruxes forced into `partially_addressed` and inflating the rate?
+
+**Result: no — not for the pinned evaluator.** Offered the option, the model never uses it, and the metric does not move. Adding `undecidable` to the shipped grammar (t/3097 Rec 2) is **not warranted** on artifact-correction grounds.
+
+## Design
+
+Isolate the *grammar* variable by holding the crux *set* fixed (avoids the crux-set drift confound, t/1670):
+- **arm A (shipped)** — the existing 3-option labels on `neutral_evaluations[-1].cruxes[].status`.
+- **arm A′ (control)** — re-classify the *same given* cruxes with a 3-option prompt.
+- **arm B (treatment)** — re-classify the *same given* cruxes with a 4-option prompt (`+undecidable`, disclosed definition). A′ and B are byte-identical except the grammar.
+
+Sample: 12 debates with structural `never_resolved ≥ 0.5` (terminal-`identified`, where the artifact should concentrate), 47 cruxes, 3 passes/arm, pinned `gemini-3.5-flash-lite` @ t=0.2. Cruxes given, never re-identified. Run: `python crux_grammar_ab.py` (needs `GEMINI_API_KEY`).
+
+## Numbers
+
+- **`undecidable` usage in B: 0 / 47 × 3 passes = 0 / 141.** Decisive.
+
+| arm | `crux_addressed_rate` |
+|---|---|
+| shipped-A | 0.638 |
+| A′ (3-opt) | 0.557 ± 0.028 |
+| B (4-opt) | 0.497 ± 0.033 |
+
+- **Grammar effect (A′ − B) = +0.061** — run-to-run noise (~1.4× the ~0.03 per-arm SD); B moved *zero* mass into the new option, so this is not a systematic grammar shift.
+- **Reclassification confound (shipped − A′) = +0.081** — the full-eval → classification-only re-run gap is *larger* than the nominal grammar effect. (Caution for any evaluator re-labeling analysis: expect ~8-pt drift from shipped labels.)
+
+## Interpretation
+
+The t/3097 grammar-artifact hypothesis is **not supported** for the operative (pinned) evaluator: when `undecidable` exists, the model doesn't select it, so the metric is unchanged. Recommend **not** shipping the grammar change — no register event (no grammar change).
+
+Step 1's real signal — structural↔model decoupling (72% structurally terminal-`identified` vs 64% model-`addressed`; Pearson r = −0.10) — is genuine but is an **instrument disagreement, not a vocabulary gap**. Adding the missing option does not close it because the model does not perceive these cruxes as undecidable. A follow-up should target the deeper question (why the model calls structurally-never-resolved cruxes "addressed", or documenting the two instruments as non-comparable), not the grammar.
+
+## Caveats
+
+Evaluator-model-relative (t/1835) — the pinned model is the operative one, but a different evaluator might behave differently. n = 47 cruxes / 12 debates (modest). t = 0.2. A stronger nudge or a `not_yet_decidable` phrasing was not tested; the natural extension with a reasonable definition yields zero usage.

--- a/research/comp-linguist/analyses/crux-grammar-ab/crux_grammar_ab.py
+++ b/research/comp-linguist/analyses/crux-grammar-ab/crux_grammar_ab.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""t/3144 step 2 — A/B the neutral-evaluator crux-status grammar (3-option vs +undecidable).
+
+Isolates the GRAMMAR variable by holding the crux SET fixed:
+  arm A = the existing 3-option labels already on `neutral_evaluations[-1].cruxes[].status`
+          (addressed | partially_addressed | unaddressed), no new call.
+  arm B = one new classification pass per debate with the pinned evaluator model, over the
+          SAME given cruxes, using a 4-option grammar (+ undecidable). We GIVE the cruxes
+          (never re-identify) so the crux set can't drift (t/1670 lesson).
+Output: the absorption matrix (armA x armB) — how much `undecidable` drains from
+partially_addressed vs unaddressed vs addressed — and crux_addressed_rate under A vs B.
+
+Faithful-port note (reproduce-before-assert / checklist ch.6): arm B reuses the shipped
+neutralEvaluator framing + constraints verbatim; the DELIBERATE, documented deviation is
+(a) cruxes are given not re-identified and (b) the task is status-classification only with
+the 4th option — exactly the grammar change Rec-2 would ship. Evaluator model pinned to
+gemini-3.5-flash-lite (t/1835/t/1843: crux metrics are evaluator-model-relative).
+
+Pure read of the data repo; writes only labels + summary JSON in --out-dir. No LLM on --dry-run.
+"""
+import argparse, json, os, random, statistics, sys, time
+from collections import Counter, defaultdict
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8")
+HERE = Path(__file__).resolve().parent
+SEED = 3144
+STATES_A = ["addressed", "partially_addressed", "unaddressed"]
+STATES_B = STATES_A + ["undecidable"]
+
+def resolve_data_root() -> Path:
+    env = os.environ.get("AI_TRIAD_DATA_ROOT")
+    if env:
+        return Path(env)
+    return Path(r"C:\Users\jsnov\repos\ai-triad-data")
+
+# Arm-B prompt: shipped neutralEvaluator framing/constraints, restructured to classify a GIVEN
+# fixed crux set with the 4-option grammar. Only `undecidable` carries a disclosed definition
+# (the other three are self-descriptive, as in the shipped prompt).
+ARM_B_PROMPT = """You are an independent, neutral evaluator of a structured debate. You have NO affiliation with any speaker. You do not know the speakers' backgrounds, affiliations, or commitments. They are anonymous.
+
+TOPIC: {topic}
+
+You are given the CRUXES already identified in this debate (the core disagreements that, if resolved, would change one or more speakers' conclusions). Do NOT add, remove, or merge cruxes. For EACH given crux, classify whether the debate addressed it, using EXACTLY one of these four statuses:
+   - addressed: the debate engaged the crux and moved it toward resolution
+   - partially_addressed: the debate engaged the crux but left it substantially open
+   - unaddressed: the debate did not engage the crux
+   - undecidable: the debate did not produce enough evidence or engagement to determine whether the crux was addressed (it was raised or implied but never adjudicated either way)
+
+CONSTRAINTS:
+- Never refer to speakers by anything other than their labels (Speaker A, Speaker B, Speaker C, Moderator).
+- Base your assessment ONLY on what appears in the transcript. Do not bring outside knowledge about the topic.
+- Return ONLY valid JSON matching the schema below. No markdown fences, no preamble.
+
+GIVEN CRUXES:
+{cruxes_block}
+
+OUTPUT SCHEMA:
+{{"cruxes": [{{"id": "crux-1", "status": "addressed | partially_addressed | unaddressed | undecidable"}}]}}
+
+TRANSCRIPT:
+{transcript}"""
+
+# Arm A' — the 3-option CONTROL: byte-identical to ARM_B_PROMPT except it omits `undecidable`
+# (bullet + schema). A'↔B isolates the GRAMMAR alone (same prompt structure); shipped-A↔A'
+# isolates the prompt-structure/reclassification effect (full-eval vs classification-only).
+ARM_A_PROMPT = """You are an independent, neutral evaluator of a structured debate. You have NO affiliation with any speaker. You do not know the speakers' backgrounds, affiliations, or commitments. They are anonymous.
+
+TOPIC: {topic}
+
+You are given the CRUXES already identified in this debate (the core disagreements that, if resolved, would change one or more speakers' conclusions). Do NOT add, remove, or merge cruxes. For EACH given crux, classify whether the debate addressed it, using EXACTLY one of these three statuses:
+   - addressed: the debate engaged the crux and moved it toward resolution
+   - partially_addressed: the debate engaged the crux but left it substantially open
+   - unaddressed: the debate did not engage the crux
+
+CONSTRAINTS:
+- Never refer to speakers by anything other than their labels (Speaker A, Speaker B, Speaker C, Moderator).
+- Base your assessment ONLY on what appears in the transcript. Do not bring outside knowledge about the topic.
+- Return ONLY valid JSON matching the schema below. No markdown fences, no preamble.
+
+GIVEN CRUXES:
+{cruxes_block}
+
+OUTPUT SCHEMA:
+{{"cruxes": [{{"id": "crux-1", "status": "addressed | partially_addressed | unaddressed"}}]}}
+
+TRANSCRIPT:
+{transcript}"""
+
+def strip_transcript(d) -> str:
+    lines = []
+    for t in (d.get("transcript") or []):
+        if not isinstance(t, dict):
+            continue
+        sp = t.get("speaker") or t.get("pov") or t.get("role") or t.get("speaker_label") or "?"
+        txt = t.get("content") or t.get("text") or t.get("message") or t.get("body") or ""
+        if isinstance(txt, dict):
+            txt = txt.get("text") or json.dumps(txt)
+        if txt:
+            lines.append(f"Speaker {sp}: {txt}")
+    return "\n\n".join(lines)
+
+def never_resolved_frac(d) -> float:
+    ct = d.get("crux_tracker") or []
+    if not ct:
+        return 0.0
+    ident = sum(1 for c in ct if c.get("state") == "identified")
+    return ident / len(ct)
+
+def load_debates(data_root):
+    out = []
+    ddir = data_root / "debates"
+    for fn in sorted(ddir.glob("debate-*.json")):
+        try:
+            d = json.loads(fn.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        ne = d.get("neutral_evaluations")
+        if not (d.get("crux_tracker") and ne):
+            continue
+        last = ne[-1] if isinstance(ne, list) else ne
+        cruxes = [c for c in (last.get("cruxes") or []) if c.get("status") in STATES_A]
+        if not cruxes:
+            continue
+        tp = d.get("topic")
+        if isinstance(tp, dict):
+            tp = tp.get("final") or tp.get("original") or tp.get("refined") or ""
+        topic = tp or d.get("title") or ""
+        out.append({"id": d.get("id"), "file": fn.name, "topic": topic,
+                    "never_resolved": never_resolved_frac(d), "cruxes": cruxes, "transcript": strip_transcript(d)})
+    return out
+
+def parse_arm_b(text):
+    t = (text or "").strip()
+    if t.startswith("```"):
+        t = t.split("```", 2)[1].lstrip("json").strip("` \n") if "```" in t[3:] else t
+    s, e = t.find("{"), t.rfind("}")
+    if s == -1 or e == -1:
+        return None
+    try:
+        obj = json.loads(t[s:e+1])
+        return {c["id"]: c.get("status") for c in obj.get("cruxes", []) if c.get("id")}
+    except Exception:
+        return None
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--min-never-resolved", type=float, default=0.5)
+    ap.add_argument("--max-debates", type=int, default=12)
+    ap.add_argument("--passes", type=int, default=3)
+    ap.add_argument("--model", default="gemini-3.5-flash-lite")
+    ap.add_argument("--temperature", type=float, default=0.2)
+    ap.add_argument("--workers", type=int, default=6)
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--out-dir", default=str(HERE))
+    args = ap.parse_args()
+
+    data_root = resolve_data_root()
+    debates = load_debates(data_root)
+    hi = [x for x in debates if x["never_resolved"] >= args.min_never_resolved]
+    rng = random.Random(SEED)
+    rng.shuffle(hi)
+    sample = sorted(hi[:args.max_debates], key=lambda x: x["id"])
+    n_cruxes = sum(len(x["cruxes"]) for x in sample)
+    armA = Counter(c["status"] for x in sample for c in x["cruxes"])
+    print(f"[pop] debates with both structures: {len(debates)} | high-never_resolved(>= {args.min_never_resolved}): {len(hi)}")
+    print(f"[sample] {len(sample)} debates, {n_cruxes} cruxes | arm-A dist: {dict(armA)}")
+
+    if args.dry_run:
+        d0 = sample[0]
+        cb = "\n".join(f'- {c["id"]}: {c["description"]}' for c in d0["cruxes"])
+        p = ARM_B_PROMPT.format(topic=d0["topic"], cruxes_block=cb, transcript=d0["transcript"][:1500])
+        print("\n[dry-run] first arm-B prompt (transcript truncated):\n")
+        print(p[:2600])
+        return 0
+
+    import google.generativeai as genai
+    genai.configure(api_key=os.environ.get("GEMINI_API_KEY", ""))
+    model = genai.GenerativeModel(args.model, generation_config={"temperature": args.temperature, "response_mime_type": "application/json"})
+    from concurrent.futures import ThreadPoolExecutor
+
+    def classify(deb, tmpl):
+        cb = "\n".join(f'- {c["id"]}: {c["description"]}' for c in deb["cruxes"])
+        prompt = tmpl.format(topic=deb["topic"], cruxes_block=cb, transcript=deb["transcript"][:24000])
+        for attempt in range(4):
+            try:
+                r = model.generate_content(prompt)
+                v = parse_arm_b(r.text or "")
+                if v:
+                    return v
+            except Exception as ex:
+                sys.stderr.write(f"  [warn] {deb['id']} a{attempt}: {type(ex).__name__}\n")
+            time.sleep(0.8 * (attempt + 1))
+        return {}
+
+    def run_arm(tmpl, name):
+        ps = []
+        for p in range(args.passes):
+            t0 = time.time()
+            with ThreadPoolExecutor(max_workers=args.workers) as ex:
+                res = list(ex.map(lambda deb: classify(deb, tmpl), sample))
+            ps.append({deb["id"]: labels for deb, labels in zip(sample, res)})
+            print(f"[{name} pass {p}] {time.time()-t0:.0f}s", flush=True)
+        return ps
+
+    passes_A = run_arm(ARM_A_PROMPT, "A'(3opt)")   # control: same prompt, 3 options
+    passes_B = run_arm(ARM_B_PROMPT, "B(4opt)")    # treatment: +undecidable
+
+    def addr_rate(ps):  # per-pass fraction 'addressed' over all classified cruxes
+        out = []
+        for pp in ps:
+            allx = [pp.get(deb["id"], {}).get(c["id"]) for deb in sample for c in deb["cruxes"]]
+            allx = [x for x in allx if x in STATES_B]
+            out.append(sum(1 for x in allx if x == "addressed") / len(allx) if allx else float("nan"))
+        return out
+    rate_Ap, rate_B = addr_rate(passes_A), addr_rate(passes_B)
+    rate_A_shipped = armA["addressed"] / n_cruxes
+
+    # undecidable usage in B across ALL passes (the decisive number)
+    undec_by_pass = [sum(1 for deb in sample for c in deb["cruxes"] if pp.get(deb["id"], {}).get(c["id"]) == "undecidable") for pp in passes_B]
+
+    # clean grammar absorption: A'(pass0) -> B(pass0), same prompt structure
+    absorption = defaultdict(Counter)
+    for deb in sample:
+        for c in deb["cruxes"]:
+            a0 = passes_A[0].get(deb["id"], {}).get(c["id"])
+            b0 = passes_B[0].get(deb["id"], {}).get(c["id"])
+            if a0 in STATES_B and b0 in STATES_B:
+                absorption[a0][b0] += 1
+
+    mean = lambda xs: statistics.mean([x for x in xs if x == x]) if any(x == x for x in xs) else float("nan")
+    sd = lambda xs: statistics.stdev([x for x in xs if x == x]) if len([x for x in xs if x == x]) > 1 else 0.0
+    summary = {
+        "ticket": "t/3144", "step": 2, "model": args.model, "temperature": args.temperature,
+        "seed": SEED, "passes": args.passes, "min_never_resolved": args.min_never_resolved,
+        "n_debates": len(sample), "n_cruxes": n_cruxes, "arm_A_shipped_distribution": dict(armA),
+        "DECISIVE_undecidable_usage_in_B_per_pass": undec_by_pass,
+        "grammar_absorption_Aprime_to_B_pass0": {a: dict(absorption[a]) for a in STATES_B},
+        "crux_addressed_rate": {
+            "A_shipped_labels": round(rate_A_shipped, 4),
+            "Aprime_3opt_mean": round(mean(rate_Ap), 4), "Aprime_per_pass": [round(x, 4) for x in rate_Ap],
+            "B_4opt_mean": round(mean(rate_B), 4), "B_per_pass": [round(x, 4) for x in rate_B],
+            "GRAMMAR_effect_Aprime_minus_B": round(mean(rate_Ap) - mean(rate_B), 4),
+            "reclassification_effect_shipped_minus_Aprime": round(rate_A_shipped - mean(rate_Ap), 4),
+            "reclass_run_instability_sd": {"Aprime": round(sd(rate_Ap), 4), "B": round(sd(rate_B), 4)},
+        },
+        "interpretation": "GRAMMAR_effect isolates the +undecidable option (A' vs B, identical prompt); "
+                          "reclassification_effect is the confound (shipped full-eval vs classification-only "
+                          "re-run). If undecidable usage ~0 and GRAMMAR_effect ~0, the missing option does NOT "
+                          "distort crux_addressed_rate — the t/3097 artifact hypothesis is not supported for "
+                          "this model, and any shipped-vs-reclassified gap is re-run noise, not grammar.",
+    }
+    outp = Path(args.out_dir)
+    (outp / "crux_grammar_ab_labels.json").write_text(json.dumps({"passes_A": passes_A, "passes_B": passes_B, "sample_ids": [x["id"] for x in sample]}, indent=2, ensure_ascii=False), encoding="utf-8")
+    (outp / "crux_grammar_ab_summary.json").write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")
+    print("\n=== DECISIVE: undecidable usage in B per pass ===", undec_by_pass)
+    print("=== grammar absorption A'(3opt) -> B(4opt), pass0 ===")
+    for a in STATES_B:
+        if absorption[a]: print(f"  {a:22s} -> {dict(absorption[a])}")
+    print(f"\ncrux_addressed_rate: shipped-A={rate_A_shipped:.3f}  A'(3opt)={mean(rate_Ap):.3f}  B(4opt)={mean(rate_B):.3f}")
+    print(f"  GRAMMAR effect (A'-B) = {mean(rate_Ap)-mean(rate_B):+.3f}   reclassification (shipped-A') = {rate_A_shipped-mean(rate_Ap):+.3f}")
+    print("wrote crux_grammar_ab_summary.json")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/comp-linguist/analyses/crux-grammar-ab/crux_grammar_ab_labels.json
+++ b/research/comp-linguist/analyses/crux-grammar-ab/crux_grammar_ab_labels.json
@@ -1,0 +1,458 @@
+{
+  "passes_A": [
+    {
+      "1418ee11-5641-4033-a400-c26c9f5e4f45": {
+        "crux-1": "partially_addressed",
+        "crux-2": "unaddressed",
+        "crux-3": "addressed",
+        "crux-4": "unaddressed",
+        "crux-5": "unaddressed",
+        "crux-6": "unaddressed",
+        "crux-7": "partially_addressed"
+      },
+      "4bb43eb9-295b-45a1-9ba8-27c728dd8c9a": {
+        "crux-1": "addressed",
+        "crux-2": "partially_addressed",
+        "crux-3": "addressed",
+        "crux-4": "partially_addressed",
+        "crux-5": "unaddressed",
+        "crux-6": "partially_addressed",
+        "crux-7": "addressed"
+      },
+      "5651af16-687f-4315-a6f6-c759eaa84865": {
+        "crux-1": "partially_addressed",
+        "crux-2": "partially_addressed",
+        "crux-3": "addressed"
+      },
+      "5663d315-ab39-4156-a631-4817abb5a4bd": {
+        "crux-1": "partially_addressed",
+        "crux-2": "addressed",
+        "crux-3": "addressed",
+        "crux-4": "addressed"
+      },
+      "5990c8c2-8798-415b-89da-0c8de630adf0": {
+        "crux-1": "partially_addressed",
+        "crux-2": "addressed"
+      },
+      "61424059-3ebf-4c10-9f08-48cfe593546b": {
+        "crux-1": "addressed",
+        "crux-2": "addressed",
+        "crux-3": "addressed",
+        "crux-4s": "partially_addressed"
+      },
+      "68739781-1a15-44ef-8771-ce5f88bbce92": {
+        "crux-1": "addressed",
+        "crux-2": "partially_addressed",
+        "crux-3": "addressed",
+        "crux-4": "addressed",
+        "crux-5": "addressed",
+        "crux-6": "unaddressed"
+      },
+      "835bff57-5a78-454e-b263-2e51fc3e1832": {
+        "crux-1": "addressed",
+        "crux-2": "addressed"
+      },
+      "a0eaaca9-3732-43f6-b386-44d049c065d1": {
+        "crux-1": "addressed",
+        "crux-2": "addressed",
+        "crux-3": "addressed",
+        "crux-4": "addressed",
+        "crux-5": "partially_addressed"
+      },
+      "aac6f142-8662-401e-b48c-9d0f9e84cc46": {
+        "crux-1": "addressed",
+        "crux-2": "addressed"
+      },
+      "f8e651ef-5e80-4ea8-9434-7e9158fa5c7f": {
+        "crux-1": "addressed",
+        "crux-2": "partially_addressed",
+        "crux-3": "addressed"
+      },
+      "f9c54c70-dfc3-4255-b125-0c49da39c519": {
+        "crux-1": "partially_addressed",
+        "crux-2": "addressed"
+      }
+    },
+    {
+      "1418ee11-5641-4033-a400-c26c9f5e4f45": {
+        "crux-1": "unaddressed",
+        "crux-2": "unaddressed",
+        "crux-3": "addressed",
+        "crux-4": "unaddressed",
+        "crux-5": "unaddressed",
+        "crux-6": "unaddressed",
+        "crux-7": "partially_addressed"
+      },
+      "4bb43eb9-295b-45a1-9ba8-27c728dd8c9a": {
+        "crux-1": "addressed",
+        "crux-2": "partially_addressed",
+        "crux-3": "partially_addressed",
+        "crux-4": "addressed",
+        "crux-5": "unaddressed",
+        "crux-6": "addressed",
+        "crux-7": "addressed"
+      },
+      "5651af16-687f-4315-a6f6-c759eaa84865": {
+        "crux-1": "partially_addressed",
+        "crux-2": "partially_addressed",
+        "crux-3": "partially_addressed"
+      },
+      "5663d315-ab39-4156-a631-4817abb5a4bd": {
+        "crux-1": "partially_addressed",
+        "crux-2": "addressed",
+        "crux-3": "addressed",
+        "crux-4": "addressed"
+      },
+      "5990c8c2-8798-415b-89da-0c8de630adf0": {
+        "crux-1": "partially_addressed",
+        "crux-2": "addressed"
+      },
+      "61424059-3ebf-4c10-9f08-48cfe593546b": {
+        "crux-1": "addressed",
+        "crux-2": "addressed",
+        "crux-3": "addressed",
+        "crux-4": "addressed"
+      },
+      "68739781-1a15-44ef-8771-ce5f88bbce92": {
+        "crux-1": "addressed",
+        "crux-2": "partially_addressed",
+        "crux-3": "addressed",
+        "crux-4": "addressed",
+        "crux-5": "addressed",
+        "crux-6": "unaddressed"
+      },
+      "835bff57-5a78-454e-b263-2e51fc3e1832": {
+        "crux-1": "partially_addressed",
+        "crux-2": "addressed"
+      },
+      "a0eaaca9-3732-43f6-b386-44d049c065d1": {
+        "crux-1": "addressed",
+        "crux-2": "addressed",
+        "crux-3": "addressed",
+        "crux-4": "partially_addressed",
+        "crux-5": "partially_addressed"
+      },
+      "aac6f142-8662-401e-b48c-9d0f9e84cc46": {
+        "crux-1": "addressed",
+        "crux-2": "addressed"
+      },
+      "f8e651ef-5e80-4ea8-9434-7e9158fa5c7f": {
+        "crux-1": "partially_addressed",
+        "crux-2": "addressed",
+        "crux-3": "addressed"
+      },
+      "f9c54c70-dfc3-4255-b125-0c49da39c519": {
+        "crux-1": "partially_addressed",
+        "crux-2": "partially_addressed"
+      }
+    },
+    {
+      "1418ee11-5641-4033-a400-c26c9f5e4f45": {
+        "crux-1": "unaddressed",
+        "crux-2": "unaddressed",
+        "crux-3": "partially_addressed",
+        "crux-4": "unaddressed",
+        "crux-5": "unaddressed",
+        "crux-6": "unaddressed",
+        "crux-7": "partially_addressed"
+      },
+      "4bb43eb9-295b-45a1-9ba8-27c728dd8c9a": {
+        "crux-1": "addressed",
+        "crux-2": "partially_addressed",
+        "crux-3": "addressed",
+        "crux-4": "partially_addressed",
+        "crux-5": "unaddressed",
+        "crux-6": "addressed",
+        "crux-7": "addressed"
+      },
+      "5651af16-687f-4315-a6f6-c759eaa84865": {
+        "crux-1": "addressed",
+        "crux-2": "partially_addressed",
+        "crux-3": "partially_addressed"
+      },
+      "5663d315-ab39-4156-a631-4817abb5a4bd": {
+        "crux-1": "partially_addressed",
+        "crux-2": "addressed",
+        "crux-3": "addressed",
+        "crux-4": "addressed"
+      },
+      "5990c8c2-8798-415b-89da-0c8de630adf0": {
+        "crux-1": "partially_addressed",
+        "crux-2": "addressed"
+      },
+      "61424059-3ebf-4c10-9f08-48cfe593546b": {
+        "crux-1": "addressed",
+        "crux-2": "addressed",
+        "crux-3": "addressed",
+        "crux-4": "addressed"
+      },
+      "68739781-1a15-44ef-8771-ce5f88bbce92": {
+        "crux-1": "addressed",
+        "crux-2": "partially_addressed",
+        "crux-3": "addressed",
+        "crux-4": "addressed",
+        "crux-5": "addressed",
+        "crux-6": "unaddressed"
+      },
+      "835bff57-5a78-454e-b263-2e51fc3e1832": {
+        "crux-1": "addressed",
+        "crux-2": "addressed"
+      },
+      "a0eaaca9-3732-43f6-b386-44d049c065d1": {
+        "crux-1": "addressed",
+        "crux-2": "addressed",
+        "crux-3": "addressed",
+        "crux-4": "partially_addressed",
+        "crux-5": "partially_addressed"
+      },
+      "aac6f142-8662-401e-b48c-9d0f9e84cc46": {
+        "crux-1": "addressed",
+        "crux-2": "addressed"
+      },
+      "f8e651ef-5e80-4ea8-9434-7e9158fa5c7f": {
+        "crux-1": "partially_addressed",
+        "crux-2": "partially_addressed",
+        "crux-3": "addressed"
+      },
+      "f9c54c70-dfc3-4255-b125-0c49da39c519": {
+        "crux-1": "partially_addressed",
+        "crux-2": "addressed"
+      }
+    }
+  ],
+  "passes_B": [
+    {
+      "1418ee11-5641-4033-a400-c26c9f5e4f45": {
+        "crux-1": "unaddressed",
+        "crux-2": "unaddressed",
+        "crux-3": "partially_addressed",
+        "crux-4": "unaddressed",
+        "crux-5": "partially_addressed",
+        "crux-6": "unaddressed",
+        "crux-7": "partially_addressed"
+      },
+      "4bb43eb9-295b-45a1-9ba8-27c728dd8c9a": {
+        "crux-1": "addressed",
+        "crux-2": "partially_addressed",
+        "crux-3": "partially_addressed",
+        "crux-4": "partially_addressed",
+        "crux-5": "partially_addressed",
+        "crux-6": "partially_addressed",
+        "crux-7": "addressed"
+      },
+      "5651af16-687f-4315-a6f6-c759eaa84865": {
+        "crux-1": "addressed",
+        "crux-2": "partially_addressed",
+        "crux-3": "addressed"
+      },
+      "5663d315-ab39-4156-a631-4817abb5a4bd": {
+        "crux-1": "partially_addressed",
+        "crux-2": "addressed",
+        "crux-3": "addressed",
+        "crux-4": "addressed"
+      },
+      "5990c8c2-8798-415b-89da-0c8de630adf0": {
+        "crux-1": "unaddressed",
+        "crux-2": "addressed"
+      },
+      "61424059-3ebf-4c10-9f08-48cfe593546b": {
+        "crux-1": "partially_addressed",
+        "crux-2": "addressed",
+        "crux-3": "addressed",
+        "crux-4": "addressed"
+      },
+      "68739781-1a15-44ef-8771-ce5f88bbce92": {
+        "crux-1": "addressed",
+        "crux-2": "partially_addressed",
+        "crux-3": "addressed",
+        "crux-4": "partially_addressed",
+        "crux-5": "addressed",
+        "crux-6": "unaddressed"
+      },
+      "835bff57-5a78-454e-b263-2e51fc3e1832": {
+        "crux-1": "addressed",
+        "crux-2": "addressed"
+      },
+      "a0eaaca9-3732-43f6-b386-44d049c065d1": {
+        "crux-1": "addressed",
+        "crux-2": "addressed",
+        "crux-3": "addressed",
+        "crux-4": "addressed",
+        "crux-5": "addressed"
+      },
+      "aac6f142-8662-401e-b48c-9d0f9e84cc46": {
+        "crux-1": "addressed",
+        "crux-2": "addressed"
+      },
+      "f8e651ef-5e80-4ea8-9434-7e9158fa5c7f": {
+        "crux-1": "addressed",
+        "crux-2": "partially_addressed",
+        "crux-3": "addressed"
+      },
+      "f9c54c70-dfc3-4255-b125-0c49da39c519": {
+        "crux-1": "partially_addressed",
+        "crux-2": "partially_addressed"
+      }
+    },
+    {
+      "1418ee11-5641-4033-a400-c26c9f5e4f45": {
+        "crux-1": "unaddressed",
+        "crux-2": "unaddressed",
+        "crux-3": "partially_addressed",
+        "crux-4": "unaddressed",
+        "crux-5": "unaddressed",
+        "crux-6": "unaddressed",
+        "crux-7": "partially_addressed"
+      },
+      "4bb43eb9-295b-45a1-9ba8-27c728dd8c9a": {
+        "crux-1": "addressed",
+        "crux-2": "addressed",
+        "crux-3": "partially_addressed",
+        "crux-4": "partially_addressed",
+        "crux-5": "unaddressed",
+        "crux-6": "partially_addressed",
+        "crux-7": "addressed"
+      },
+      "5651af16-687f-4315-a6f6-c759eaa84865": {
+        "crux-1": "addressed",
+        "crux-2": "partially_addressed",
+        "crux-3": "addressed"
+      },
+      "5663d315-ab39-4156-a631-4817abb5a4bd": {
+        "crux-1": "partially_addressed",
+        "crux-2": "addressed",
+        "crux-3": "addressed",
+        "crux-4": "addressed"
+      },
+      "5990c8c2-8798-415b-89da-0c8de630adf0": {
+        "crux-1": "unaddressed",
+        "crux-2": "addressed"
+      },
+      "61424059-3ebf-4c10-9f08-48cfe593546b": {
+        "crux-1": "addressed",
+        "crux-2": "addressed",
+        "crux-3": "addressed",
+        "crux-4": "addressed"
+      },
+      "68739781-1a15-44ef-8771-ce5f88bbce92": {
+        "crux-1": "addressed",
+        "crux-2": "unaddressed",
+        "crux-3": "addressed",
+        "crux-4": "addressed",
+        "crux-5": "partially_addressed",
+        "crux-6": "unaddressed"
+      },
+      "835bff57-5a78-454e-b263-2e51fc3e1832": {
+        "crux-1": "addressed",
+        "crux-2": "partially_addressed"
+      },
+      "a0eaaca9-3732-43f6-b386-44d049c065d1": {
+        "crux-1": "addressed",
+        "crux-2": "addressed",
+        "crux-3": "addressed",
+        "crux-4": "partially_addressed",
+        "crux-5": "partially_addressed"
+      },
+      "aac6f142-8662-401e-b48c-9d0f9e84cc46": {
+        "crux-1": "addressed",
+        "crux-2": "partially_addressed"
+      },
+      "f8e651ef-5e80-4ea8-9434-7e9158fa5c7f": {
+        "crux-1": "addressed",
+        "crux-2": "partially_addressed",
+        "crux-3": "addressed"
+      },
+      "f9c54c70-dfc3-4255-b125-0c49da39c519": {
+        "crux-1": "partially_addressed",
+        "crux-2": "partially_addressed"
+      }
+    },
+    {
+      "1418ee11-5641-4033-a400-c26c9f5e4f45": {
+        "crux-1": "unaddressed",
+        "crux-2": "unaddressed",
+        "crux-3": "partially_addressed",
+        "crux-4": "unaddressed",
+        "crux-5": "unaddressed",
+        "crux-6": "unaddressed",
+        "crux-7": "partially_addressed"
+      },
+      "4bb43eb9-295b-45a1-9ba8-27c728dd8c9a": {
+        "crux-1": "partially_addressed",
+        "crux-2": "partially_addressed",
+        "crux-3": "partially_addressed",
+        "crux-4": "partially_addressed",
+        "crux-5": "unaddressed",
+        "crux-6": "partially_addressed",
+        "crux-7": "partially_addressed"
+      },
+      "5651af16-687f-4315-a6f6-c759eaa84865": {
+        "crux-1": "addressed",
+        "crux-2": "partially_addressed",
+        "crux-3": "partially_addressed"
+      },
+      "5663d315-ab39-4156-a631-4817abb5a4bd": {
+        "crux-1": "partially_addressed",
+        "crux-2": "addressed",
+        "crux-3": "addressed",
+        "crux-4": "addressed"
+      },
+      "5990c8c2-8798-415b-89da-0c8de630adf0": {
+        "crux-1": "unaddressed",
+        "crux-2": "addressed"
+      },
+      "61424059-3ebf-4c10-9f08-48cfe593546b": {
+        "crux-1": "addressed",
+        "crux-2": "addressed",
+        "crux-3": "addressed",
+        "crux-4": "addressed"
+      },
+      "68739781-1a15-44ef-8771-ce5f88bbce92": {
+        "crux-1": "addressed",
+        "crux-2": "unaddressed",
+        "crux-3": "addressed",
+        "crux-4": "addressed",
+        "crux-5": "addressed",
+        "crux-6": "unaddressed"
+      },
+      "835bff57-5a78-454e-b263-2e51fc3e1832": {
+        "crux-1": "addressed",
+        "crux-2": "addressed"
+      },
+      "a0eaaca9-3732-43f6-b386-44d049c065d1": {
+        "crux-1": "addressed",
+        "crux-2": "addressed",
+        "crux-3": "partially_addressed",
+        "crux-4": "addressed",
+        "crux-5": "partially_addressed"
+      },
+      "aac6f142-8662-401e-b48c-9d0f9e84cc46": {
+        "crux-1": "addressed",
+        "crux-2": "addressed"
+      },
+      "f8e651ef-5e80-4ea8-9434-7e9158fa5c7f": {
+        "crux-1": "addressed",
+        "crux-2": "partially_addressed",
+        "crux-3": "addressed"
+      },
+      "f9c54c70-dfc3-4255-b125-0c49da39c519": {
+        "crux-1": "partially_addressed",
+        "crux-2": "partially_addressed"
+      }
+    }
+  ],
+  "sample_ids": [
+    "1418ee11-5641-4033-a400-c26c9f5e4f45",
+    "4bb43eb9-295b-45a1-9ba8-27c728dd8c9a",
+    "5651af16-687f-4315-a6f6-c759eaa84865",
+    "5663d315-ab39-4156-a631-4817abb5a4bd",
+    "5990c8c2-8798-415b-89da-0c8de630adf0",
+    "61424059-3ebf-4c10-9f08-48cfe593546b",
+    "68739781-1a15-44ef-8771-ce5f88bbce92",
+    "835bff57-5a78-454e-b263-2e51fc3e1832",
+    "a0eaaca9-3732-43f6-b386-44d049c065d1",
+    "aac6f142-8662-401e-b48c-9d0f9e84cc46",
+    "f8e651ef-5e80-4ea8-9434-7e9158fa5c7f",
+    "f9c54c70-dfc3-4255-b125-0c49da39c519"
+  ]
+}

--- a/research/comp-linguist/analyses/crux-grammar-ab/crux_grammar_ab_summary.json
+++ b/research/comp-linguist/analyses/crux-grammar-ab/crux_grammar_ab_summary.json
@@ -1,0 +1,59 @@
+{
+  "ticket": "t/3144",
+  "step": 2,
+  "model": "gemini-3.5-flash-lite",
+  "temperature": 0.2,
+  "seed": 3144,
+  "passes": 3,
+  "min_never_resolved": 0.5,
+  "n_debates": 12,
+  "n_cruxes": 47,
+  "arm_A_shipped_distribution": {
+    "partially_addressed": 15,
+    "addressed": 30,
+    "unaddressed": 2
+  },
+  "DECISIVE_undecidable_usage_in_B_per_pass": [
+    0,
+    0,
+    0
+  ],
+  "grammar_absorption_Aprime_to_B_pass0": {
+    "addressed": {
+      "partially_addressed": 5,
+      "addressed": 22
+    },
+    "partially_addressed": {
+      "unaddressed": 2,
+      "partially_addressed": 9,
+      "addressed": 2
+    },
+    "unaddressed": {
+      "unaddressed": 4,
+      "partially_addressed": 2
+    },
+    "undecidable": {}
+  },
+  "crux_addressed_rate": {
+    "A_shipped_labels": 0.6383,
+    "Aprime_3opt_mean": 0.5574,
+    "Aprime_per_pass": [
+      0.587,
+      0.5319,
+      0.5532
+    ],
+    "B_4opt_mean": 0.4965,
+    "B_per_pass": [
+      0.5319,
+      0.4894,
+      0.4681
+    ],
+    "GRAMMAR_effect_Aprime_minus_B": 0.0609,
+    "reclassification_effect_shipped_minus_Aprime": 0.0809,
+    "reclass_run_instability_sd": {
+      "Aprime": 0.0278,
+      "B": 0.0325
+    }
+  },
+  "interpretation": "GRAMMAR_effect isolates the +undecidable option (A' vs B, identical prompt); reclassification_effect is the confound (shipped full-eval vs classification-only re-run). If undecidable usage ~0 and GRAMMAR_effect ~0, the missing option does NOT distort crux_addressed_rate — the t/3097 artifact hypothesis is not supported for this model, and any shipped-vs-reclassified gap is re-run noise, not grammar."
+}


### PR DESCRIPTION
t/3144 step 2 deliverable (analyses-only, CL scope). A/B of the neutral-evaluator crux-status grammar (3-option vs +undecidable), crux set held fixed, pinned gemini-3.5-flash-lite.

**Result:** the evaluator uses `undecidable` **0/141** times when offered; crux_addressed_rate barely moves (grammar effect +0.06 = run-noise; the reclassification confound +0.08 is larger). **Refutes** the t/3097 grammar-artifact hypothesis for the pinned evaluator → Rec 2 (add `undecidable` to the shipped `neutralEvaluator.ts` grammar) is **not warranted**; recommend not shipping it. Step-1's structural↔model decoupling is an instrument disagreement, not a vocabulary gap.

Files: harness (`crux_grammar_ab.py`), summary + persisted labels, `FINDINGS.md`. Full detail t/3144#5. No production-code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)