### PR TITLE
fix(server): gate anon/free-tier debate generation — free-key-pool exhaustion (t/3230)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/anonDebateGate.test.ts
+++ b/taxonomy-editor/src/server/__tests__/anonDebateGate.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment node
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3230 — enforceAnonDebateGate. A single anonymous debate drains the shared free Gemini key pool
+// (K=4) → 429 storm → ~485s retry → user-facing 500 (prod incident, owner-approved disable). The
+// gate 403s free-tier DEBATE generation (isFree && debateId) BEFORE any key/provider call, and is
+// reversible via the `anon-debates` feature flag. These arms lock: blocked only for free+debate+
+// flag-off; pass-through for flag-on, non-debate, and authenticated; flag not consulted when the
+// cheap isFree/debateId guards already exclude the request (short-circuit).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ServerResponse } from 'http';
+
+const { anonEnabled, record } = vi.hoisted(() => ({ anonEnabled: vi.fn(), record: vi.fn() }));
+vi.mock('../featureFlags.js', () => ({ isAnonDebatesEnabled: anonEnabled }));
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({ getGlobalRecorder: () => ({ record }) }));
+// onnxEmbedding is pulled in transitively via aiBackends; stub it so the import is cheap + hermetic.
+vi.mock('../../../../lib/embeddings/onnxEmbedding.js', () => ({
+  tryWarmup: vi.fn(async () => false), warmup: vi.fn(async () => false),
+  computeEmbedding: vi.fn(async () => []), computeEmbeddings: vi.fn(async () => []),
+}));
+
+import { enforceAnonDebateGate } from '../routes/generationContext.js';
+
+/** Minimal ServerResponse stub capturing writeHead/end. */
+function makeRes(): ServerResponse & { statusCode: number; body: string; ended: boolean } {
+  const res = {
+    statusCode: 0, body: '', ended: false,
+    writeHead(code: number) { this.statusCode = code; return this; },
+    end(chunk?: string) { this.body = chunk ?? ''; this.ended = true; return this; },
+  };
+  return res as unknown as ServerResponse & { statusCode: number; body: string; ended: boolean };
+}
+
+describe('enforceAnonDebateGate (t/3230)', () => {
+  beforeEach(() => { anonEnabled.mockReset(); record.mockReset(); });
+
+  it('free-tier debate + flag OFF → 403 (handled), non-retryable body, records a warn', () => {
+    anonEnabled.mockReturnValue(false);
+    const res = makeRes();
+    const handled = enforceAnonDebateGate(res, true, 'deb-123');
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(403);
+    const body = JSON.parse(res.body);
+    expect(body.reason).toBe('anon_debates_disabled');
+    expect(body.retryable).toBe(false);
+    expect(record).toHaveBeenCalledTimes(1);
+    expect(record.mock.calls[0][0]).toMatchObject({ level: 'warn', component: 'ai-generate' });
+  });
+
+  it('free-tier debate + flag ON → pass-through (no response sent)', () => {
+    anonEnabled.mockReturnValue(true);
+    const res = makeRes();
+    expect(enforceAnonDebateGate(res, true, 'deb-123')).toBe(false);
+    expect(res.ended).toBe(false);
+    expect(record).not.toHaveBeenCalled();
+  });
+
+  it('free-tier NON-debate (no debateId) → pass-through even with flag OFF', () => {
+    anonEnabled.mockReturnValue(false);
+    const res = makeRes();
+    expect(enforceAnonDebateGate(res, true, undefined)).toBe(false);
+    expect(res.ended).toBe(false);
+  });
+
+  it('authenticated/paid debate (isFree=false) → pass-through even with flag OFF', () => {
+    anonEnabled.mockReturnValue(false);
+    const res = makeRes();
+    expect(enforceAnonDebateGate(res, false, 'deb-123')).toBe(false);
+    expect(res.ended).toBe(false);
+  });
+
+  it('short-circuit: the flag is NOT read when isFree is false or debateId is absent', () => {
+    anonEnabled.mockReturnValue(false);
+    enforceAnonDebateGate(makeRes(), false, 'deb-123');
+    enforceAnonDebateGate(makeRes(), true, undefined);
+    expect(anonEnabled).not.toHaveBeenCalled();
+  });
+});

