### PR TITLE
ci(devops): ACA cpu:memory allowed-pair validation gate (t/3212)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
       container: ${{ steps.filter.outputs.container }}
       lockfile-sync: ${{ steps.filter.outputs.lockfile-sync }}
       bicep-env: ${{ steps.filter.outputs.bicep-env }}
+      bicep-resources: ${{ steps.filter.outputs.bicep-resources }}
     steps:
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4.0.3
         id: filter
@@ -181,6 +182,12 @@ jobs:
               - '.github/workflows/deploy-azure.yml'
               - 'operations/devops/Get-BicepBaseEnv.ps1'
               - 'operations/devops/Test-BicepEnvDrift.ps1'
+              - '.github/workflows/ci.yml'
+            # 'bicep-resources' gates bicep-aca-resources (t/3212). Triggers when
+            # main.bicep or the validator script changes. Skip = OK through ci-gate.
+            bicep-resources:
+              - 'deploy/azure/main.bicep'
+              - 'operations/devops/Test-BicepAcaResourcePairs.ps1'
               - '.github/workflows/ci.yml'
 
   test-powershell:
@@ -1301,6 +1308,25 @@ jobs:
         shell: pwsh
         run: ./operations/devops/Test-BicepEnvDrift.ps1
 
+  # ── bicep-aca-resources: ACA cpu:memory allowed-pair validation (t/3212) ──
+  # Parses cpu:memory pairs from deploy/azure/main.bicep and validates each
+  # against the ACA Consumption fixed allowed-pairs table (co-located in the
+  # script). Catches the #1771 escape: 2.0vCPU+2Gi compiled fine with
+  # `az bicep build` but fails ARM deploy with ContainerAppInvalidResourceTotal.
+  # Path-filtered; skip = OK through ci-gate.
+  bicep-aca-resources:
+    needs: [changes]
+    if: >-
+      always() && !cancelled() &&
+      (github.event_name != 'pull_request' || needs.changes.outputs.bicep-resources == 'true')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
+
+      - name: Validate ACA cpu:memory pairs in main.bicep (t/3212)
+        shell: pwsh
+        run: ./operations/devops/Test-BicepAcaResourcePairs.ps1
+
   # ── ci-gate: the SINGLE required status context (t/1962) ──────────────────
   # Replaces the 6 individual code-check contexts in branch protection. Those get
   # SKIPPED by path-filtering on non-electron PRs (docs-only, PS-only); a skipped
@@ -1334,9 +1360,11 @@ jobs:
   # lib/brief/schemas/*.write.json contract changes; path-filtered to lib, skip = OK.
   # test-python (t/2933) is gated here: runs scripts/test_*.py under pytest;
   # path-filtered to scripts/** changes, skip = OK.
+  # bicep-aca-resources (t/3212) is gated here: ACA cpu:memory allowed-pair
+  # validation in main.bicep; path-filtered to bicep-resources changes, skip = OK.
   ci-gate:
     name: ci-gate
