### PR TITLE
fix(server): add Pino stdout log to anon-debate gate — TL observable condition (t/3230 follow-up)

### DIFF
--- a/taxonomy-editor/src/server/routes/generationContext.ts
+++ b/taxonomy-editor/src/server/routes/generationContext.ts
@@ -20,6 +20,7 @@ import { getClientIp } from '../httpKit.js';
 import { callerTierIdentity } from '../security/accessControl.js';
 import { getCurrentUser } from '../security/userContext.js';
 import { isAnonDebatesEnabled } from '../featureFlags.js';
+import { log } from '../logger.js';
 
 export type ResolvedTier = ReturnType<typeof proxyTiers.resolveTier>;
 
@@ -74,6 +75,9 @@ export function enforceAnonDebateGate(res: http.ServerResponse, isFree: boolean,
     message: 'Anonymous debate generation blocked — anon debates disabled (t/3230)',
     data: { tier_level: 'free', debateId: debateId.slice(0, 64), reason: 'anon-debates-disabled' },
   });
+  // TL GV condition (observable): also emit to Pino/stdout so blocks are countable in Log Analytics
+  // (the FR record above lives in the ring buffer only). One line per blocked anon debate.
+  log.api.warn({ component: 'ai-generate', reason: 'anon-debates-disabled', tier_level: 'free', debateId: debateId.slice(0, 64) }, 'anon debate generation blocked (t/3230)');
   res.writeHead(403, { 'Content-Type': 'application/json' });
   res.end(JSON.stringify({
     error: 'Anonymous debates are temporarily disabled. Sign in to run debates.',


### PR DESCRIPTION
## t/3230 follow-up — completes TL impl-GV condition 3 (observable)

**#1824 (the anon-gate) merged at `64b06253`, one commit BEFORE my condition-3 push** — so the observable Pino log landed nowhere. The gate itself is live on main (incident mitigated); this lands the missing observability.

TL's 3 conditions: (1) fail-closed ✓ and (2) server-authoritative ✓ were already in #1824. (3) **observable** was an FR-ring record only (invisible to Log Analytics — the exact t/3165 lesson). This adds a `log.api.warn` on each block so anon-debate denials are countable in stdout.

Self-cert: **/trivial-change** (4-line log addition, no behavior change; TL already GV'd the design). eslint 0 errors, tsc clean, gate test 5/5 (verified pre-cherry-pick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)