--- a/taxonomy-editor/src/server/featureFlags.ts
+++ b/taxonomy-editor/src/server/featureFlags.ts
@@ -124,6 +124,17 @@ const SEED_FLAGS: Record<string, FlagDef> = {
     created_at: '2026-08-07T00:00:00.000Z', updated_at: '2026-08-07T00:00:00.000Z',
     created_by: 'seed',
   },
+  'anon-debates': {
+    // t/3230: default OFF — a single anonymous debate exhausts the shared free Gemini key pool
+    // (K=4) → 429 storm → ~485s retry → user-facing 500 (prod incident, owner-approved disable).
+    // While OFF, free-tier debate generation is 403'd (generationContext.enforceAnonDebateGate).
+    // Re-enable = an admin flip to true (data.flags merges over SEED, no redeploy) once a
+    // throttled anon mode (fewer rounds / no fact-check search / per-IP cap) lands.
+    name: 'anon-debates', enabled: false, scope: 'global',
+    description: 'Allow anonymous/free-tier users to run debates — OFF (t/3230: anon debates drain the free-key pool)',
+    created_at: '2026-09-02T00:00:00.000Z', updated_at: '2026-09-02T00:00:00.000Z',
+    created_by: 'seed',
+  },
 };
 
 // ── Config loading (mtime cache, quotas.ts pattern) ──
@@ -327,6 +338,13 @@ function resolve(def: FlagDef | undefined, ctx: FlagUserContext): boolean {
 /** Resolve a single flag for the current user. Unknown → false (AC#1). */
 export function getFlag(name: string): boolean {
   return resolve(getConfig().flags[name], currentContext());
+}
+
+/** t/3230: are anonymous/free-tier debates allowed? Default false (the `anon-debates` seed is OFF)
+ *  — gates free-tier debate generation in generationContext.enforceAnonDebateGate. An admin flip
+ *  to true re-enables without a redeploy. Single swap-point for the mechanism. */
+export function isAnonDebatesEnabled(): boolean {
+  return getFlag('anon-debates');
 }
 
 /** All flags resolved for the current user. */

--- a/taxonomy-editor/src/server/routes/ai.ts
+++ b/taxonomy-editor/src/server/routes/ai.ts
@@ -27,7 +27,7 @@ import { hasApiKey, getPaidGeminiFallbackKey, type AIBackend } from '../config.j
 import * as proxyTiers from '../ai/proxyTiers.js';
 import * as rateLimiter from '../security/rateLimiter.js';
 import * as ai from '../ai/aiBackends.js';
-import { resolveGenerationContext, enforceBackendAllowed } from './generationContext.js';
+import { resolveGenerationContext, enforceBackendAllowed, enforceAnonDebateGate } from './generationContext.js';
 
 import * as fileIO from '../storage/fileIO.js';
 import { beginEmbeddingCompute, endEmbeddingCompute, embeddingLoadSnapshot, evaluateEmbeddingLoadShed, isEmbeddingModelWarm, markEmbeddingModelWarm } from '../embeddingsLoad.js';
@@ -392,6 +392,11 @@ export function registerAiRoutes(r: Router, ctx: ServerCtx): void {
       // Free-tier cost is bounded by tokensPerDay + per-IP rate limits; the redundant
       // per-prompt char cap was removed in t/812 (broke long debate prompts).
       const { tier, isFree, limitKey, effectiveModel, backend } = resolveGenerationContext(req, model);
+      // t/3230: a single anonymous debate drains the shared free Gemini key pool (K=4) → 429 storm
+      // → ~485s retry → user-facing 500. Block free-tier debate generation (reversible via the
+      // `anon-debates` flag) BEFORE any key/provider call — covers debate rounds AND the fact-check
+      // `search` calls (both carry debateId). Authenticated debates + non-debate free-tier untouched.
+      if (enforceAnonDebateGate(res, isFree, debateId)) return; // 403 when anon debates disabled
       if (enforceBackendAllowed(res, tier, backend)) return; // 403 if backend not on tier
 
       // Rate limiting: per-IP RPM (free tier) / per-user RPM + daily token budget (429 on breach).

--- a/taxonomy-editor/src/server/routes/generationContext.ts
+++ b/taxonomy-editor/src/server/routes/generationContext.ts
@@ -19,6 +19,7 @@ import { type AIBackend } from '../config.js';
 import { getClientIp } from '../httpKit.js';
 import { callerTierIdentity } from '../security/accessControl.js';
 import { getCurrentUser } from '../security/userContext.js';
+import { isAnonDebatesEnabled } from '../featureFlags.js';
 
 export type ResolvedTier = ReturnType<typeof proxyTiers.resolveTier>;
 
@@ -56,5 +57,27 @@ export function enforceBackendAllowed(res: http.ServerResponse, tier: ResolvedTi
   });
   res.writeHead(403, { 'Content-Type': 'application/json' });
   res.end(JSON.stringify({ error: `Backend '${backend}' not available on your tier`, tier_level: tier.level, requested_backend: backend }));
+  return true;
+}
+
+/** 403 + record when an anonymous/free-tier caller runs a DEBATE while anon debates are disabled
+ *  (t/3230: a single anon debate drains the shared free Gemini key pool (K=4) → 429 storm → ~485s
+ *  retry → user-facing 500). The `debateId` marker is present on every debate generate — including
+ *  the fact-check `search` calls, the biggest key burn — so `isFree && debateId` scopes the block
+ *  to exactly the free-tier debate flow; authenticated debates and all non-debate free-tier
+ *  generation are untouched. Reversible: an admin flip of the `anon-debates` flag → true re-enables
+ *  with no redeploy. Returns true when it has already sent a response (caller must return). */
+export function enforceAnonDebateGate(res: http.ServerResponse, isFree: boolean, debateId: string | undefined): boolean {
+  if (!isFree || !debateId || isAnonDebatesEnabled()) return false;
+  getGlobalRecorder()?.record({
+    type: 'ai.error', component: 'ai-generate', level: 'warn',
+    message: 'Anonymous debate generation blocked — anon debates disabled (t/3230)',
+    data: { tier_level: 'free', debateId: debateId.slice(0, 64), reason: 'anon-debates-disabled' },
+  });
+  res.writeHead(403, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({
+    error: 'Anonymous debates are temporarily disabled. Sign in to run debates.',
+    reason: 'anon_debates_disabled', retryable: false,
+  }));
   return true;
 }


