### PR TITLE
fix(server): synthetic-embeddings cache generation-guard + jsonStringifyChunked toJSON caveat (t/3237)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/syntheticEmbeddingsCache.test.ts
+++ b/taxonomy-editor/src/server/__tests__/syntheticEmbeddingsCache.test.ts
@@ -102,4 +102,26 @@ describe('synthetic-embeddings serialize-once cache (t/3165)', () => {
     const b = await getBuffer();
     expect(b.toString('utf-8')).toBe('null');
   });
+
+  it('generation-guard: invalidate() during an in-flight cold build does NOT cache the stale bytes (t/3237)', async () => {
+    let resolveLoad!: (v: unknown) => void;
+    const fresh = { n2: { pov: 'saf', vectors: [[9, 9]] } };
+    loadSynth.mockReturnValueOnce(new Promise((r) => { resolveLoad = r; })).mockResolvedValue(fresh);
+    const p = getBuffer();      // cold build in-flight
+    invalidate();               // invalidation lands MID-BUILD → bumps the generation
+    resolveLoad(sample);        // the in-flight build resolves with the now-stale sample
+    const stale = await p;
+    expect(JSON.parse(stale.toString('utf-8'))).toEqual(sample); // the awaiter still gets its requested bytes
+    const next = await getBuffer();                              // NOT cached → rebuilds
+    expect(loadSynth).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(next.toString('utf-8'))).toEqual(fresh);   // serves the fresh generation
+  });
+
+  it('jsonStringifyChunked does NOT honor a top-level toJSON (documented caveat, t/3237)', async () => {
+    const withTopLevelToJSON = { toJSON: () => 'custom', a: 1 } as unknown;
+    const buf = await jsonStringifyChunked(withTopLevelToJSON, 2);
+    // JSON.stringify honors toJSON → '"custom"'; the chunked serializer iterates entries directly.
+    expect(buf.toString('utf-8')).not.toBe(JSON.stringify(withTopLevelToJSON));
+    expect(JSON.parse(buf.toString('utf-8'))).toEqual({ a: 1 }); // function value omitted, a:1 kept
+  });
 });

