### PR TITLE
gate(eslint): flip degraded-return rule warn→error (t/3205 Gate Promotion) [GATED: TL GV]

### DIFF
--- a/taxonomy-editor/eslint-rules/__tests__/require-warn-on-degraded-catch-return.test.ts
+++ b/taxonomy-editor/eslint-rules/__tests__/require-warn-on-degraded-catch-return.test.ts
@@ -73,5 +73,10 @@ rt.run('require-warn-on-degraded-catch-return', rule, {
       code: h("try { await load(); } catch (e) { return undefined; }"),
       errors: [{ messageId: 'degradedReturnNeedsWarn' }],
     },
+    // Dedicated empty-array fire branch: bare `return []` from an IO path, no recorder (TL nit, p/342#254).
+    {
+      code: h("try { await load(); } catch (e) { return []; }"),
+      errors: [{ messageId: 'degradedReturnNeedsWarn' }],
+    },
   ],
 });

--- a/taxonomy-editor/eslint.config.mjs
+++ b/taxonomy-editor/eslint.config.mjs
@@ -81,11 +81,12 @@ export default tseslint.config(
       // ADR-003 enforcement (t/1323, repo-review B-401): every catch records to the
       // flight recorder. Flipped warn→error once the tree was clean (0 violations).
       'local/require-flight-recorder-in-catch': 'error',
-      // t/3200 (Fallback-Path Logging): a degraded-default return from a data/IO catch must record
-      // at WARN/ERROR. Shipped 'warn' (non-blocking visibility) — separate rule from the base one so
-      // this severity is independent. Promotion to 'error' is a separate GV-gated step once the
-      // t/3169 cleanup lands the WARNs and the flagged count reaches zero (TL t/3200#2).
-      'local/require-warn-on-degraded-catch-return': 'warn',
+      // t/3200/t/3205 (Fallback-Path Logging): a degraded-default return (`[]`/`{}`/`null`/`undefined`)
+      // from a data/IO catch must record at WARN/ERROR. Flipped warn→error at zero-noise (TL Gate
+      // Promotion, t/3200#2 / p/342#254): the per-owner cleanup (t/3219–t/3223) + the predicate
+      // refinement (#1812) drove the flagged count to 0. Separate rule from the base one so severity
+      // is independent.
+      'local/require-warn-on-degraded-catch-return': 'error',
       'max-lines': MAX_LINES_SRC,
       // ActionableError nesting gate (t/2764 / t/2761): forbid err.message in problem:.
       // Custom rule (not no-restricted-syntax) so it restricts to error-named identifiers


### PR DESCRIPTION
Promotes `local/require-warn-on-degraded-catch-return` from `warn` → `error` at zero-noise (TL Gate Promotion, t/3200#2 / p/342#254).

**Zero-noise reached:** per-owner cleanup (t/3219–t/3223: ElectronMain #1813, ServerAPI #1817, Rosetta #1819) + the predicate refinement (#1812) drove the flagged count to **0** across taxonomy-editor/src. Verified: `eslint src/` exits **0** at error.

**Both-arms proof:** RuleTester **21/21** — added a dedicated bare-`return []` fire case (your nit, p/342#254). Fires on `[]`/`{}`/`null`/`undefined` (IO, no recorder); silent on boolean guards, `{ok:false,reason}`, non-empty arrays, and any catch that logs first.

Config file (`eslint.config.mjs`) is Rosetta's — they did the renderer cleanup and cleared filing this flip (p/10#106). Draft → **Main TL GV** (Gate Promotion: zero-noise + both arms). No rush — I know you're mid the t/3165 recurrence. Closes t/3205 on GV + merge.