### PR TITLE
chore(eslint): drop 2 now-unused require-warn disables — unblocks t/3205 flip

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/resilience.ts
+++ b/taxonomy-editor/src/renderer/bridge/resilience.ts
@@ -331,12 +331,9 @@ async function isBackpressure(res: Response): Promise<boolean> {
   try {
     const data = await res.clone().json() as { retryable?: unknown } | null;
     return data?.retryable === true;
-    // Classifier, not a degradation: a non-JSON / empty body means the response is NOT
-    // typed-backpressure (e.g. a genuinely-down 503). Returning false routes it to the
-    // real-failure path, which fails fast and trips the breaker — recorded there, not here.
-    // eslint-disable-next-line local/require-warn-on-degraded-catch-return -- classification, not a fallback; the genuine-down path is what records (t/3222)
   } catch {
-    /* silent by design: non-JSON / empty body = not typed-backpressure; the genuine-down path records downstream */
+    /* silent by design: non-JSON / empty body = not typed-backpressure (e.g. a genuinely-down 503);
+       returning false routes it to the real-failure path, which fails fast + trips the breaker, recorded there */
     return false;
   }
 }

--- a/taxonomy-editor/src/renderer/lib/analyticsEmitter.ts
+++ b/taxonomy-editor/src/renderer/lib/analyticsEmitter.ts
@@ -90,7 +90,6 @@ export async function resolveAnalyticsUser(): Promise<string> {
     if (prof && prof.isAnonymous === false && prof.userId) return prof.userId;
     const me = meRes.ok ? (await meRes.json()) as { user?: string } : null;
     return me?.user || '_anonymous';
-    // eslint-disable-next-line local/require-warn-on-degraded-catch-return -- benign best-effort telemetry: identity resolution failing degrades analytics to anon-keyed (no functional impact); no recorder dependency in this low-level telemetry-id resolver (t/3222)
   } catch { /* telemetry — silent by design */ return '_anonymous'; }
 }
 


### PR DESCRIPTION
Shared Lib refined the `require-warn-on-degraded-catch-return` predicate to `[]`/`{}`/`null`/`undefined` only (#1812, t/3200 GV). It no longer flags two sites I annotated as false positives in t/3222, so those `// eslint-disable-next-line` directives are now **unused-disable** warnings gating the warn→error flip (t/3205#5, p/10#104, p/588).

## Change
Drop the 2 unused directives:
- `resilience.ts` `isBackpressure` — returns `false` (a classifier, never `[]`/`{}`/`null`)
- `analyticsEmitter.ts` `resolveAnalyticsUser` — returns the string `'_anonymous'`

The `/* silent by design */` comments **stay** — they still satisfy the sibling `require-flight-recorder-in-catch` rule.

## Verification
eslint on both files: **0** of `require-warn`, `require-flight-recorder-in-catch`, and unused-disable. (The lone remaining warning is a pre-existing `resilientFetch` complexity flag, untouched by this change.)

Clears the last `src/renderer` noise before Shared Lib files the warn→error PR.

Commit: 0f353ecd

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>
Co-Authored-By: Main (Shared Lib) <main.lib@ai-triad-research.orca.local>