### PR DESCRIPTION
## t/3230 — prod incident (owner-approved), auth-surface → **Main (TL) GV**

A single anonymous debate drains the shared free Gemini key pool (K=4) → 429 storm → ~485s retry → user-facing 500. Owner approved disabling anon debates; owner also confirmed the design (build as-is). Partial interim relief for t/3165 too (fewer concurrent in-process AI calls).

### Change
- **`enforceAnonDebateGate`** (`routes/generationContext.ts`, mirrors `enforceBackendAllowed`): 403s when `isFree && debateId` and the `anon-debates` flag is OFF. Wired in `/api/ai/generate` **before any key/provider call** (`routes/ai.ts`). `debateId` rides every debate generate incl. the `search:true` fact-check calls (biggest key burn) → one gate covers rounds + fact-checks.
- **Blast radius:** only free-tier **and** debate. Authenticated debates + all non-debate free-tier generation untouched.
- **Reversible:** `anon-debates` feature flag, **default OFF** (seeded, mirrors `env-web-opeds`). Admin flip → true re-enables, **no redeploy** = rollback path. `isAnonDebatesEnabled()` is the single swap-point.

### Tests
`anonDebateGate.test.ts` — 5 arms: blocked only for free+debate+flag-off; pass-through for flag-on / non-debate / authenticated; flag not read when the cheap guards exclude the request. **5/5**; tsc clean; eslint 0 errors.

### Scope split
Issue #2 (the ~485s retry → opaque 500) is `lib/ai-client/retry.ts` = Shared Lib → routed as **t/3232**.

Draft pending TL GV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)