### PR TITLE
ci(embeddings): wire real-ONNX bit-exact equivalence check into CI (t/3198)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
       debate: ${{ steps.filter.outputs.debate }}
       schema: ${{ steps.filter.outputs.schema }}
       lib: ${{ steps.filter.outputs.lib }}
+      embeddings: ${{ steps.filter.outputs.embeddings }}
       python: ${{ steps.filter.outputs.python }}
       container: ${{ steps.filter.outputs.container }}
       lockfile-sync: ${{ steps.filter.outputs.lockfile-sync }}
@@ -115,6 +116,14 @@ jobs:
               - '.github/workflows/ci.yml'
             lib:
               - 'lib/**'
+              - '.github/workflows/ci.yml'
+            # 'embeddings' gates embedding-onnx-equivalence (t/3198): the real-ONNX bit-exact
+            # worker↔in-thread check. Narrower than 'lib' — only the embeddings subtree (worker,
+            # in-thread module, harness) or a ci.yml edit can change the equivalence outcome, so
+            # a broad lib change need not pay the build:server + model-download cost. Advisory job
+            # (not in ci-gate needs), so a too-narrow filter cannot false-green a required context.
+            embeddings:
+              - 'lib/embeddings/**'
               - '.github/workflows/ci.yml'
             python:
               - 'scripts/**'
@@ -1267,6 +1276,88 @@ jobs:
           # ALLOWED_ORIGINS='' to catch the getCorsOrigin() empty-array → undefined regression.
           ALLOWED_ORIGINS: ''
         run: pnpm exec vitest run src/server/
+
+  # ── embedding-onnx-equivalence: real-ONNX bit-exact worker↔in-thread equivalence (t/3198) ──
+  # Runs the t/3181 condition-3 check in CI, closing the t/3189 "only-runs-on-one-box" gap: the
+  # off-thread worker (intra-op=1) must produce BIT-EXACT vectors vs the in-thread default path on
+  # the SAME execution provider. `offThreadEmbedding.test.ts`'s equivalence case is skip-guarded and
+  # cannot spawn the real worker under vitest (defaultWorkerFactory loads ./embeddingWorker.js next to
+  # the SOURCE, where no compiled sibling exists, and vitest doesn't transform code inside a spawned
+  # node worker_thread). So this job runs the harness against the BUILT server dist — build:server
+  # emits the runnable worker + in-thread module to dist/server/lib/embeddings/, the exact artifacts
+  # prod ships — with the fp32 model provisioned exactly as taxonomy-editor/Dockerfile's onnx-model
+  # stage does (same 3 HF files, cached).
+  #
+  # ADVISORY — deliberately NOT in ci-gate `needs`. A first-of-its-kind bit-exact float assertion
+  # stays non-blocking per the "no flaky blocking gates" rule until it proves stable across green
+  # cycles; a red here still surfaces as a failed check on the PR. Promotion to a required gate is a
+  # follow-up for TL Gate Verification. Path-filtered to lib/embeddings changes; skip = N/A.
+  embedding-onnx-equivalence:
+    needs: [changes]
+    if: >-
+      always() && !cancelled() &&
+      (github.event_name != 'pull_request' || needs.changes.outputs.embeddings == 'true')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86  # v6.0.10
+        with:
+          version: '11.20.0'
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
+
+      - name: Install dependencies (retry on transient failures)
+        run: |
+          for i in 1 2 3; do
+            pnpm install --frozen-lockfile && break
+            if [ "$i" -lt 3 ]; then
+              echo "pnpm install attempt $i failed; retry in $((i * 15))s"
+              sleep $((i * 15))
+            else
+              echo "::error::pnpm install failed after $i attempts"
+              exit 1
+            fi
+          done
+
+      - name: Build server (emits the runnable off-thread worker + in-thread module to dist)
+        working-directory: taxonomy-editor
+        run: pnpm run build:server
+
+      # Cache the flat fp32 model set (model.onnx + tokenizer.json + tokenizer_config.json). Keyed on
+      # the model contract (Xenova/all-MiniLM-L6-v2 fp32, t/1651). Bump the -v1 suffix if the contract
+      # changes. A cache hit skips the HF download → near-zero marginal cost (the t/3198 intent).
+      - name: Cache fp32 ONNX model
+        id: onnx-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: .cache/onnx-models/all-MiniLM-L6-v2
+          key: onnx-model-all-MiniLM-L6-v2-fp32-v1
+
+      - name: Provision fp32 model from Hugging Face (cache miss only)
+        if: steps.onnx-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          DIR=.cache/onnx-models/all-MiniLM-L6-v2
+          mkdir -p "$DIR"
+          BASE=https://huggingface.co/Xenova/all-MiniLM-L6-v2/resolve/main
+          curl -fsSL "$BASE/onnx/model.onnx"       -o "$DIR/model.onnx"
+          curl -fsSL "$BASE/tokenizer.json"        -o "$DIR/tokenizer.json"
+          curl -fsSL "$BASE/tokenizer_config.json" -o "$DIR/tokenizer_config.json"
+          ls -l "$DIR"
+
+      - name: Real-ONNX bit-exact equivalence (off-thread intra-op=1 vs in-thread default, CPU EP)
+        env:
+          AI_TRIAD_ONNX_MODEL_DIR: ${{ github.workspace }}/.cache/onnx-models/all-MiniLM-L6-v2
+          # Pin the CPU EP — the EP CI and prod (ACA, no GPU) run, and the only one where the
+          # bit-exact contract holds (a GPU EP is non-deterministic across sessions). The harness
+          # also self-defaults this; set here for visibility.
+          AI_TRIAD_ONNX_FORCE_CPU: '1'
+        run: node lib/embeddings/onnx-equivalence-check.mjs
 
   # ── workflow-lint: enforce SHA-pinned actions, env-var indirection, permissions ──
   # Mechanically catches the M14/M15/L8 failure classes (t/2529). Always runs —

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1345,9 +1345,13 @@ jobs:
           DIR=.cache/onnx-models/all-MiniLM-L6-v2
           mkdir -p "$DIR"
           BASE=https://huggingface.co/Xenova/all-MiniLM-L6-v2/resolve/main
