### PR TITLE
obs(server): emit serialize_ms on every synthetic-embeddings GET — deterministic self-proof (t/3165)

### DIFF
--- a/taxonomy-editor/src/server/routes/taxonomy.ts
+++ b/taxonomy-editor/src/server/routes/taxonomy.ts
@@ -40,7 +40,13 @@ let _synthEmbeddingsInFlight: Promise<Buffer> | null = null;
 let _synthGen = 0;
 
 async function getSyntheticEmbeddingsBuffer(): Promise<Buffer> {
-  if (_synthEmbeddingsBuffer) return _synthEmbeddingsBuffer;
+  if (_synthEmbeddingsBuffer) {
+    // Warm hit — the serialize is skipped entirely (cached Buffer). Emit serialize_ms:0 so the deploy's
+    // self-proof (serialize_ms cold-once → warm≈0, t/3165) is greppable on EVERY synth GET, not only the
+    // single cold build — independent of which request first warmed the cache. cache:'hit' vs 'cold'.
+    log.api.info({ component: 'synthetic-embeddings', cache: 'hit', serialize_ms: 0, bytes: _synthEmbeddingsBuffer.length }, 'synthetic-embeddings served from cache (warm)');
+    return _synthEmbeddingsBuffer;
+  }
   if (_synthEmbeddingsInFlight) return _synthEmbeddingsInFlight; // promise-dedupe: one cold build for a burst
   const gen = _synthGen; // the generation this build belongs to; a concurrent invalidate() bumps _synthGen
   _synthEmbeddingsInFlight = (async () => {
@@ -58,7 +64,7 @@ async function getSyntheticEmbeddingsBuffer(): Promise<Buffer> {
     // t/3165 phase-timing (cold path only) → the next real synth GET proves load_ms vs serialize_ms +
     // heap; on a warm hit this line never runs (serve is near-zero) = the fix's self-proof.
     log.api.info({
-      component: 'synthetic-embeddings', load_ms: loadMs, serialize_ms: serializeMs, bytes: buffer.length,
+      component: 'synthetic-embeddings', cache: 'cold', load_ms: loadMs, serialize_ms: serializeMs, bytes: buffer.length,
       node_count: data ? Object.keys(data).length : 0,
       heap_before: heapBefore, heap_after: process.memoryUsage().heapUsed,
     }, 'synthetic-embeddings built + serialized + cached (cold path)');


### PR DESCRIPTION
## t/3165 — makes the deploy self-proof deterministic → **Main (TL) GV** (design pre-approved p/522#175)

**Why:** #1832's cold-path phase-timing logs `serialize_ms` once per process (on the cold build). DevOps saw 0 `serialize_ms` lines on a staging "cold" GET → diagnosed (TL-accepted, p/522#173-175) as a **warm-cache artifact**: no boot prewarm, so the first synth GET (the staging smoke/warm-gate probe) built the cache before DevOps's GET → warm hit → no cold-path line. **Not** a filter/wiring bug (same logger+level as the request-completion log that *did* emit; `LOG_TRIAGE_KEYS` only reduces >16KB lines; the cold-path log is unconditional on a real cold build).

**Fix:** emit `serialize_ms` on the **warm path** too — `cache:'hit', serialize_ms:0` on every cache-served GET, `cache:'cold'` on the one build. Now `serialize_ms` is greppable on **every** synth GET regardless of restart/warm timing: the first cold GET shows the real number (prod: the 400MB serialize, chunk-yield-bounded), every warm GET confirms `cache:hit` + `serialize=0` = the binding close criterion self-proves.

Deliberately **NOT** a boot prewarm — a 400MB / 301s prod load at boot would blow the warm-gate.

### Verify
`tsc -p tsconfig.server.json` clean; eslint 0; `syntheticEmbeddingsCache.test.ts` **18/18** (cache behavior unchanged — this adds a log line only).

Folds into the bundle → DevOps re-verifies `serialize_ms` emits on a staging synth GET (deterministic now, even at stub scale) → prod dispatch self-proves on the first real 400MB cold GET.

🤖 Generated with [Claude Code](https://claude.com/claude-code)