### PR TITLE
fix(server): serialize-once cache for synthetic-embeddings — kills the 3s main-thread block (t/3165)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/syntheticEmbeddingsCache.test.ts
+++ b/taxonomy-editor/src/server/__tests__/syntheticEmbeddingsCache.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment node
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3165 — the synthetic-embeddings serialize-once cache + the httpKit chunk-yield serializer.
+// Root cause: /api/taxonomy/synthetic-embeddings rebuilt (network .npy read + parse + build) AND
+// re-`JSON.stringify`'d the STATIC ~4144-vector / ~400MB corpus on every debate-triggered GET — an
+// un-yielded ~3s main-thread block + ~400MB GC churn. Fix: serialize once, cache the Buffer, serve it
+// near-free; promise-dedupe so a cold-start burst launches ONE build; chunk-yield the cold serialize.
+//
+// These lock: (1) jsonStringifyChunked is byte-identical to JSON.stringify (arrays/objects/null/edge
+// cases) so the response contract is unchanged; (2) the cache serves from memory (loader NOT re-called),
+// dedupes concurrent cold callers to one build, and the invalidator forces a rebuild.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { loadSynth } = vi.hoisted(() => ({ loadSynth: vi.fn() }));
+vi.mock('../storage/fileIO.js', () => ({ loadSyntheticEmbeddings: loadSynth }));
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({ getGlobalRecorder: () => ({ record: vi.fn() }) }));
+
+import { jsonStringifyChunked } from '../httpKit.js';
+import { __getSyntheticEmbeddingsBufferForTest as getBuffer, __invalidateSyntheticEmbeddingsCache as invalidate } from '../routes/taxonomy.js';
+
+describe('jsonStringifyChunked — byte-identical to JSON.stringify (t/3165)', () => {
+  // yieldEvery=2 forces the yield path even on tiny inputs.
+  const cases: Array<[string, unknown]> = [
+    ['number[][] array', [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]]],
+    ['synthetic-embeddings-shaped map', { n1: { pov: 'acc', vectors: [[0.1, 0.2]] }, n2: { pov: 'saf', vectors: [[0.3, 0.4]] } }],
+    ['null', null],
+    ['empty array', []],
+    ['empty object', {}],
+    ['object with undefined-valued key (omitted)', { a: 1, b: undefined, c: 3 }],
+    ['array with undefined slot (→ null)', [1, undefined, 3]],
+    ['nested + strings + numbers', { k: 'v"quote', arr: [1, [2, 3], { deep: true }], n: -0.5 }],
+    ['string primitive', 'hello'],
+    ['number primitive', 42],
+  ];
+  for (const [name, value] of cases) {
+    it(name, async () => {
+      const buf = await jsonStringifyChunked(value, 2);
+      expect(buf.toString('utf-8')).toBe(JSON.stringify(value) ?? 'null');
+    });
+  }
+
+  it('round-trips a larger map identically', async () => {
+    const big: Record<string, { pov: string; vectors: number[][] }> = {};
+    for (let i = 0; i < 500; i++) big[`node-${i}`] = { pov: i % 2 ? 'acc' : 'saf', vectors: [[i, i + 0.5, i + 0.25]] };
+    const buf = await jsonStringifyChunked(big, 64);
+    expect(buf.toString('utf-8')).toBe(JSON.stringify(big));
+    expect(JSON.parse(buf.toString('utf-8'))).toEqual(big);
+  });
+});
+
+describe('synthetic-embeddings serialize-once cache (t/3165)', () => {
+  const sample = { n1: { pov: 'acc', vectors: [[0.1, 0.2]] } };
+
+  beforeEach(() => {
+    invalidate();
+    loadSynth.mockReset();
+  });
+
+  it('serves from cache on the 2nd call — loader runs ONCE', async () => {
+    loadSynth.mockResolvedValue(sample);
+    const b1 = await getBuffer();
+    const b2 = await getBuffer();
+    expect(loadSynth).toHaveBeenCalledTimes(1); // cache hit, no rebuild
+    expect(b1).toBe(b2); // same cached Buffer instance
+    expect(JSON.parse(b1.toString('utf-8'))).toEqual(sample);
+  });
+
+  it('promise-dedupe: a concurrent cold burst launches ONE build', async () => {
+    let resolveLoad!: (v: unknown) => void;
+    loadSynth.mockReturnValue(new Promise((r) => { resolveLoad = r; }));
+    const p1 = getBuffer();
+    const p2 = getBuffer();
+    const p3 = getBuffer();
+    resolveLoad(sample);
+    const [b1, b2, b3] = await Promise.all([p1, p2, p3]);
+    expect(loadSynth).toHaveBeenCalledTimes(1); // single-flight — not 3 builds
+    expect(b1).toBe(b2);
+    expect(b2).toBe(b3);
+  });
+
+  it('invalidator forces a rebuild on the next call', async () => {
+    loadSynth.mockResolvedValue(sample);
+    await getBuffer();
+    invalidate();
+    await getBuffer();
+    expect(loadSynth).toHaveBeenCalledTimes(2); // rebuilt after invalidation
+  });
+
+  it('a failed cold build is not cached — the next call retries', async () => {
+    loadSynth.mockRejectedValueOnce(new Error('npy read failed')).mockResolvedValue(sample);
+    await expect(getBuffer()).rejects.toThrow('npy read failed');
+    const b = await getBuffer(); // retries, succeeds
+    expect(loadSynth).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(b.toString('utf-8'))).toEqual(sample);
+  });
+
+  it('null corpus (no synth files) serializes to `null` and is served', async () => {
+    loadSynth.mockResolvedValue(null);
+    const b = await getBuffer();
+    expect(b.toString('utf-8')).toBe('null');
+  });
+});

