### PR TITLE
chore(server): drop 2 orphaned degraded-catch eslint-disables in featureFlags (t/3205#4)

### DIFF
--- a/taxonomy-editor/src/server/featureFlags.ts
+++ b/taxonomy-editor/src/server/featureFlags.ts
@@ -205,7 +205,6 @@ function currentFlagsHash(): string {
     const fd = fs.openSync(flagsPath(), 'r');
     try { return crypto.createHash('sha256').update(fs.readFileSync(fd)).digest('hex'); }
     finally { fs.closeSync(fd); }
-    // eslint-disable-next-line local/require-warn-on-degraded-catch-return -- ENOENT is the expected no-flags-file baseline (→ '' hash), not a degradation; all other errors re-throw
   } catch (err) {
     /* telemetry — silent by design: only ENOENT returns the '' baseline (expected, not an error); every other error re-throws to the recording caller */
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') return '';
@@ -222,7 +221,6 @@ function readFreshFlags(): { config: FlagsConfig; hash: string } {
       const data = JSON.parse(buf.toString('utf-8')) as Partial<FlagsConfig>;
       return { config: { flags: { ...SEED_FLAGS, ...(data.flags ?? {}) } }, hash: crypto.createHash('sha256').update(buf).digest('hex') };
     } finally { fs.closeSync(fd); }
-    // eslint-disable-next-line local/require-warn-on-degraded-catch-return -- ENOENT is the expected no-flags-file baseline (→ seed flags), not a degradation; all other errors re-throw
   } catch (err) {
     /* telemetry — silent by design: only ENOENT returns the seed baseline (expected, not an error); every other error re-throws to the recording caller */
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') return { config: { flags: { ...SEED_FLAGS } }, hash: '' };


### PR DESCRIPTION
## Zero-noise cleanup before the t/3205 flip (per 01a03864, t/3205#4)

Self-cert: **/trivial-change** — remove 2 unused lint directives, single file, no behavior change.

The t/3200 predicate refinement (**#1812**, `[]`/`{}`/`null`/`undefined` only) no longer flags `currentFlagsHash`'s `return ''` or `readFreshFlags`' populated-object return, so the two `// eslint-disable-next-line local/require-warn-on-degraded-catch-return` directives added in #1797 are now **orphaned** → `--report-unused-disable-directives` noise that would block the zero-noise flip.

- Removed both disable directives.
- **Kept** the `/* telemetry — silent by design */` markers — the base `require-flight-recorder-in-catch` rule still needs them on the ENOENT path.

### Verify
- `eslint --report-unused-disable-directives src/server/featureFlags.ts`: clean (0 unused-disable, 0 require-warn, 0 require-flight-recorder).
- `tsc -p tsconfig.server.json` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)