### PR TITLE
ci(container): reconciler --selftest INSIDE the prod image + paths-filter (t/3213 re-land)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,11 @@ jobs:
             # change the image — it must trigger the build (t/2094 review, TL2).
             container:
               - 'taxonomy-editor/**'
+              # research/comp-linguist/scripts/** — the grounding reconciler is COPYd into
+              # the prod image (Dockerfile, Rosetta #1810). Per the t/2094 paths-filter
+              # soundness rule, every Dockerfile COPY input must gate test-container, or a
+              # reconciler-only change false-greens a SKIPPED container job.
+              - 'research/comp-linguist/scripts/**'
               - '.dockerignore'
               - 'lib/**'
               - 'scripts/**'
@@ -973,6 +978,18 @@ jobs:
           push: false
           load: true
           tags: ai-triad-test:ci
+
+      - name: Reconciler --selftest INSIDE the prod image (t/3213)
+        # Proves reconcile_grounding.py + its numpy dep are actually present and
+        # runnable IN the shipped image (Rosetta #1810 COPYs them in). The host-side
+        # selftest (test-python, t/3189) proves the source contract; this proves the
+        # image bakes it. G8-enable prereq — without this the reconciler could be
+        # dead-on-arrival in prod (t/3172#4) and no gate would catch it.
+        env:
+          IMAGE: ai-triad-test:ci
+        run: |
+          docker run --rm --entrypoint python3 "$IMAGE" \
+            research/comp-linguist/scripts/reconcile_grounding.py --selftest
 
       - name: Run container liveness smoke — server starts + answers (t/2048, t/2067)
         timeout-minutes: 8


### PR DESCRIPTION
## Why a re-land
The ci.yml half of t/3213 was **stranded** when #1810 self-merged at its stale cached head `074cda33` — merge `4c4ed341` carried only Rosetta's Dockerfile arm. This delta never reached main, so the **in-image reconciler selftest has never run**. AC is not met until it does. (Stale-head-merge class #701/#830 — prevention tracked in t/3225.)

## Change (ci.yml only)
1. **test-container**: new step runs `reconcile_grounding.py --selftest` with `python3` as entrypoint **inside `ai-triad-test:ci`** — proves the reconciler + numpy are actually baked into the shipped image (Rosetta's Dockerfile COPY, #1810). Complements the host-side selftest (test-python, t/3189) which proves only the source contract.
2. **container paths-filter**: `+ research/comp-linguist/scripts/**` so a reconciler-only change gates test-container (t/2094 soundness rule — a SKIPPED gated job reads as satisfied).

## AC (this time proven for real)
Merge only after the **"Reconciler --selftest INSIDE the prod image"** step is confirmed to **EXECUTE and PASS** in the run logs on THIS head (not job-green on a predecessor), head-verified vs `git ls-remote`. Draft until then + TL Gate Verification.

## G8 relation
This is the container prereq for the staged G8 enable. It does NOT flip any flag. Enable remains TL's staged path (G8a → observe → G8b) under jsnover deploy-auth.