--- a/taxonomy-editor/src/server/httpKit.ts
+++ b/taxonomy-editor/src/server/httpKit.ts
@@ -26,6 +26,48 @@ export function json(res: ServerResponse, data: unknown, status = 200): void {
   res.end(JSON.stringify(data));
 }
 
+/** t/3165: serialize a large array or plain object to a JSON Buffer WITHOUT a single un-yielded
+ *  JSON.stringify. A ~4144-entry synthetic-embeddings map (or a big number[][]) stringified at once
+ *  blocked the prod event loop ~3s. This builds the JSON incrementally, yielding to the loop every
+ *  `yieldEvery` top-level items. Output is byte-identical to JSON.stringify for arrays / plain objects
+ *  of JSON-safe values (same key order, no whitespace, undefined/function-valued keys omitted, array
+ *  holes → null). Non-array/non-object values fall back to a direct stringify. */
+export async function jsonStringifyChunked(value: unknown, yieldEvery = 256): Promise<Buffer> {
+  const yieldToLoop = (): Promise<void> => new Promise<void>((r) => setImmediate(r));
+  if (Array.isArray(value)) {
+    if (value.length === 0) return Buffer.from('[]');
+    const parts: string[] = new Array(value.length);
+    for (let i = 0; i < value.length; i++) {
+      parts[i] = JSON.stringify(value[i]) ?? 'null'; // array slot of undefined/function → null
+      if ((i + 1) % yieldEvery === 0) await yieldToLoop();
+    }
+    return Buffer.from('[' + parts.join(',') + ']');
+  }
+  if (value !== null && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>);
+    const parts: string[] = [];
+    for (let i = 0; i < entries.length; i++) {
+      const sv = JSON.stringify(entries[i][1]);
+      if (sv === undefined) continue; // undefined/function/symbol values are omitted, like JSON.stringify
+      parts.push(JSON.stringify(entries[i][0]) + ':' + sv);
+      if ((i + 1) % yieldEvery === 0) await yieldToLoop();
+    }
+    return Buffer.from('{' + parts.join(',') + '}');
+  }
+  return Buffer.from(JSON.stringify(value) ?? 'null');
+}
+
+/** t/3165: send a pre-serialized JSON Buffer. Mirrors json()'s idempotent-write guard; use with a
+ *  cached Buffer (e.g. the serialize-once synthetic-embeddings cache) to skip re-stringifying. */
+export function sendJsonBuffer(res: ServerResponse, buffer: Buffer, status = 200): void {
+  if (res.writableEnded || res.headersSent) {
+    log.server.warn({ component: 'httpKit', status }, 'sendJsonBuffer(): response already sent — skipping duplicate write');
+    return;
+  }
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(buffer);
+}
+
 // t/1379: record 4xx client errors to the flight recorder (warn — expected
 // client errors, not server faults) so a client-side 4xx can be correlated with
 // server state by requestId. Server-side dump only; never leaked to the client.

