### PR TITLE
feat(ai-call-log): core JSONL schema + AI_CALL_LOG_ENABLED flag + append-writer (t/3241)

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -113,6 +113,11 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | `Invoke-AphorismBatch` | Backfill camp-voiced sober aphorisms (~3-8 words) on POV nodes — presentational only, never a scoring input; skips pillars/deprecated (t/1550) |
 | `New-SyntheticCorpus` | Generate synthetic training data |
 
+### AI Call Log (t/3235)
+| Cmdlet | Use when |
+|--------|----------|
+| `Clear-AICallLog` | Rotate/clear the AI call log (`ai-call-log.jsonl`) so the next logged call restarts `ID` at 1 — a "session" is one log file. No-op if absent; honors `-WhatIf`. Capture is behind the default-off `AI_CALL_LOG_ENABLED` flag (t/3241) |
+
 ### Health & Diagnostics
 | Cmdlet | Use when |
 |--------|----------|

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -13,6 +13,7 @@
 
     # Functions exported from this module
     FunctionsToExport = @(
+        'Clear-AICallLog'   # t/3241 — AI Call Log core (rotate/clear)
         'Get-Tax'
         'Update-TaxEmbeddings'
         'Import-AITriadDocument'

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -762,6 +762,7 @@ Set-Alias -Name 'Workflow'             -Value 'Show-WorkflowRunner'    -Scope Gl
 # Export public surface
 # ─────────────────────────────────────────────────────────────────────────────
 Export-ModuleMember -Function @(
+    'Clear-AICallLog'   # t/3241 — AI Call Log core (rotate/clear)
     'Get-Tax'
     'Update-TaxEmbeddings'
     'Import-AITriadDocument'

--- a/scripts/AITriad/Private/AICallLog.ps1
+++ b/scripts/AITriad/Private/AICallLog.ps1
@@ -1,0 +1,149 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+# AI Call Log — core (t/3241; epic t/3235, TL design t/3235#1). A per-call audit log behind the
+# default-off AI_CALL_LOG_ENABLED flag. Storage: append-only JSONL under the resolved data root
+# (mirrors the flight-recorder file pattern; Get-/Show-AICallLog run in a SEPARATE process from the
+# debate that writes, so an on-disk file — not an in-memory session — is what survives). These are
+# dot-sourced Private helpers: the capture hook (t/3242) calls Write-AICallLogEntry; Get-/Show-
+# AICallLog (t/3243/3244) read the same file; Clear-AICallLog (Public) rotates it.
+#
+# Record schema (7 fields, in order): ID, Datetime, Scenario, PromptID, PromptStart, RetryCount, Status.
+
+function Test-AICallLogEnabled {
+    <#
+    .SYNOPSIS
+        Is the AI call log enabled? True iff $env:AI_CALL_LOG_ENABLED is a truthy value.
+    .DESCRIPTION
+        Default OFF: unset/empty/anything-not-truthy → $false, so the capture hook is a single
+        early-return with zero overhead (the AC's "flag off → no perf impact"). Truthy values:
+        1 | true | yes | on (case-insensitive).
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param()
+    $v = [Environment]::GetEnvironmentVariable('AI_CALL_LOG_ENABLED')
+    return (-not [string]::IsNullOrWhiteSpace($v)) -and ($v -match '^(1|true|yes|on)$')
+}
+
+function Get-AICallLogPath {
+    <#
+    .SYNOPSIS
+        Absolute path to ai-call-log.jsonl under the resolved data root.
+    .DESCRIPTION
+        Storage-path resolution per t/3235#1: env AI_TRIAD_DATA_ROOT > .aitriad.json > platform
+        default (via the shared Get-DataRoot resolver). Not guaranteed to exist — the writer
+        creates the parent dir on first append.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+    return (Join-Path (Get-DataRoot) 'ai-call-log.jsonl')
+}
+
+function Get-AICallLogNextId {
+    <#
+    .SYNOPSIS
+        Next monotonic record ID for the log file: last record's ID + 1, else 1.
+    .DESCRIPTION
+        ID is monotonic WITHIN the current file ("a session = the file"); Clear-AICallLog removes
+        the file so the next id restarts at 1. Reads only the last line (Get-Content -Tail 1), not
+        the whole file. A malformed/absent tail falls back to 1 (fresh session).
+    #>
+    [CmdletBinding()]
+    [OutputType([int])]
+    param([Parameter(Mandatory)][string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) { return 1 }
+    $last = Get-Content -LiteralPath $Path -Tail 1 -Encoding utf8 -ErrorAction SilentlyContinue
+    if ([string]::IsNullOrWhiteSpace($last)) { return 1 }
+    try {
+        $prev = $last | ConvertFrom-Json -ErrorAction Stop
+        if ($prev.PSObject.Properties['ID']) { return ([int]$prev.ID + 1) }
+    }
+    catch {
+        # Fallback-path logging (docs/error-handling.md): a corrupt tail line shouldn't wedge the
+        # counter — restart the id sequence and surface why.
+        Write-Warning "Get-AICallLogNextId: could not parse the last log line in '$Path' ($($_.Exception.Message)); restarting ID at 1."
+    }
+    return 1
+}
+
+function Write-AICallLogEntry {
+    <#
+    .SYNOPSIS
+        Append one 7-field JSONL record to the AI call log — a no-op when the flag is off.
+    .DESCRIPTION
+        The single append-writer for the AI Call Log (t/3235#1). Returns immediately with ZERO
+        overhead unless AI_CALL_LOG_ENABLED is truthy (the capture hook, t/3242, calls this on every
+        AI call). Writes are FAIL-SAFE: an IO error is WARNed and swallowed (fallback-path logging)
+        so enabling the audit log can never break the AI call it audits.
+
+        Record fields (schema of record, in order):
+          ID          monotonic within the file (Get-AICallLogNextId)
+          Datetime    UTC, ISO-8601 round-trip ('o')
+          Scenario    caller-supplied tag (e.g. Debate, Chat, Fact Check, Logical Form)
+          PromptID    UsageID from ai-usages.json, or '' when absent
+          PromptStart first 160 chars of the rendered prompt
+          RetryCount  0 first attempt, N for the Nth retry
+          Status      HTTP/API status (e.g. 200, 429, 500, timeout)
+    .PARAMETER Path
+        Log file override (fixtures/tests). Default: Get-AICallLogPath.
+    #>
+    [CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter()]
+        [AllowEmptyString()]
+        [string]$Scenario = '',
+
+        [Parameter()]
+        [AllowEmptyString()]
+        [string]$PromptID = '',
+
+        [Parameter()]
+        [AllowEmptyString()]
+        [string]$PromptStart = '',
+
+        [Parameter()]
+        [int]$RetryCount = 0,
+
+        [Parameter()]
+        [AllowEmptyString()]
+        [string]$Status = '',
+
+        [Parameter()]
+        [string]$Path
+    )
+    Set-StrictMode -Version Latest
+
+    if (-not (Test-AICallLogEnabled)) { return }   # default-off: single early-return, zero overhead
+
+    $logPath = if ($PSBoundParameters.ContainsKey('Path') -and $Path) { $Path } else { Get-AICallLogPath }
+
+    try {
+        $dir = Split-Path -Parent $logPath
+        if ($dir -and -not (Test-Path -LiteralPath $dir)) {
+            New-Item -ItemType Directory -Path $dir -Force | Out-Null
+        }
+
+        $start = [string]$PromptStart
+        if ($start.Length -gt 160) { $start = $start.Substring(0, 160) }
+
+        # [ordered] so the JSONL field order matches the schema of record.
+        $record = [ordered]@{
+            ID          = Get-AICallLogNextId -Path $logPath
+            Datetime    = [DateTime]::UtcNow.ToString('o')
+            Scenario    = $Scenario
+            PromptID    = $PromptID
+            PromptStart = $start
+            RetryCount  = $RetryCount
+            Status      = $Status
+        }
+        $line = $record | ConvertTo-Json -Compress -Depth 4
+        Add-Content -LiteralPath $logPath -Value $line -Encoding utf8NoBOM
+    }
+    catch {
+        # Fail-safe (t/3235#1): audit logging must never break the call it audits.
+        Write-Warning "Write-AICallLogEntry: failed to append to '$logPath' ($($_.Exception.Message)); continuing (audit log is non-fatal)."
+    }
+}

--- a/scripts/AITriad/Public/Clear-AICallLog.ps1
+++ b/scripts/AITriad/Public/Clear-AICallLog.ps1
@@ -1,0 +1,49 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Clear-AICallLog {
+    <#
+    .SYNOPSIS
+        Rotate/clear the AI call log — removes ai-call-log.jsonl so the next entry restarts ID at 1.
+    .DESCRIPTION
+        The rotate/clear for the AI Call Log (t/3241; epic t/3235). A "session" is one log file, so
+        clearing it starts a fresh session — the next Write-AICallLogEntry mints ID 1 again. No-op
+        (Removed=$false) when the file is already absent. Honors -WhatIf/-Confirm (it deletes a file).
+    .PARAMETER Path
+        Log file override (fixtures/tests). Default: Get-AICallLogPath (data-root resolved).
+    .OUTPUTS
+        [pscustomobject] { Path, Removed } — the resolved path and whether a file was deleted.
+    .EXAMPLE
+        Clear-AICallLog
+        Starts a fresh AI-call-log session (ID resets to 1 on the next logged call).
+    .EXAMPLE
+        Clear-AICallLog -WhatIf
+        Shows what would be removed without deleting.
+    .LINK
+        Get-AICallLog
+    .LINK
+        Show-AICallLog
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter()]
+        [string]$Path
+    )
+    Set-StrictMode -Version Latest
+
+    $logPath = if ($PSBoundParameters.ContainsKey('Path') -and $Path) { $Path } else { Get-AICallLogPath }
+
+    $removed = $false
+    if (Test-Path -LiteralPath $logPath) {
+        if ($PSCmdlet.ShouldProcess($logPath, 'Remove AI call log (reset session, next ID = 1)')) {
+            Remove-Item -LiteralPath $logPath -Force
+            $removed = $true
+        }
+    }
+
+    return [pscustomobject]@{
+        Path    = $logPath
+        Removed = $removed
+    }
+}

--- a/tests/AICallLog.Tests.ps1
+++ b/tests/AICallLog.Tests.ps1
@@ -1,0 +1,145 @@
+# Tag: unit (t/3241)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    AI Call Log — core (t/3241; epic t/3235). Flag semantics, the append-writer record shape +
+    monotonic ID, and the rotate/clear cmdlet.
+.DESCRIPTION
+    Private helpers (Test-AICallLogEnabled / Write-AICallLogEntry) are exercised via InModuleScope;
+    the writer takes a -Path override so nothing touches the real data-root log. The env flag is
+    process-global, so an AfterEach clears it to keep tests independent.
+#>
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1') -Force -WarningAction SilentlyContinue
+}
+
+Describe 'AI Call Log core (t/3241)' -Tag 'unit' {
+
+    AfterEach {
+        Remove-Item Env:AI_CALL_LOG_ENABLED -ErrorAction SilentlyContinue
+    }
+
+    Context 'Test-AICallLogEnabled — default-off flag' {
+        It 'is FALSE when the flag is unset (default off)' {
+            Remove-Item Env:AI_CALL_LOG_ENABLED -ErrorAction SilentlyContinue
+            InModuleScope AITriad { Test-AICallLogEnabled } | Should -BeFalse
+        }
+        It 'is TRUE for truthy value <_>' -ForEach @('1', 'true', 'TRUE', 'yes', 'on') {
+            $env:AI_CALL_LOG_ENABLED = $_
+            InModuleScope AITriad { Test-AICallLogEnabled } | Should -BeTrue
+        }
+        It 'is FALSE for non-truthy value "<_>"' -ForEach @('0', 'false', 'no', 'off', '') {
+            $env:AI_CALL_LOG_ENABLED = $_
+            InModuleScope AITriad { Test-AICallLogEnabled } | Should -BeFalse
+        }
+    }
+
+    Context 'Write-AICallLogEntry — no-op when the flag is off' {
+        It 'writes NOTHING when the flag is off (zero-overhead early return, AC)' {
+            Remove-Item Env:AI_CALL_LOG_ENABLED -ErrorAction SilentlyContinue
+            $log = Join-Path $TestDrive 'off.jsonl'
+            InModuleScope AITriad -Parameters @{ P = $log } {
+                param($P)
+                Write-AICallLogEntry -Scenario 'Debate' -Status '200' -Path $P
+            }
+            Test-Path -LiteralPath $log | Should -BeFalse
+        }
+    }
+
+    Context 'Write-AICallLogEntry — record shape when on' {
+        BeforeEach { $env:AI_CALL_LOG_ENABLED = '1' }
+
+        It 'writes one well-formed JSONL record with all 7 fields' {
+            $log = Join-Path $TestDrive 'on.jsonl'
+            InModuleScope AITriad -Parameters @{ P = $log } {
+                param($P)
+                Write-AICallLogEntry -Scenario 'Logical Form' `
+                    -PromptID 'enrichment.logical-form-formalization' `
+                    -PromptStart 'Formalize this claim.' -RetryCount 2 -Status '200' -Path $P
+            }
+            $lines = @(Get-Content -LiteralPath $log)
+            $lines.Count | Should -Be 1
+            $rec = $lines[0] | ConvertFrom-Json
+            foreach ($f in 'ID', 'Datetime', 'Scenario', 'PromptID', 'PromptStart', 'RetryCount', 'Status') {
+                $rec.PSObject.Properties[$f] | Should -Not -BeNullOrEmpty -Because "field '$f' must be present"
+            }
+            $rec.ID         | Should -Be 1
+            $rec.Scenario   | Should -Be 'Logical Form'
+            $rec.PromptID   | Should -Be 'enrichment.logical-form-formalization'
+            $rec.RetryCount | Should -Be 2
+            $rec.Status     | Should -Be '200'
+            # Assert Datetime on the RAW line, not $rec.Datetime — PS7 ConvertFrom-Json coerces the
+            # ISO-8601 string to [DateTime] (drops the literal 'Z'); the on-disk contract is the text.
+            $lines[0] | Should -Match '"Datetime":"\d{4}-\d{2}-\d{2}T[0-9:.]+Z"'   # UTC ISO-8601
+        }
+
+        It 'truncates PromptStart to 160 chars' {
+            $log = Join-Path $TestDrive 'trunc.jsonl'
+            $long = 'x' * 500
+            InModuleScope AITriad -Parameters @{ P = $log; Long = $long } {
+                param($P, $Long)
+                Write-AICallLogEntry -Scenario 'Chat' -PromptStart $Long -Status '200' -Path $P
+            }
+            $rec = Get-Content -LiteralPath $log | Select-Object -First 1 | ConvertFrom-Json
+            $rec.PromptStart.Length | Should -Be 160
+        }
+
+        It 'assigns monotonic IDs across appends (1,2,3)' {
+            $log = Join-Path $TestDrive 'mono.jsonl'
+            InModuleScope AITriad -Parameters @{ P = $log } {
+                param($P)
+                Write-AICallLogEntry -Scenario 'A' -Status '200' -Path $P
+                Write-AICallLogEntry -Scenario 'B' -Status '429' -Path $P
+                Write-AICallLogEntry -Scenario 'C' -Status '500' -Path $P
+            }
+            $ids = @(Get-Content -LiteralPath $log | ForEach-Object { ($_ | ConvertFrom-Json).ID })
+            $ids | Should -Be @(1, 2, 3)
+        }
+    }
+
+    Context 'Clear-AICallLog — rotate resets the session' {
+        BeforeEach { $env:AI_CALL_LOG_ENABLED = '1' }
+
+        It 'removes the file and the next write restarts ID at 1' {
+            $log = Join-Path $TestDrive 'rotate.jsonl'
+            InModuleScope AITriad -Parameters @{ P = $log } {
+                param($P)
+                Write-AICallLogEntry -Scenario 'A' -Status '200' -Path $P
+                Write-AICallLogEntry -Scenario 'B' -Status '200' -Path $P
+            }
+            @(Get-Content -LiteralPath $log).Count | Should -Be 2
+
+            $res = Clear-AICallLog -Path $log
+            $res.Removed | Should -BeTrue
+            Test-Path -LiteralPath $log | Should -BeFalse
+
+            InModuleScope AITriad -Parameters @{ P = $log } {
+                param($P)
+                Write-AICallLogEntry -Scenario 'C' -Status '200' -Path $P
+            }
+            (Get-Content -LiteralPath $log | Select-Object -First 1 | ConvertFrom-Json).ID | Should -Be 1
+        }
+
+        It 'is a no-op (Removed=$false) when the file is absent' {
+            $log = Join-Path $TestDrive 'absent.jsonl'
+            $res = Clear-AICallLog -Path $log
+            $res.Removed | Should -BeFalse
+            { Clear-AICallLog -Path $log } | Should -Not -Throw
+        }
+    }
+
+    Context 'Manifest export' {
+        It 'exports Clear-AICallLog' {
+            Get-Command Clear-AICallLog -Module AITriad | Should -Not -BeNullOrEmpty
+        }
+        It 'FunctionsToExport includes Clear-AICallLog' {
+            $manifestPath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psd1'
+            (Test-ModuleManifest -Path $manifestPath).ExportedFunctions.Keys | Should -Contain 'Clear-AICallLog'
+        }
+    }
+}

--- a/tests/DataWriteSinkGuard.Tests.ps1
+++ b/tests/DataWriteSinkGuard.Tests.ps1
@@ -58,6 +58,7 @@ BeforeAll {
         'scripts/AITriad/Public/New-OpEd.ps1'              = 'writes op-ed Markdown output (new file, non-data-of-record)'
         'scripts/AITriad/Public/New-SyntheticCorpus.ps1'   = 'append-checkpoint + fresh corpus generation + NEW metadata (not a whole-file data rewrite)'
         'scripts/AITriad/Public/Test-DebatePersistence.ps1' = 'writes a random persist-probe .tmp (test probe, non-data)'
+        'scripts/AITriad/Private/AICallLog.ps1'            = 'append-only AI call-log JSONL (Add-Content); references Get-DataRoot only to locate the log file — never read-mutate-rewrites a data-of-record file (t/3241)'
     }
 
     # A data-of-record path token (basename or data-dir accessor). Kept specific so


### PR DESCRIPTION
Task **A** of the AI Call Log epic (t/3235) — the interface-first foundation that unblocks B/C/D/E. Built to the TL design in **t/3235#1**.

## New `Private/AICallLog.ps1` (dot-sourced helpers)
- `Test-AICallLogEnabled` → `[bool]`; true iff `$env:AI_CALL_LOG_ENABLED` matches `^(1|true|yes|on)$` (case-insensitive). **Default OFF.**
- `Get-AICallLogPath` → `ai-call-log.jsonl` under the resolved data root (env > `.aitriad.json` > platform default, via `Get-DataRoot`; mirrors the flight-recorder file pattern).
- `Get-AICallLogNextId` → monotonic ID within the file (tail record +1, else 1).
- `Write-AICallLogEntry` → the single append-writer. **Early-return no-op when the flag is off** (zero overhead, per the AC). Emits the 7-field record (`ID`, `Datetime` UTC ISO-8601, `Scenario`, `PromptID`, `PromptStart` ≤160 chars, `RetryCount`, `Status`) as one `ConvertTo-Json -Compress` line. **Fail-safe**: an IO error is WARNed and swallowed so enabling the audit log can never break the AI call it audits. `-Path` override for tests.

## New `Public/Clear-AICallLog.ps1`
Rotate/clear (`SupportsShouldProcess`): removes the log so the next entry restarts `ID` at 1 ("session" = file). Returns `{Path, Removed}`. Registered in psd1 + psm1 + cataloged.

## Tests — `tests/AICallLog.Tests.ps1` (19 cases)
Flag default-off + truthy/falsy matrix; flag-off no-op (no file written); flag-on 7-field record shape; `PromptStart` truncation; monotonic ID across appends; `Clear` resets ID→1 + absent-file no-op; manifest export. **19/19 green; `Test-ModuleManifest` passes.** (Datetime asserted on the raw JSONL line — PS7 `ConvertFrom-Json` coerces the ISO string to `[DateTime]`.)

## Notes
- **Judgment call** (flagged in t/3241#1 for TL veto): made the rotate/clear a **public** `Clear-AICallLog` (vs a private helper) — natural user op, completes the Get/Show/Clear family.
- **Design gate**: core schema/storage/flag are TL-decided (t/3235#1); public `Clear-AICallLog` self-certifies `/add-ps-cmdlet`. No new cross-role interface.
- Unblocks B (capture hook) / C (`Get-AICallLog`) / D (`Show-AICallLog`) / E (TS capture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)