### PR TITLE
fix(ai-client): cap rate-limit retry budget so a 429 surfaces fast, n…

### DIFF
--- a/lib/ai-client/retry.test.ts
+++ b/lib/ai-client/retry.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { withRetry, parseRateLimitHeaders, parseRateLimitType, retryableFetch, makeFetchSignal } from './retry.js';
+import { withRetry, parseRateLimitHeaders, parseRateLimitType, retryableFetch, makeFetchSignal, CLI_RETRY_CONFIG } from './retry.js';
 import type { RetryConfig } from './retry.js';
 
 const FAST_CONFIG: RetryConfig = {
@@ -475,5 +475,74 @@ describe('retryableFetch — response size cap (t/2719)', () => {
       timeoutMs: 5000, fetchFn, config: FAST_CONFIG,
     });
     expect(result.bodyText).toBe('{"result":"ok"}');
+  });
+});
+
+describe('rate-limit retry budget cap (t/3232)', () => {
+  // The server path is ACA-ingress-bound: a rate-limit must surface a retryable 429 FAST, not sleep
+  // ~480s (120s floor × ~4) past the ingress timeout into an opaque 500. Config-driven so CLI is untouched.
+  const SERVER_CAP: RetryConfig = {
+    maxRetries: 5, strategy: 'exponential', maxBackoffS: 30,
+    rateLimitMaxAttempts: 2, rateLimitMaxSleepS: 30,
+  };
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it('withRetry: caps rate-limit attempts (surfaces the 429 at rateLimitMaxAttempts, not maxRetries)', async () => {
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation((fn: Function) => { fn(); return 0 as unknown as ReturnType<typeof setTimeout>; });
+    let calls = 0;
+    await expect(withRetry(async () => { calls++; throw new Error('API error 429: Rate limited'); }, SERVER_CAP, 'test'))
+      .rejects.toThrow('429');
+    expect(calls).toBe(2); // rateLimitMaxAttempts, NOT maxRetries(5) → surfaces fast
+  });
+
+  it('withRetry: fast-fails an exhausted key pool (no retry, no sleep)', async () => {
+    let calls = 0;
+    await expect(withRetry(async () => { calls++; throw new Error('429: api_key_exhausted — all keys rate limited'); }, SERVER_CAP, 'test'))
+      .rejects.toThrow('exhausted');
+    expect(calls).toBe(1);
+  });
+
+  it('withRetry: CLI config keeps the full rate-limit budget (unchanged — no cap)', async () => {
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation((fn: Function) => { fn(); return 0 as unknown as ReturnType<typeof setTimeout>; });
+    let calls = 0;
+    await expect(withRetry(async () => { calls++; throw new Error('API error 429: Rate limited'); }, CLI_RETRY_CONFIG, 'test'))
+      .rejects.toThrow('429');
+    expect(calls).toBe(5); // CLI maxRetries, unchanged by t/3232
+  });
+
+  it('retryableFetch: surfaces a 429 after rateLimitMaxAttempts (not maxRetries)', async () => {
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation((fn: Function) => { fn(); return 0 as unknown as ReturnType<typeof setTimeout>; });
+    let calls = 0;
+    const fetchFn = vi.fn().mockImplementation(() => { calls++; return Promise.resolve({
+      ok: false, status: 429, headers: new Headers(),
+      text: () => Promise.resolve('{"error":{"message":"rate limit per minute"}}'),
+    }); });
+    await expect(retryableFetch({ label: 'test', url: 'https://x', init: { method: 'POST' }, timeoutMs: 5000, fetchFn, config: SERVER_CAP }))
+      .rejects.toThrow(/Rate limited/);
+    expect(calls).toBe(2); // capped, not maxRetries(5)
+  });
+
+  it('retryableFetch: caps a long server Retry-After so ingress is not held', async () => {
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation((fn: Function) => { fn(); return 0 as unknown as ReturnType<typeof setTimeout>; });
+    const backoffs: number[] = [];
+    let calls = 0;
+    const fetchFn = vi.fn().mockImplementation(() => {
+      calls++;
+      if (calls === 1) return Promise.resolve({ ok: false, status: 429, headers: new Headers({ 'retry-after': '300' }), text: () => Promise.resolve('{}') });
+      return Promise.resolve({ ok: true, status: 200, headers: new Headers(), text: () => Promise.resolve('{"ok":true}') });
+    });
+    await retryableFetch({ label: 'test', url: 'https://x', init: { method: 'POST' }, timeoutMs: 5000, fetchFn, config: SERVER_CAP, onRetry: (p) => backoffs.push(p.backoffSeconds) });
+    expect(backoffs[0]).toBe(30); // Retry-After 300 capped to rateLimitMaxSleepS
+  });
+
+  it('retryableFetch: fast-fails an exhausted key pool', async () => {
+    let calls = 0;
+    const fetchFn = vi.fn().mockImplementation(() => { calls++; return Promise.resolve({
+      ok: false, status: 429, headers: new Headers(),
+      text: () => Promise.resolve('{"error":{"message":"api_key_exhausted: all keys rate limited"}}'),
+    }); });
+    await expect(retryableFetch({ label: 'test', url: 'https://x', init: { method: 'POST' }, timeoutMs: 5000, fetchFn, config: SERVER_CAP }))
+      .rejects.toThrow(/exhausted/);
+    expect(calls).toBe(1);
   });
 });