-    needs: [changes, test-powershell, test-electron, test-container, python-embed-smoke, test-python, dependency-coverage, lockfile-overrides-check, lib-lint, renderer-tsc, contrast-check, test-server-prod-config, workflow-lint, bicep-env-drift, schema-version-bump, render-smoke]
+    needs: [changes, test-powershell, test-electron, test-container, python-embed-smoke, test-python, dependency-coverage, lockfile-overrides-check, lib-lint, renderer-tsc, contrast-check, test-server-prod-config, workflow-lint, bicep-env-drift, schema-version-bump, render-smoke, bicep-aca-resources]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/operations/devops/Test-BicepAcaResourcePairs.ps1
+++ b/operations/devops/Test-BicepAcaResourcePairs.ps1
@@ -1,0 +1,140 @@
+<#
+.SYNOPSIS
+    CI gate: validates that every Container App's cpu:memory pair in main.bicep
+    is an ACA Consumption plan allowed combination. Exits non-zero on any invalid pair.
+
+.DESCRIPTION
+    Parses deploy/azure/main.bicep for `resources: { cpu: ... memory: ... }` blocks
+    and checks each pair against the ACA Consumption allowed-pairs table (co-located
+    here per gate co-location practice).
+
+    ACA Consumption allowed cpu:memory pairs (source: Azure docs):
+      0.25 vCPU / 0.5 Gi    0.50 vCPU / 1 Gi      0.75 vCPU / 1.5 Gi
+      1.00 vCPU / 2 Gi      1.25 vCPU / 2.5 Gi    1.50 vCPU / 3 Gi
+      1.75 vCPU / 3.5 Gi   2.00 vCPU / 4 Gi
+
+    Gate proof arms (required in PR description before merge — t/3212):
+      FIRE (invalid combo): cpu: json('2.0') + memory: '2Gi' -> exits 1
+      FIRE (zero pairs):    bicep with no resources block     -> exits 1
+      CLEAN:                existing valid pairs              -> exits 0
+
+.PARAMETER BicepPath
+    Path to deploy/azure/main.bicep. Defaults to repo-relative location.
+
+.PARAMETER SuppressAnnotations
+    Emits plain PAIR-ERROR: lines instead of ::error:: annotations. Use in tests
+    to avoid polluting CI log with annotations from deliberate FIRE-arm runs.
+#>
+[CmdletBinding()]
+param(
+    [string]$BicepPath,
+    [switch]$SuppressAnnotations
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# ── Allowed-pairs table (co-located per gate co-location practice) ────────────
+# Key: cpu as [double]; Value: required memory string
+$allowedPairs = @{
+    [double]0.25 = '0.5Gi'
+    [double]0.5  = '1Gi'
+    [double]0.75 = '1.5Gi'
+    [double]1.0  = '2Gi'
+    [double]1.25 = '2.5Gi'
+    [double]1.5  = '3Gi'
+    [double]1.75 = '3.5Gi'
+    [double]2.0  = '4Gi'
+}
+
+function Write-CIError([string]$msg) {
+    if ($SuppressAnnotations) { Write-Host "PAIR-ERROR: $msg" }
+    else { Write-Host "::error::$msg" }
+}
+
+$repoRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+if (-not $BicepPath) { $BicepPath = Join-Path $repoRoot 'deploy/azure/main.bicep' }
+
+if (-not (Test-Path $BicepPath)) {
+    Write-CIError "main.bicep not found at: $BicepPath"
+    exit 1
+}
+
+# ── Parse resources blocks ────────────────────────────────────────────────────
+# State machine: detect 'resources: {', collect cpu/memory, close on '}'.
+# The resources block in ACA Bicep is flat (no nested braces), so the first
+# closing '}' after the opening terminates the block.
+$lines    = Get-Content $BicepPath
+$inBlock  = $false
+$cpu      = $null
+$memory   = $null
+$pairs    = [System.Collections.Generic.List[PSCustomObject]]::new()
+
+foreach ($line in $lines) {
+    if (-not $inBlock) {
+        if ($line -match 'resources\s*:\s*\{') {
+            $inBlock = $true
+            $cpu     = $null
+            $memory  = $null
+        }
+        continue
+    }
+
+    # Extract cpu — handles both json('N') and bare numeric forms
+    if ($line -match 'cpu\s*:\s*json\s*\(\s*''([^'']+)''\s*\)') {
+        $cpu = $Matches[1]
+    } elseif ($line -match "cpu\s*:\s*([0-9]+(?:\.[0-9]+)?)") {
+        $cpu = $Matches[1]
+    }
+
+    # Extract memory — e.g. memory: '4Gi'
+    if ($line -match "memory\s*:\s*'([^']+)'") {
+        $memory = $Matches[1]
+    }
+
+    # Closing brace — end of resources block
+    if ($line -match '^\s*\}\s*$') {
+        if ($null -ne $cpu -and $null -ne $memory) {
+            $pairs.Add([PSCustomObject]@{ Cpu = $cpu; Memory = $memory })
+        }
+        $inBlock = $false
+        $cpu     = $null
+        $memory  = $null
+    }
+}
+
+# ── No-silent-skip guard ──────────────────────────────────────────────────────
+if ($pairs.Count -eq 0) {
+    Write-CIError 'No cpu:memory pairs found in main.bicep resources blocks — check parsing or bicep structure'
+    exit 1
+}
+
+# ── Validate each pair ────────────────────────────────────────────────────────
+$pass = $true
+$rows = [System.Collections.Generic.List[PSCustomObject]]::new()
+
+foreach ($pair in $pairs) {
+    $cpuDouble = [double]$pair.Cpu
+    $expected  = $allowedPairs[$cpuDouble]
+
+    if ($null -eq $expected) {
+        $rows.Add([PSCustomObject]@{ Cpu = $pair.Cpu; Memory = $pair.Memory; Expected = '(no valid pair for this cpu)'; Status = 'FAIL' })
+        Write-CIError "Invalid ACA cpu:memory — cpu=$($pair.Cpu) is not a recognized ACA Consumption vCPU value"
+        $pass = $false
+    } elseif ($pair.Memory -ne $expected) {
+        $rows.Add([PSCustomObject]@{ Cpu = $pair.Cpu; Memory = $pair.Memory; Expected = $expected; Status = 'FAIL' })
+        Write-CIError "Invalid ACA cpu:memory — cpu=$($pair.Cpu) requires memory=$expected, got '$($pair.Memory)' (ContainerAppInvalidResourceTotal — t/3212)"
+        $pass = $false
+    } else {
+        $rows.Add([PSCustomObject]@{ Cpu = $pair.Cpu; Memory = $pair.Memory; Expected = $expected; Status = 'OK' })
+    }
+}
+
+$rows | Format-Table Cpu, Memory, Expected, Status -AutoSize | Out-String | Write-Host
+
+if (-not $pass) {
+    Write-CIError 'ACA cpu:memory validation failed. Fix main.bicep to use an allowed pair. See t/3212.'
+    exit 1
+}
+
+Write-Host "ACA cpu:memory validation PASSED — $($pairs.Count) pair(s) checked."


### PR DESCRIPTION
## Summary

- New `operations/devops/Test-BicepAcaResourcePairs.ps1`: parses `resources: { cpu: ... memory: ... }` blocks from `main.bicep`, validates each pair against the co-located ACA Consumption allowed-pairs table, no-silent-skip guard
- New `bicep-aca-resources` CI job with `bicep-resources` paths filter; added to `ci-gate` needs
- Closes the #1771 escape: `2.0vCPU+2Gi` compiled fine with `az bicep build` but failed ARM deploy with `ContainerAppInvalidResourceTotal`

## Gate Verification (both-arms — Quality TL required in PR description, t/3212)

**CLEAN arm** — existing valid pairs pass:
```
Cpu  Memory Expected Status
---  ------ -------- ------
2.0  4Gi    4Gi      OK
0.25 0.5Gi  0.5Gi    OK

ACA cpu:memory validation PASSED — 2 pair(s) checked.
Exit: 0
```

**FIRE arm 1** — `json('2.0')` + `'2Gi'` (invalid combo, prod cpu form):
```
PAIR-ERROR: Invalid ACA cpu:memory — cpu=2.0 requires memory=4Gi, got '2Gi' (ContainerAppInvalidResourceTotal — t/3212)

Cpu Memory Expected Status
--- ------ -------- ------
2.0 2Gi    4Gi      FAIL

PAIR-ERROR: ACA cpu:memory validation failed. Fix main.bicep to use an allowed pair. See t/3212.
Exit: 1
```

**FIRE arm 2** — zero pairs found (no resources block):
```
PAIR-ERROR: No cpu:memory pairs found in main.bicep resources blocks — check parsing or bicep structure
Exit: 1
```

## Test plan

- [ ] CI passes green on this PR
- [ ] `bicep-aca-resources` job appears in checks and is green
- [ ] Verify base is `main` before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoFczg4VoqfBtCeDHkJfv6