### PR TITLE
fix(debate): fire crux finalization sweep on app-run synthesis path (t/3226)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/storeTestHarness.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/storeTestHarness.ts
@@ -217,6 +217,9 @@ vi.mock('@lib/debate/convergenceSignals', () => ({
 
 vi.mock('@lib/debate/cruxResolution', () => ({
   updateCruxTracker: vi.fn().mockReturnValue(undefined),
+  // t/3226: requestSynthesis now runs the debate-end finalization sweep. Passthrough mock —
+  // the real transition (identified→undecided) is unit-tested in lib/debate; here it's a no-op.
+  finalizeUndecidedCruxes: vi.fn((tracker?: unknown[]) => tracker ?? []),
 }));
 
 vi.mock('@lib/debate/taxonomyGapAnalysis', () => ({

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/synthesisSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/synthesisSlice.ts
@@ -16,6 +16,7 @@ import { trackDebateComplete } from '../../../lib/analyticsEmitter';
 import { generateId, nowISO, stripCodeFences, parseAIJson, extractArraysFromPartialJson, formatRecentTranscript } from '@lib/debate/helpers';
 import { runSynthesisPhases } from '@lib/debate/synthesisPhases';
 import type { SynthesisInput } from '@lib/debate/synthesisPhases';
+import { finalizeUndecidedCruxes } from '@lib/debate/cruxResolution';
 import { formatTaxonomyContext } from '../../../utils/taxonomyContext';
 import { formatCommitments, formatEstablishedPoints, formatConcessionCandidatesHint } from '../../../prompts/argumentNetwork';
 import { formatVocabularyContext } from '@lib/debate/vocabularyContext';
@@ -892,11 +893,27 @@ export const createSynthesisSlice: StateCreator<DebateStore, [], [], SynthesisSl
       ? policyRegistry.slice(0, 10).map(p => `${p.id}: ${p.action}`)
       : undefined;
 
+    // t/3226: debate-end finalization sweep — transition unadjudicated `identified` cruxes to the
+    // terminal `undecided` state (t/1676) BEFORE synthesis reads crux_tracker, so calibration
+    // extract() sees `undecided` and crux_undecided_rate stops being trivially 0. App-run debates
+    // never instantiate DebateEngine (the CLI path that runs this at Phase 3b), so without this the
+    // whole corpus ends with unresolved cruxes stuck in `identified` (t/3226#1). Idempotent, so a
+    // resume()→re-synthesis double-fire is a no-op. saveDebate persists it before the read below.
+    const finalCruxTracker = finalizeUndecidedCruxes(
+      activeDebate.crux_tracker,
+      activeDebate.transcript.length,
+      activeDebate.argument_network?.nodes ?? [],
+      activeDebate.argument_network?.edges ?? [],
+      activeDebate.transcript,
+    );
+    set({ activeDebate: { ...activeDebate, crux_tracker: finalCruxTracker } });
+    await saveDebate('finalizeUndecidedCruxes');
+
     const synthInput: SynthesisInput = {
       topic: activeDebate.topic.final,
       transcript: fullTranscript,
       audience: activeDebate.audience,
-      cruxTracker: activeDebate.crux_tracker,
+      cruxTracker: finalCruxTracker,
       policyLines,
       hasSourceDoc,
     };


### PR DESCRIPTION
Fixes the app-path gap in t/3226: `finalizeUndecidedCruxes` (transition unadjudicated `identified` cruxes → terminal `undecided`, t/1676) was only wired into the **CLI** DebateEngine path (Phase 3b). App-run debates never instantiate DebateEngine — they finalize via `useDebateStore` — so the sweep never fired: **1,306 / 1,806** tracked cruxes stuck in `identified`, and `crux_undecided_rate` trivially 0, hiding the real censoring signal from the R-4 gate (t/3226#1).

## Change
`synthesisSlice.ts` `requestSynthesis`, immediately before `synthInput` reads `crux_tracker`:
- `finalizeUndecidedCruxes(crux_tracker, transcript.length, argument_network?.nodes ?? [], argument_network?.edges ?? [], transcript)`
- `set` the finalized tracker to state → `await saveDebate('finalizeUndecidedCruxes')` (persist **before** the read) → feed `finalCruxTracker` into `synthInput`.
- Idempotent (t/1676) → resume()→re-synthesis double-fire is a no-op. `saveDebate` swallows its own errors (never throws), so the pre-try placement is safe.

Implemented per **DebateTool's e/135 spec**; all args verified available on `activeDebate` (t/3226#3). `lib/debate/cruxResolution.ts` unchanged. I dropped the optional per-debate observability record from my first draft to stay faithful to the owner's verified spec + avoid complexity creep on an already-flagged function — the observability win (`crux_undecided_rate` now populating) is delivered by the wiring itself.

## Test
Added `finalizeUndecidedCruxes` (passthrough) to the `@lib/debate/cruxResolution` mock in `storeTestHarness.ts` — without it the 3 `requestSynthesis` tests fail on the missing mock export.

## Verification
- `useDebateStore` suite: **277/277 green** (incl. all `requestSynthesis` + daily-limit-during-synthesis tests).
- renderer-tsc: 0 errors in changed files (the 3 `../lib` errors are the known worktree pnpm-hoist artifact, absent in CI).
- eslint: 0 errors.

DebateTool closes t/3226 when this lands (t/3226#4).

Commit: 73a69f33

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>
Co-Authored-By: Main (DebateTool) <main.lib-debate@ai-triad-research.orca.local>