--- a/taxonomy-editor/src/server/routes/taxonomy.ts
+++ b/taxonomy-editor/src/server/routes/taxonomy.ts
@@ -11,13 +11,66 @@
 
 import type { Router } from '../httpKit.js';
 import type { ServerCtx } from './context.js';
-import { json, error, param } from '../httpKit.js';
+import { json, error, param, jsonStringifyChunked, sendJsonBuffer } from '../httpKit.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 import * as fileIO from '../storage/fileIO.js';
 import { stampNodeAuthorship, diffNodes } from '../storage/editMeta.js';
 import { isAnonymousUser } from '../security/userContext.js';
 import { getFlag } from '../featureFlags.js';
 import { enqueueGroundingReconcile } from '../groundingReconcileHook.js';
+import { log } from '../logger.js';
+
+// ── t/3165: serialize-once cache for /api/taxonomy/synthetic-embeddings ───────────────────────────
+// The synthetic corpus (~4144 vectors, ~400MB) is STATIC, but loadSyntheticEmbeddings() rebuilds it on
+// EVERY call (per-POV .npy network read + parseNpy + build) and the route re-JSON.stringify'd it — an
+// un-yielded ~3s main-thread block + ~400MB GC churn, once PER DEBATE (taxonomyContext fetches the full
+// corpus). Cache the SERIALIZED Buffer: the cold path builds+serializes once (chunk-yielded so even that
+// doesn't block), every later GET serves the Buffer near-free. Promise-dedupe (cache the in-flight
+// promise) so a cold-start BURST launches ONE build, not N (= DevOps's single-flight guard, subsumed).
+//
+// CACHE-INVALIDATION CONTRACT (Gate Co-Location): this process-lifetime cache is correct ONLY while the
+// synthetic corpus is WRITE-FROZEN. No server route mutates it today (the client updateSyntheticEmbeddings
+// POST is not wired server-side). IF a synth-mutation route is ever added it MUST call
+// __invalidateSyntheticEmbeddingsCache() after the write, or GETs will serve a stale corpus.
+let _synthEmbeddingsBuffer: Buffer | null = null;
+let _synthEmbeddingsInFlight: Promise<Buffer> | null = null;
+
+async function getSyntheticEmbeddingsBuffer(): Promise<Buffer> {
+  if (_synthEmbeddingsBuffer) return _synthEmbeddingsBuffer;
+  if (_synthEmbeddingsInFlight) return _synthEmbeddingsInFlight; // promise-dedupe: one cold build for a burst
+  _synthEmbeddingsInFlight = (async () => {
+    const t0 = Date.now();
+    const heapBefore = process.memoryUsage().heapUsed;
+    const data = await fileIO.loadSyntheticEmbeddings();
+    const loadMs = Date.now() - t0;
+    const t1 = Date.now();
+    const buffer = await jsonStringifyChunked(data); // yields the loop during the cold serialize
+    const serializeMs = Date.now() - t1;
+    _synthEmbeddingsBuffer = buffer;
+    // t/3165 phase-timing (cold path only) → the next real synth GET proves load_ms vs serialize_ms +
+    // heap; on a warm hit this line never runs (serve is near-zero) = the fix's self-proof.
+    log.api.info({
+      component: 'synthetic-embeddings', load_ms: loadMs, serialize_ms: serializeMs, bytes: buffer.length,
+      node_count: data ? Object.keys(data).length : 0,
+      heap_before: heapBefore, heap_after: process.memoryUsage().heapUsed,
+    }, 'synthetic-embeddings built + serialized + cached (cold path)');
+    return buffer;
+  })();
+  try {
+    return await _synthEmbeddingsInFlight;
+  } finally {
+    // Clear the in-flight handle: on success _synthEmbeddingsBuffer now holds the result; on failure the
+    // handle is dropped so the next request retries the build rather than re-throwing a stale rejection.
+    _synthEmbeddingsInFlight = null;
+  }
+}
+
+/** t/3165: drop the cached serialized synthetic-embeddings. MUST be called by any future
+ *  synth-mutation route after it writes (see the write-frozen contract above). Exported for that + tests. */
+export function __invalidateSyntheticEmbeddingsCache(): void { _synthEmbeddingsBuffer = null; }
+
+/** @internal t/3165 test hook — exercise the cache/dedupe path without the full Router harness. */
+export const __getSyntheticEmbeddingsBufferForTest = getSyntheticEmbeddingsBuffer;
 
 export function registerTaxonomyRoutes(r: Router, ctx: ServerCtx): void {
   const { get, put } = r;
@@ -27,8 +80,11 @@ export function registerTaxonomyRoutes(r: Router, ctx: ServerCtx): void {
 
   get('/api/taxonomy/synthetic-embeddings', async (_req, res) => {
     try {
-      const data = await fileIO.loadSyntheticEmbeddings();
-      json(res, data);
+      // t/3165: serve the serialize-once cached Buffer (near-free on a hit). The cold path builds +
+      // chunk-yield-serializes once, promise-deduped for concurrent cold callers. See the cache-
+      // invalidation (write-frozen) contract at the cache site above.
+      const buffer = await getSyntheticEmbeddingsBuffer();
+      sendJsonBuffer(res, buffer);
     } catch (err) {
       getGlobalRecorder()?.record({
         type: 'system.error',


### PR DESCRIPTION
## t/3165 — the incident fix → **Main (TL) GV** (design LOCKED e/136#37)

**Root cause (converged):** the offload works (worker off-main, `printenv=1`, cache resolves). The prod 3018ms event-loop block was **not** the debate `/compute` serialize (all batches ≤512 ≈ 350ms) — it mapped 1:1 to **`/api/taxonomy/synthetic-embeddings`**: a STATIC ~4144-vector / ~400MB corpus that `loadSyntheticEmbeddings()` **rebuilds every call** (per-POV `.npy` network read + `parseNpy` + build) and the route re-`JSON.stringify`'d un-yielded on main — **once per debate** (`taxonomyContext` fetches the full corpus). ~400MB heap spike + ~3s block.

### Fix (route-level, my scope)
- **Serialize once → cache the Buffer**; serve near-free on every later GET (skips load/parse/build/serialize). **Promise-dedupe** (cache the in-flight promise) so a cold-start burst launches ONE build (= DevOps's single-flight, subsumed — no separate guard).
- **`httpKit.jsonStringifyChunked`** — byte-identical to `JSON.stringify`, yields the loop every N top-level items → even the COLD serialize can't block past the liveness deadline.
- **Cold-path phase-timing** (`load_ms` / `serialize_ms` / heap before+after) → the redeploy self-proves: next real synth GET shows `serialize_ms`→~0 (cache hit) + heap flat + no block.
- **`__invalidateSyntheticEmbeddingsCache()`** exported + a co-located **write-frozen contract** comment (process-lifetime cache is safe only while the corpus doesn't mutate; no server synth-mutation route exists today — if one is added it MUST invalidate).

Response body **byte-identical** → zero client change. **Anon auth-gate NOT included** (TL call: t/3230 already blocks the debate trigger for anon; anon-access + the payload-subset redesign ride TL's fast-follow).

### ⚠ Deviation (flagged for GV)
Fix set listed a `/compute` cap + chunk-yield as belt-and-suspenders. **Deferred** — Diagnostics disproved `/compute` as the culprit (all ≤512 ≈ 350ms), so a never-firing cap + a yield on a non-culprit path would add blast radius (2 more files) to an incident PR for zero incident value; the `jsonStringifyChunked` helper is in place for a trivial follow-up. Say the word in GV and I'll add it.

### Verify
`tsc -p tsconfig.server.json` clean; eslint 0; **`syntheticEmbeddingsCache.test.ts` 16/16** (byte-identity across array/object/null/edge cases + cache/dedupe/invalidate/retry-on-failure); routeTable 4/4 (registration unchanged).

### Close criteria (post one-bundle redeploy)
On a REAL synth GET: `serialize_ms`→~0 (cache hit) + heap bounded + no event-loop block; Diagnostics co-verifies calm loop. Prevention (loop-sampler covers the serialize phase, tie t/3210) filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)