--- a/lib/ai-client/retry.ts
+++ b/lib/ai-client/retry.ts
@@ -100,6 +100,15 @@ export interface RetryConfig {
   strategy: 'fixed' | 'exponential';
   fixedDelays?: number[];
   maxBackoffS?: number;
+  /** Separate, LOW cap on RATE-LIMIT (429) attempts (t/3232). On the ingress-bound SERVER path a
+   *  rate-limited generate must surface a retryable 429 FAST (routes/ai.ts maps it) rather than sleep
+   *  through ~480s of 120s-floor retries and blow the ACA ingress timeout into an opaque 500. Unset →
+   *  falls back to `maxRetries` (CLI keeps its full "wait for quota" budget, unchanged). */
+  rateLimitMaxAttempts?: number;
+  /** Cap (seconds) on each rate-limit sleep AND on a respected server `Retry-After` (t/3232). Unset →
+   *  the `RATE_LIMIT_MIN_DELAY_S` floor. The SERVER sets this low so neither the floor nor a long
+   *  provider Retry-After can hold ingress — the 429 surfaces and is converted to a fast 429. */
+  rateLimitMaxSleepS?: number;
 }
 
 export const CLI_RETRY_CONFIG: RetryConfig = {
@@ -112,6 +121,11 @@ export const SERVER_RETRY_CONFIG: RetryConfig = {
   maxRetries: 5,
   strategy: 'exponential',
   maxBackoffS: 30,
+  // t/3232: the server path is ACA-ingress-bound. Cap rate-limit retries so a 429 surfaces as a
+  // retryable 429 in ≤~30s (routes/ai.ts → fast 429 + Retry-After), not ~480s of 120s-floor sleeps
+  // that exceed the ingress timeout → opaque 500. Transient (network) retries keep maxRetries=5.
+  rateLimitMaxAttempts: 2,
+  rateLimitMaxSleepS: 30,
 };
 
 // Server-side rate limiting (429, not user quota) typically clears within 1-2 minutes.
@@ -130,6 +144,7 @@ export async function withRetry<T>(
   // taxonomy-editor/src/renderer/utils/retryClassifier.ts — intentionally NOT shared (different
   // layer, different budget). If you change the transient-retry set here, check whether that
   // classifier wants the same, and vice versa.
+  let rateLimitAttempts = 0; // t/3232: rate-limit attempts are budgeted separately from transient retries
   for (let attempt = 1; attempt <= config.maxRetries; attempt++) {
     if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
     try {
@@ -153,10 +168,24 @@ export async function withRetry<T>(
       if (!isRetryable || attempt === config.maxRetries) throw err;
       if (lower.includes('per day') || lower.includes('rpd') || lower.includes('daily')) throw err;
       const isRateLimit = msg.includes('429') || /rate[_ -]?limit/.test(lower);
+      // t/3232: an EXHAUSTED key pool won't clear by sleeping — surface the 429 immediately.
+      if (isRateLimit && (lower.includes('api_key_exhausted') || lower.includes('all keys') || lower.includes('key pool exhausted'))) throw err;
+      // t/3232: rate-limit attempts are capped SEPARATELY (low, on the server) so a 429 surfaces fast
+      // instead of sleeping past the ingress timeout. CLI leaves rateLimitMaxAttempts unset → full budget.
+      if (isRateLimit) {
+        rateLimitAttempts++;
+        if (config.rateLimitMaxAttempts != null && rateLimitAttempts >= config.rateLimitMaxAttempts) throw err;
+      }
       const baseDelay = config.strategy === 'fixed'
         ? (config.fixedDelays?.[attempt - 1] ?? 45)
         : Math.min(2 ** attempt, config.maxBackoffS ?? 30);
-      const delay = isRateLimit ? Math.max(baseDelay, RATE_LIMIT_MIN_DELAY_S) : baseDelay;
+      // t/3232: rate-limit sleep is capped at rateLimitMaxSleepS on the server (ingress-safe); unset
+      // (CLI) keeps the RATE_LIMIT_MIN_DELAY_S "wait for quota" floor.
+      const delay = isRateLimit
+        ? (config.rateLimitMaxSleepS != null
+            ? Math.min(baseDelay, config.rateLimitMaxSleepS)
+            : Math.max(baseDelay, RATE_LIMIT_MIN_DELAY_S))
+        : baseDelay;
       const errSummary = err instanceof ActionableError ? err.problem : msg.slice(0, 300);
       onLog?.(`[retry] ${label} attempt ${attempt}/${config.maxRetries} failed (${errSummary}), waiting ${delay}s...`);
       await abortableSleep(delay * 1000, signal);
@@ -181,6 +210,7 @@ export async function retryableFetch(opts: {
   signal?: AbortSignal;
 }): Promise<{ response: Response; bodyText: string }> {
   const config = opts.config ?? SERVER_RETRY_CONFIG;
+  let rateLimitAttempts = 0; // t/3232: rate-limit (429/503) attempts budgeted separately from network retries
   for (let attempt = 1; attempt <= config.maxRetries; attempt++) {
     if (opts.signal?.aborted) throw new DOMException('Aborted', 'AbortError');
     let response: Response;
@@ -223,18 +253,35 @@ export async function retryableFetch(opts: {
           ],
         });
       }
-      if (attempt === config.maxRetries) {
+      // t/3232: an EXHAUSTED key pool won't clear by sleeping — surface the 429 immediately.
+      const rlLower = `${retryBody} ${limitMessage}`.toLowerCase();
+      if (response.status === 429 && (rlLower.includes('api_key_exhausted') || rlLower.includes('all keys') || rlLower.includes('key pool exhausted'))) {
         throw new ActionableError({
           goal: `Generate text via ${opts.label}`,
-          problem: `${response.status === 429 ? 'Rate limited' : 'Service unavailable'} after ${config.maxRetries} attempts. ${limitMessage}`,
+          problem: `Rate limited (HTTP 429) — the API key pool is exhausted. ${limitMessage}`,
+          location: `ai-client.retryableFetch(${opts.label})`,
+          nextSteps: ['Retry shortly — the rate limit clears within ~1-2 minutes', 'Switch to a different AI provider (Settings → AI Model)'],
+        });
+      }
+      // t/3232: cap rate-limit attempts on the server so a 429 surfaces FAST (≪ ingress timeout)
+      // rather than ~480s of 120s-floor sleeps. CLI leaves rateLimitMaxAttempts unset → full budget.
+      rateLimitAttempts++;
+      const rateLimitCapHit = config.rateLimitMaxAttempts != null && rateLimitAttempts >= config.rateLimitMaxAttempts;
+      if (attempt === config.maxRetries || rateLimitCapHit) {
+        throw new ActionableError({
+          goal: `Generate text via ${opts.label}`,
+          problem: `${response.status === 429 ? 'Rate limited' : 'Service unavailable'} after ${rateLimitAttempts} rate-limit attempt(s). ${limitMessage}`,
           location: `ai-client.retryableFetch(${opts.label})`,
           nextSteps: ['Wait a minute and retry', 'Switch to a different AI provider (Settings → AI Model)', 'Check the API provider status page'],
         });
       }
       const exponentialBackoff = Math.min(2 ** attempt, config.maxBackoffS ?? 30);
-      const backoff = rateLimitHeaders.retryAfterSeconds != null
-        ? rateLimitHeaders.retryAfterSeconds  // respect server's guidance unconditionally
+      let backoff = rateLimitHeaders.retryAfterSeconds != null
+        ? rateLimitHeaders.retryAfterSeconds  // respect server's guidance...
         : Math.max(exponentialBackoff, RATE_LIMIT_MIN_DELAY_S);
+      // t/3232: ...but CAP it (incl. a long provider Retry-After) on the server so a rate-limit can't
+      // hold ingress past the timeout. Unset (CLI) leaves the guidance/floor intact.
+      if (config.rateLimitMaxSleepS != null) backoff = Math.min(backoff, config.rateLimitMaxSleepS);
       opts.onRetry?.({ attempt, maxRetries: config.maxRetries, backoffSeconds: backoff, limitType, limitMessage, rateLimitHeaders });
       await abortableSleep(backoff * 1000, opts.signal);
       continue;


### PR DESCRIPTION
**Prod incident t/3230, issue #2** (my scope: `lib/ai-client/retry.ts`). A rate-limited server generate slept ~485s (120s floor × ~4 retries in `withRetry` + `retryableFetch`) before throwing 429 → exceeded the ACA ingress timeout → opaque empty-body 500. `routes/ai.ts:293` already maps a bubbled 429 → fast retryable 429, but the sleeps ran first.

## Config-driven fix (CLI unchanged)
- `RetryConfig` gains `rateLimitMaxAttempts` + `rateLimitMaxSleepS`.
- `SERVER_RETRY_CONFIG`: **2** rate-limit attempts / **30s** sleep cap → a 429 surfaces in **≤~30s** ≪ ingress timeout.
- Both `withRetry` + `retryableFetch`: rate-limit attempts budgeted separately from transient retries; each rate-limit sleep AND a respected server `Retry-After` are capped (a long provider Retry-After can no longer hold ingress).
- Fast-fail on `api_key_exhausted` (a drained pool won't clear by sleeping — the incident's actual trigger).
- Transient (network) retries unchanged (`maxRetries=5`). CLI keeps its 120s "wait for quota" floor.

## Verify
retry.test.ts **46/46** (6 new: attempt-cap, Retry-After cap, exhaustion fast-fail, CLI-unchanged) · eslint 0 · server tsc 0. Design + numbers on t/3232#1.

@ServerAPI (diagnosed this) — review the caps (2 / 30s)? Pairs with your t/3230 anon-debate gating. @Main (TL) fyi. Closes t/3232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