-          curl -fsSL "$BASE/onnx/model.onnx"       -o "$DIR/model.onnx"
-          curl -fsSL "$BASE/tokenizer.json"        -o "$DIR/tokenizer.json"
-          curl -fsSL "$BASE/tokenizer_config.json" -o "$DIR/tokenizer_config.json"
+          # Retry the HF fetch — it 429s / times out intermittently on cache-miss, and a bare
+          # curl fails the job (DevOps review, p/27#41). curl's native retry backs off on all
+          # errors (incl. 429) + connection refusals; --fail keeps a non-200 an error.
+          fetch() { curl --retry 5 --retry-delay 5 --retry-connrefused --retry-all-errors -fSL "$1" -o "$2"; }
+          fetch "$BASE/onnx/model.onnx"       "$DIR/model.onnx"
+          fetch "$BASE/tokenizer.json"        "$DIR/tokenizer.json"
+          fetch "$BASE/tokenizer_config.json" "$DIR/tokenizer_config.json"
           ls -l "$DIR"
 
       - name: Real-ONNX bit-exact equivalence (off-thread intra-op=1 vs in-thread default, CPU EP)

--- a/lib/embeddings/offThreadEmbedding.test.ts
+++ b/lib/embeddings/offThreadEmbedding.test.ts
@@ -267,9 +267,13 @@ function realOnnxAvailable(): boolean {
 const REAL_ONNX = realOnnxAvailable();
 if (!REAL_ONNX) {
   // VISIBLE skip (TL condition, p/342#227): a green CI must never read as "equivalence verified" when
-  // it was actually skipped. Run locally with AI_TRIAD_ONNX_MODEL_DIR set + `lib` built; CI wiring is
-  // tracked as a follow-up (equivalence-in-CI whenever the ONNX-node model next lands in a CI job).
-  console.warn('[offThreadEmbedding.test] real-ONNX equivalence test SKIPPED — onnxruntime-node/model absent (condition-3 evidence is the reported local run; CI wiring tracked in follow-up)');
+  // it was actually skipped. This vitest case stays skip-guarded for LOCAL use (run with
+  // AI_TRIAD_ONNX_MODEL_DIR set + `lib` built). In CI the equivalence is exercised by the
+  // `embedding-onnx-equivalence` job (t/3198), which runs lib/embeddings/onnx-equivalence-check.mjs
+  // against the BUILT server dist with the fp32 model provisioned — vitest can't spawn the real worker
+  // here (no compiled embeddingWorker.js sibling in the source tree). Keep TEXTS/assertion in sync
+  // with that harness.
+  console.warn('[offThreadEmbedding.test] real-ONNX equivalence test SKIPPED — onnxruntime-node/model absent (local-only path; CI runs it via the embedding-onnx-equivalence job / onnx-equivalence-check.mjs, t/3198)');
 }
 
 describe('offThreadEmbedding — real-ONNX same-EP bit-exact equivalence (condition 3, skip-guarded)', () => {
@@ -282,7 +286,13 @@ describe('offThreadEmbedding — real-ONNX same-EP bit-exact equivalence (condit
     ]);
     expect(offThread).toHaveLength(inThread.length);
     for (let i = 0; i < inThread.length; i++) {
-      expect(Array.from(offThread[i])).toEqual(inThread[i]); // bit-exact — no tolerance (report if it diverges)
+      // Compare at the fp32 boundary: the worker marshals vectors OUT via a Float32Array transfer
+      // buffer (already fp32), while onnx.computeEmbeddings' l2Normalize returns number[] (fp64
+      // doubles). A raw fp32-vs-fp64 compare is off by ~fp32 epsilon BY CONSTRUCTION — a comparison
+      // artifact, not a divergence — so quantize the in-thread side to fp32 (the precision embeddings
+      // are stored/consumed at). Then the contract is genuinely BIT-EXACT (t/3198; CI runs this via
+      // lib/embeddings/onnx-equivalence-check.mjs in the embedding-onnx-equivalence job).
+      expect(Array.from(offThread[i])).toEqual(Array.from(new Float32Array(inThread[i]))); // fp32, bit-exact
     }
   });
 });