--- a/taxonomy-editor/src/server/httpKit.ts
+++ b/taxonomy-editor/src/server/httpKit.ts
@@ -31,7 +31,10 @@ export function json(res: ServerResponse, data: unknown, status = 200): void {
  *  blocked the prod event loop ~3s. This builds the JSON incrementally, yielding to the loop every
  *  `yieldEvery` top-level items. Output is byte-identical to JSON.stringify for arrays / plain objects
  *  of JSON-safe values (same key order, no whitespace, undefined/function-valued keys omitted, array
- *  holes → null). Non-array/non-object values fall back to a direct stringify. */
+ *  holes → null). Non-array/non-object values fall back to a direct stringify.
+ *  CAVEAT (t/3237): assumes a PLAIN top-level array/object — a top-level `toJSON()` is NOT honored
+ *  (the top level is iterated by entries/elements directly). Nested `toJSON()` IS honored (handled by
+ *  the inner JSON.stringify of each value). Callers with a custom top-level toJSON should use json(). */
 export async function jsonStringifyChunked(value: unknown, yieldEvery = 256): Promise<Buffer> {
   const yieldToLoop = (): Promise<void> => new Promise<void>((r) => setImmediate(r));
   if (Array.isArray(value)) {

--- a/taxonomy-editor/src/server/routes/taxonomy.ts
+++ b/taxonomy-editor/src/server/routes/taxonomy.ts
@@ -32,12 +32,17 @@ import { log } from '../logger.js';
 // synthetic corpus is WRITE-FROZEN. No server route mutates it today (the client updateSyntheticEmbeddings
 // POST is not wired server-side). IF a synth-mutation route is ever added it MUST call
 // __invalidateSyntheticEmbeddingsCache() after the write, or GETs will serve a stale corpus.
+// A generation counter guards the invalidate-during-in-flight-build race (t/3237): an invalidation that
+// lands WHILE a cold build is running bumps _synthGen, so that build declines to publish its now-stale
+// bytes to the cache and the next GET rebuilds against the new generation.
 let _synthEmbeddingsBuffer: Buffer | null = null;
 let _synthEmbeddingsInFlight: Promise<Buffer> | null = null;
+let _synthGen = 0;
 
 async function getSyntheticEmbeddingsBuffer(): Promise<Buffer> {
   if (_synthEmbeddingsBuffer) return _synthEmbeddingsBuffer;
   if (_synthEmbeddingsInFlight) return _synthEmbeddingsInFlight; // promise-dedupe: one cold build for a burst
+  const gen = _synthGen; // the generation this build belongs to; a concurrent invalidate() bumps _synthGen
   _synthEmbeddingsInFlight = (async () => {
     const t0 = Date.now();
     const heapBefore = process.memoryUsage().heapUsed;
@@ -46,7 +51,10 @@ async function getSyntheticEmbeddingsBuffer(): Promise<Buffer> {
     const t1 = Date.now();
     const buffer = await jsonStringifyChunked(data); // yields the loop during the cold serialize
     const serializeMs = Date.now() - t1;
-    _synthEmbeddingsBuffer = buffer;
+    // Generation-guard (t/3237): publish to the cache ONLY if no invalidation landed mid-build. Else this
+    // build's bytes are stale — still hand them to the current awaiters (they requested pre-invalidation),
+    // but don't cache them, so the next GET rebuilds against the new generation.
+    if (gen === _synthGen) _synthEmbeddingsBuffer = buffer;
     // t/3165 phase-timing (cold path only) → the next real synth GET proves load_ms vs serialize_ms +
     // heap; on a warm hit this line never runs (serve is near-zero) = the fix's self-proof.
     log.api.info({
@@ -67,7 +75,7 @@ async function getSyntheticEmbeddingsBuffer(): Promise<Buffer> {
 
 /** t/3165: drop the cached serialized synthetic-embeddings. MUST be called by any future
  *  synth-mutation route after it writes (see the write-frozen contract above). Exported for that + tests. */
-export function __invalidateSyntheticEmbeddingsCache(): void { _synthEmbeddingsBuffer = null; }
+export function __invalidateSyntheticEmbeddingsCache(): void { _synthEmbeddingsBuffer = null; _synthGen++; }
 
 /** @internal t/3165 test hook — exercise the cache/dedupe path without the full Router harness. */
 export const __getSyntheticEmbeddingsBufferForTest = getSyntheticEmbeddingsBuffer;


### PR DESCRIPTION
## t/3237 — closes the two non-blocking GV notes from #1832 (t/3165)

Self-cert: **/trivial-change** (small robustness + doc, follows the pattern, no new API/schema; closes TL's GV notes p/522#170).

1. **Generation-guard (real latent bug):** `__invalidateSyntheticEmbeddingsCache()` called DURING an in-flight cold build would still publish the pre-invalidation (stale) bytes when that build resolved. Added a monotonic `_synthGen` counter — the build captures `gen` at start, `invalidate()` bumps it, and the build caches its result **only if `gen` is still current** (else it hands the bytes to the current awaiters but doesn't cache; the next GET rebuilds against the new generation). Hardens the write-frozen contract before any synth-mutation route is ever wired.
2. **Doc caveat:** `jsonStringifyChunked` assumes a plain top-level array/object — a **top-level `toJSON()` is NOT honored** (nested `toJSON` is, via the inner `JSON.stringify`). Added the caveat + a locking test.

Both were no-trigger-today (no synth-mutation route exists).

### Verify
`tsc -p tsconfig.server.json` clean; eslint 0; **`syntheticEmbeddingsCache.test.ts` 18/18** (+ generation-guard invalidate-during-build + top-level-toJSON-not-honored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)