### PR TITLE
obs(server): surface embedding offload-flag + resolved chain to stdout (t/3165)

### DIFF
--- a/taxonomy-editor/src/server/ai/aiBackends.ts
+++ b/taxonomy-editor/src/server/ai/aiBackends.ts
@@ -814,6 +814,20 @@ export async function computeEmbeddings(
     chain.push({ name: 'onnx-batch', compute: (t) => onnxComputeEmbeddings(t) });
   }
 
+  // t/3165 observability: emit the RESOLVED chain + the offload-flag value to Pino/stdout. The
+  // completion record at :821 lands in the FR ring ONLY (invisible to Log Analytics) — which is
+  // precisely why the "offload looked engaged at flip but silently wasn't" regression took inference
+  // to diagnose. A prod compute now self-reports on stdout: offloadFlag=false + chain=['onnx-batch']
+  // (in-process, main-thread — the t/3165 starvation shape) vs offloadFlag=true +
+  // chain=['onnx-batch-worker'] (engaged). Unconditional + pre-compute → can't be masked by a
+  // swallowed downstream error.
+  log.api.info({
+    component: 'ai-backends', requester,
+    offloadFlag: isEmbeddingWorkerOffloadEnabled(),
+    chainMembers: chain.map(c => c.name),
+    inputCount: texts.length, cacheHits, cacheMisses,
+  }, 'computeEmbeddings chain resolved');
+
   try {
     // t/2985: timeout is now per-chunk inside resolveEmbeddingsChunked — no aggregate ceiling.
     const result = await resolveEmbeddingsChunked(texts, ids, local, chain);

--- a/taxonomy-editor/src/server/server.ts
+++ b/taxonomy-editor/src/server/server.ts
@@ -34,7 +34,7 @@ import {
   getStoredApiKeys, addApiKey, removeApiKey, resolveDataPath,
   getPaidGeminiFallbackKey, setPaidGeminiFallbackKey, deletePaidGeminiFallbackKey,
   BROKER_SCRIPT, SCRIPTS_DIR, getProjectRoot, type AIBackend,
-  STORAGE_MODE, CACHE_DIR,
+  STORAGE_MODE, CACHE_DIR, isEmbeddingWorkerOffloadEnabled,
 } from './config.js';
 import { GitHubAPIBackend } from './storage/githubAPIBackend.js';
 import { SessionBranchManager } from './storage/sessionBranchManager.js';
@@ -1309,6 +1309,11 @@ server.listen(PORT, BIND_HOST, () => {
   // batch/PS/Python writes that bypass the inline G8a hook. Gated on GROUNDING_SWEEP_ENABLED
   // (default OFF): inert until the sequenced enable (t/3203 + TL lock-symmetry sign-off). Unref'd.
   startGroundingSweep();
+  // t/3165 observability: one-line boot record of the offload flag's RUNTIME value, so a deploy's
+  // effective EMBEDDING_WORKER_OFFLOAD is greppable in Log Analytics at startup — the "looked set
+  // in ACA config but process.env evaluated false" regression (bicep value-form) is then visible
+  // immediately, not inferred from a debate's compute path.
+  log.server.info({ embeddingWorkerOffload: isEmbeddingWorkerOffloadEnabled() }, 'embedding offload flag at boot');
   void warmupEmbeddings().catch((err: unknown) => {
     log.server.error({ err: String(err) }, 'ONNX embedding warmup failed at boot');
     getGlobalRecorder()?.record({ type: 'system.error', component: 'server', level: 'error', message: 'ONNX embedding warmup failed at boot', error: { name: (err as Error)?.name ?? 'Error', message: String(err), stack: (err as Error)?.stack } });


### PR DESCRIPTION
## t/3165 observability — the self-diagnosing marker → **Main (TL) GV** (approved e/136#10)

The prod regression (offload "looked engaged at the durable #1793 flip but silently ran in-process ONNX on the main thread") was diagnosable only by inference: `computeEmbeddings` records its resolved `chainMembers` to the **FR ring only** (aiBackends:821), invisible to Log Analytics. Root cause (traced): the chain is `if(flag)→onnx-batch-worker / else-if→onnx-batch(in-process)`; main-thread ONNX + zero worker logs + no :827 error is **only** producible by the else branch ⇒ `isEmbeddingWorkerOffloadEnabled()` evaluating **false at runtime** (likely the bicep value-form — DevOps `printenv` confirming).

### Change (observability-only, no behavior change)
- **aiBackends.`computeEmbeddings`** — one Pino/stdout INFO at chain resolution: `{ offloadFlag, chainMembers, requester, inputCount, cacheHits, cacheMisses }`. Unconditional + pre-compute, so it can't be masked by a swallowed downstream error. Next prod debate self-reports `offloadFlag=false + chain=['onnx-batch']` (the starvation shape) vs `true + ['onnx-batch-worker']` (engaged).
- **server.ts boot** — one line logging the offload flag's runtime value, so a deploy's effective `EMBEDDING_WORKER_OFFLOAD` is greppable at startup (surfaces the "looked set in ACA config, evaluated false" gap directly).

### Verify
`tsc -p tsconfig.server.json` clean; eslint 0 errors. No test — pure logging.

Note: if `printenv` confirms the flag is false, the actual FIX is a bicep/env value-form correction (DevOps), not code — this PR is the durable self-diagnosis either way. Draft pending your GV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)