--- a/lib/embeddings/onnx-equivalence-check.mjs
+++ b/lib/embeddings/onnx-equivalence-check.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+//
+// t/3198 — CI harness for the real-ONNX same-EP bit-exact equivalence check (t/3181 condition 3).
+//
+// WHY a harness and not the vitest test: `offThreadEmbedding.test.ts`'s equivalence case is
+// SKIP-GUARDED and only runs where onnxruntime-node + the fp32 model.onnx are present. Under vitest
+// the real worker cannot spawn — `defaultWorkerFactory` does `new Worker(new URL('./embeddingWorker.js',
+// import.meta.url))` against the SOURCE tree, where no compiled `embeddingWorker.js` sibling exists,
+// and vitest does not transform code inside a spawned node worker_thread. So the equivalence is
+// exercised here against the BUILT server dist (`build:server` emits the runnable worker + all sibling
+// .js to taxonomy-editor/dist/server/lib/embeddings/ — the exact artifacts prod ships). This closes the
+// t/3189 "only-runs-on-one-box" gap: the check now runs in CI (the embedding-onnx-equivalence job)
+// whenever the ONNX-node model is provisioned, not just on a maintainer's local box.
+//
+// Contract: worker vectors (intra-op=1, off-thread) must be BIT-EXACT vs the in-thread default path on
+// the same execution provider, compared at the fp32 boundary (see the compare loop for why fp32 is
+// the correct precision). No tolerance at that boundary — any divergence is a real finding (report,
+// don't relax). The local t/3181 run reported maxAbsDiff=0 (bit-exact intraOp=1 vs default).
+//
+// Requires: AI_TRIAD_ONNX_MODEL_DIR pointing at a dir with model.onnx + tokenizer.json +
+// tokenizer_config.json, and onnxruntime-node installed. Run AFTER `build:server`.
+//
+// Exit 0 = bit-exact (or clean skip when the model is absent — printed VISIBLY, never silent).
+// Exit 1 = divergence or a setup/runtime failure.
+
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { pathToFileURL } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));            // <repo>/lib/embeddings
+const REPO_ROOT = resolve(HERE, '..', '..');                    // <repo>
+const DIST_EMB = join(REPO_ROOT, 'taxonomy-editor', 'dist', 'server', 'lib', 'embeddings');
+
+// Same texts as offThreadEmbedding.test.ts's equivalence case — keep them in sync so the harness and
+// the (locally-run) vitest test assert the identical contract.
+const TEXTS = ['AI policy alignment', 'open-source model release', 'compute governance regime'];
+
+function fail(msg) {
+  console.error(`[onnx-equivalence-check] FAIL — ${msg}`);
+  process.exit(1);
+}
+
+// ── Preconditions (fail LOUD, never silently green) ───────────────────────────
+const modelDir = process.env.AI_TRIAD_ONNX_MODEL_DIR?.trim();
+if (!modelDir) {
+  // A green run must never read as "equivalence verified" when it was actually a no-op. This harness
+  // is only invoked by the CI job that provisions the model, so an unset var here is a wiring bug.
+  fail('AI_TRIAD_ONNX_MODEL_DIR is not set — the CI job must provision the fp32 model before running this harness.');
+}
+if (!existsSync(join(modelDir, 'model.onnx'))) {
+  fail(`model.onnx not found under AI_TRIAD_ONNX_MODEL_DIR="${modelDir}" — provision the flat fp32 model set first.`);
+}
+const offThreadEntry = join(DIST_EMB, 'offThreadEmbedding.js');
+const onnxEntry = join(DIST_EMB, 'onnxEmbedding.js');
+if (!existsSync(offThreadEntry) || !existsSync(onnxEntry)) {
+  fail(`built dist modules missing under ${DIST_EMB} — run \`npm run build:server\` (in taxonomy-editor) before this harness.`);
+}
+if (!existsSync(join(DIST_EMB, 'embeddingWorker.js'))) {
+  fail(`embeddingWorker.js missing under ${DIST_EMB} — the worker entry did not emit (check tsconfig.server.json \`include\`).`);
+}
+
+// Pin the CPU EP for BOTH paths (before the dist modules init onnxruntime). The bit-exact contract
+// (t/3181 condition 3) holds on the CPU EP — the EP CI (ubuntu, no GPU) and prod (ACA, no GPU)
+// actually run. A GPU EP (dml/cuda) is non-deterministic across two sessions with different intra-op
+// thread counts (worker=1 vs in-thread default) — ~1e-8 kernel noise that is NOT a real divergence —
+// so on a GPU dev box the zero-tolerance check would spuriously fail. Forcing CPU makes the check
+// deterministic and portable. Honored by onnxEmbedding.ts (t/3198).
+process.env.AI_TRIAD_ONNX_FORCE_CPU ??= '1';
+
+console.log(`[onnx-equivalence-check] model dir: ${modelDir}`);
+console.log(`[onnx-equivalence-check] dist:      ${DIST_EMB}`);
+console.log(`[onnx-equivalence-check] texts:     ${TEXTS.length}`);
+console.log(`[onnx-equivalence-check] EP:        cpu (AI_TRIAD_ONNX_FORCE_CPU=${process.env.AI_TRIAD_ONNX_FORCE_CPU})`);
+
+// ── Run both paths on the same EP and compare bit-exact ───────────────────────
+const { computeEmbeddingsOffThread, shutdownEmbeddingWorker } = await import(pathToFileURL(offThreadEntry).href);
+const { computeEmbeddings } = await import(pathToFileURL(onnxEntry).href);
+
+let exitCode = 0;
+try {
+  const [offThread, inThread] = await Promise.all([
+    computeEmbeddingsOffThread(TEXTS, { requester: 'ci-equivalence-harness' }),
+    computeEmbeddings(TEXTS),
+  ]);
+
+  if (offThread.length !== inThread.length) {
+    fail(`vector count mismatch: off-thread=${offThread.length} vs in-thread=${inThread.length}`);
+  }
+
+  let maxAbsDiff = 0;
+  let firstDivergence = null;
+  for (let i = 0; i < inThread.length; i++) {
+    // Compare at the fp32 boundary — the precision embeddings are actually stored and consumed at
+    // (embeddings.json is fp32; the worker marshals vectors OUT via a Float32Array transfer buffer,
+    // so its output is already fp32). The in-thread path's l2Normalize returns number[] (fp64 JS
+    // doubles), so a raw fp32-vs-fp64 compare is off by ~fp32 epsilon (~1e-8) BY CONSTRUCTION — a
+    // comparison artifact, not a compute divergence. Quantizing the in-thread side to fp32 makes the
+    // contract genuinely BIT-EXACT (maxAbsDiff=0), which is what "equivalence" means for fp32
+    // embeddings (t/3198; corrects the latent fp32-vs-fp64 mismatch in offThreadEmbedding.test.ts).
+    const a = Array.from(offThread[i]);                     // worker: already fp32
+    const b = Array.from(new Float32Array(inThread[i]));    // in-thread fp64 → fp32 boundary
+    if (a.length !== b.length) {
+      fail(`dim mismatch at text ${i}: off-thread=${a.length} vs in-thread=${b.length}`);
+    }
+    for (let j = 0; j < a.length; j++) {
+      const d = Math.abs(a[j] - b[j]);
+      if (d > maxAbsDiff) maxAbsDiff = d;
+      if (d !== 0 && firstDivergence === null) firstDivergence = { text: i, dim: j, off: a[j], in: b[j] };
+    }
+  }
+
+  if (maxAbsDiff !== 0) {
+    console.error(`[onnx-equivalence-check] DIVERGENCE — maxAbsDiff=${maxAbsDiff}`);
+    console.error(`[onnx-equivalence-check] first at text ${firstDivergence.text} dim ${firstDivergence.dim}: off=${firstDivergence.off} in=${firstDivergence.in}`);
+    console.error('[onnx-equivalence-check] Contract is BIT-EXACT (no tolerance). Investigate EP/thread-config drift before relaxing (t/3181 condition 3).');
+    exitCode = 1;
+  } else {
+    console.log(`[onnx-equivalence-check] OK — bit-exact (maxAbsDiff=0) across ${inThread.length} vectors, off-thread intra-op=1 vs in-thread default on the same EP.`);
+  }
+} catch (err) {
+  console.error(`[onnx-equivalence-check] runtime error: ${err?.stack || err}`);
+  exitCode = 1;
+} finally {
+  // Release the persistent worker so the process can exit cleanly.
+  try { shutdownEmbeddingWorker(); } catch { /* best-effort */ }
+}
+
+process.exit(exitCode);

--- a/lib/embeddings/onnxEmbedding.ts
+++ b/lib/embeddings/onnxEmbedding.ts
@@ -404,7 +404,20 @@ async function init(): Promise<void> {
   const backendNames = backends.map(b => b.name);
   let executionProviders: string[];
 
-  if (_forcedCpuReason) {
+  // t/3198 — opt-in CPU pin. When AI_TRIAD_ONNX_FORCE_CPU is truthy, select the CPU EP regardless
+  // of available GPU backends. Default (env unset) is byte-identical to before. Two uses: (1) the
+  // real-ONNX equivalence check (onnx-equivalence-check.mjs) must run on the CPU EP — the EP CI and
+  // prod (ACA, no GPU) actually use, and the only one where the worker's intra-op=1 is bit-exact vs
+  // the in-thread default (a GPU EP is non-deterministic across sessions: ~1e-8 kernel noise, not a
+  // real divergence); (2) reproducing prod's CPU-only embedding behavior on a GPU dev box.
+  const forceCpuEnv = process.env.AI_TRIAD_ONNX_FORCE_CPU;
+  const forceCpu = !!forceCpuEnv && forceCpuEnv !== '0' && forceCpuEnv.toLowerCase() !== 'false';
+
+  if (forceCpu) {
+    executionProviders = ['cpu'];
+    _selectedEP = 'cpu';
+    console.warn(`[onnxEmbedding] CPU EP forced by AI_TRIAD_ONNX_FORCE_CPU=${forceCpuEnv} (skipping GPU backends: ${backendNames.filter(n => n !== 'cpu').join(', ') || 'none'})`);
+  } else if (_forcedCpuReason) {
     // t/2060 — a prior non-CPU EP OOM'd during inference; stay pinned to CPU for the
     // rest of the process so we don't re-OOM. Slower but correct.
     executionProviders = ['cpu'];


### PR DESCRIPTION
## What / Why (t/3198)

Closes the t/3189 "only-runs-on-one-box" gap for the t/3181 **condition-3** worker↔in-thread embedding equivalence. The `offThreadEmbedding.test.ts` real-ONNX case was skip-guarded (no CI job baked the ONNX-node model); this wires it into CI.

Adds an **ADVISORY** (non-required) `embedding-onnx-equivalence` job, path-filtered to `lib/embeddings/**`, that:
1. `build:server` → emits the runnable off-thread worker + in-thread module to `dist/server/lib/embeddings/` (vitest can't spawn the real worker; the built dist is the exact artifact prod ships).
2. Provisions the fp32 `all-MiniLM-L6-v2` model exactly as `taxonomy-editor/Dockerfile`'s `onnx-model` stage does (same 3 HF files, `actions/cache`d).
3. Runs `lib/embeddings/onnx-equivalence-check.mjs` asserting the off-thread worker (intra-op=1) is **bit-exact** vs the in-thread path.

## Two real issues the single-box finding hid (surfaced by running on a 2nd box)

- **EP nondeterminism.** A GPU EP (`dml`) diverges ~1e-8 across sessions. Pin the **CPU EP** (what CI + prod/ACA run) via a new opt-in `AI_TRIAD_ONNX_FORCE_CPU` env in `onnxEmbedding.ts` — default unset = **byte-identical** to before.
- **Precision-boundary bug in the existing test.** The worker marshals **fp32** (Float32Array transfer buffer); in-thread `l2Normalize` returns **fp64**. The original `toEqual(inThread)` compared fp32-vs-fp64 → off by ~fp32 epsilon **by construction** (would have spuriously failed if un-skipped). Now compared at the **fp32 boundary** (embeddings are stored/consumed as fp32) → genuinely **bit-exact (maxAbsDiff=0)**. Fixed in both the harness and the vitest test.

## Verification (local, built dist, CPU EP, real fp32 model)
- Harness: **maxAbsDiff=0** across 3 vectors ✅
- `offThreadEmbedding.test.ts`: **7 passed, 1 skipped** (skip path intact) ✅
- `workflow-lint`: 0 violations · lib `eslint`/`tsc` clean on changed files ✅

## Scope / review
- `.github/workflows/ci.yml` is **operations/devops** scope — @devops please review the job. @TL: the job is deliberately **not** in `ci-gate needs` per the "no flaky blocking gates" rule; promotion to a required gate is a **TL Gate Verification** follow-up once it has green cycles.

Closes t/3198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)