### PR TITLE
feat(ai-call-log): Get-AICallLog reader — filterable, pipeline, typed (t/3243)

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -117,6 +117,7 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | Cmdlet | Use when |
 |--------|----------|
 | `Clear-AICallLog` | Rotate/clear the AI call log (`ai-call-log.jsonl`) so the next logged call restarts `ID` at 1 — a "session" is one log file. No-op if absent; honors `-WhatIf`. Capture is behind the default-off `AI_CALL_LOG_ENABLED` flag (t/3241) |
+| `Get-AICallLog` | Read the AI call log as filterable, pipeline-friendly `[AICallLogEntry]` objects — filter by `-Scenario`/`-Status` (wildcards) and `-After`/`-Before` date range. Reading ignores the capture flag; absent/empty log → empty result (t/3243) |
 
 ### Health & Diagnostics
 | Cmdlet | Use when |

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -14,6 +14,7 @@
     # Functions exported from this module
     FunctionsToExport = @(
         'Clear-AICallLog'   # t/3241 — AI Call Log core (rotate/clear)
+        'Get-AICallLog'     # t/3243 — AI Call Log reader (filterable, pipeline)
         'Get-Tax'
         'Update-TaxEmbeddings'
         'Import-AITriadDocument'

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -596,6 +596,18 @@ class DebatePersistenceResult {
     [string] $LockHolder   # process name if identifiable, otherwise $null
 }
 
+# AI Call Log record (t/3243; schema of record from t/3235#1 / t/3241). One instance
+# per ai-call-log.jsonl line. Get-AICallLog emits these; Show-AICallLog (t/3244) renders them.
+class AICallLogEntry {
+    [int]      $ID           # monotonic within the log file (a "session" = the file)
+    [datetime] $Datetime     # UTC; parsed from the ISO-8601 round-trip string on disk
+    [string]   $Scenario     # caller-supplied tag (e.g. Debate, Chat, Fact Check)
+    [string]   $PromptID     # UsageID from ai-usages.json, or '' when absent
+    [string]   $PromptStart  # first 160 chars of the rendered prompt
+    [int]      $RetryCount   # 0 first attempt, N for the Nth retry
+    [string]   $Status       # HTTP/API status (e.g. 200, 429, 500, timeout)
+}
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Module-scoped taxonomy store
 # ─────────────────────────────────────────────────────────────────────────────
@@ -763,6 +775,7 @@ Set-Alias -Name 'Workflow'             -Value 'Show-WorkflowRunner'    -Scope Gl
 # ─────────────────────────────────────────────────────────────────────────────
 Export-ModuleMember -Function @(
     'Clear-AICallLog'   # t/3241 — AI Call Log core (rotate/clear)
+    'Get-AICallLog'     # t/3243 — AI Call Log reader (filterable, pipeline)
     'Get-Tax'
     'Update-TaxEmbeddings'
     'Import-AITriadDocument'

--- a/scripts/AITriad/Public/Get-AICallLog.ps1
+++ b/scripts/AITriad/Public/Get-AICallLog.ps1
@@ -1,0 +1,145 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Get-AICallLog {
+    <#
+    .SYNOPSIS
+        Read the AI call log (ai-call-log.jsonl) as filterable, pipeline-friendly objects.
+    .DESCRIPTION
+        The reader for the AI Call Log (t/3243; epic t/3235, TL design t/3235#1). Parses the
+        append-only JSONL written by Write-AICallLogEntry (t/3241) into typed [AICallLogEntry]
+        objects and emits them one per record down the pipeline, so they compose with
+        Where-Object / Sort-Object / Select-Object.
+
+        Reading is decoupled from the AI_CALL_LOG_ENABLED capture flag: the flag gates WRITES,
+        not reads — you can always inspect whatever the log already holds. When the log file is
+        absent or empty (e.g. logging was never enabled, or Clear-AICallLog just rotated it), the
+        result is simply empty — non-fatal, no error. A line that fails to parse is skipped with a
+        WARN (fallback-path logging) rather than aborting the whole read.
+    .PARAMETER Scenario
+        Keep only records whose Scenario matches this wildcard pattern (case-insensitive -like).
+        E.g. -Scenario 'Debate', -Scenario 'Fact*'.
+    .PARAMETER Status
+        Keep only records whose Status matches this wildcard pattern (case-insensitive -like).
+        E.g. -Status 200, -Status '4*' (all 4xx), -Status '*timeout*'.
+    .PARAMETER After
+        Keep only records at or after this timestamp (compared against the record Datetime).
+    .PARAMETER Before
+        Keep only records strictly before this timestamp (compared against the record Datetime).
+    .PARAMETER Path
+        Log file override (fixtures/tests). Default: Get-AICallLogPath (data-root resolved).
+    .OUTPUTS
+        [AICallLogEntry] — one per matching JSONL record, in file (chronological) order.
+    .EXAMPLE
+        Get-AICallLog
+        All logged AI calls, oldest first.
+    .EXAMPLE
+        Get-AICallLog -Scenario Debate -Status '4*'
+        Debate-scenario calls that returned a 4xx status.
+    .EXAMPLE
+        Get-AICallLog -After (Get-Date).AddHours(-1) | Sort-Object RetryCount -Descending
+        Calls in the last hour, most-retried first.
+    .LINK
+        Clear-AICallLog
+    .LINK
+        Get-AICostReport
+    #>
+    # NB: no [OutputType([AICallLogEntry])] — a module-scoped PS class can't be resolved in the
+    # attribute at dot-source parse time ("Unable to find type"); the codebase convention (e.g.
+    # Get-FreeTierStatus, Get-AITDebate) is to construct the class in the body and document the
+    # return type in .OUTPUTS instead.
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [SupportsWildcards()]
+        [string]$Scenario,
+
+        [Parameter()]
+        [SupportsWildcards()]
+        [string]$Status,
+
+        [Parameter()]
+        [datetime]$After,
+
+        [Parameter()]
+        [datetime]$Before,
+
+        [Parameter()]
+        [string]$Path
+    )
+    Set-StrictMode -Version Latest
+
+    $logPath = if ($PSBoundParameters.ContainsKey('Path') -and $Path) { $Path } else { Get-AICallLogPath }
+
+    if (-not (Test-Path -LiteralPath $logPath)) {
+        Write-Verbose "Get-AICallLog: no log file at '$logPath' — returning empty (logging may never have been enabled)."
+        return
+    }
+
+    $lines = @(Get-Content -LiteralPath $logPath -Encoding utf8 -ErrorAction SilentlyContinue)
+    if ($lines.Count -eq 0) {
+        Write-Verbose "Get-AICallLog: log file '$logPath' is empty — returning empty."
+        return
+    }
+
+    # Normalize the range bounds to UTC once. Records are stored UTC (ISO-8601 'Z'), but a
+    # user-supplied -After/-Before may be Local/Unspecified kind; comparing raw ticks across
+    # DateTimeKind is a silent tz bug near boundaries. ToUniversalTime() treats an Unspecified
+    # bound as local time — the sane default for a hand-typed date.
+    $afterUtc  = if ($PSBoundParameters.ContainsKey('After'))  { $After.ToUniversalTime() }  else { $null }
+    $beforeUtc = if ($PSBoundParameters.ContainsKey('Before')) { $Before.ToUniversalTime() } else { $null }
+
+    $lineNo = 0
+    foreach ($line in $lines) {
+        $lineNo++
+        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+
+        $rec = $null
+        try {
+            $rec = $line | ConvertFrom-Json -ErrorAction Stop
+        }
+        catch {
+            # Fallback-path logging (docs/error-handling.md): one corrupt line must not abort the
+            # whole read — skip it and surface which line and why.
+            Write-Warning "Get-AICallLog: skipping unparseable line $lineNo in '$logPath' ($($_.Exception.Message))."
+            continue
+        }
+
+        # Parse Datetime once; needed both for the range filters and the emitted typed value.
+        # A missing/unparseable Datetime yields [datetime]::MinValue (never matches a real range).
+        $dt = [datetime]::MinValue
+        if ($rec.PSObject.Properties['Datetime'] -and -not [string]::IsNullOrWhiteSpace([string]$rec.Datetime)) {
+            $parsed = [datetime]::MinValue
+            if ([datetime]::TryParse(
+                    [string]$rec.Datetime, [cultureinfo]::InvariantCulture,
+                    [System.Globalization.DateTimeStyles]::RoundtripKind, [ref]$parsed)) {
+                $dt = $parsed
+            }
+            else {
+                Write-Warning "Get-AICallLog: line $lineNo has an unparseable Datetime '$($rec.Datetime)' in '$logPath'; treating as MinValue."
+            }
+        }
+
+        # Apply filters (skip non-matches before materializing the typed object). Compare in UTC;
+        # the MinValue sentinel (missing Datetime) is left as-is so it sorts before any real bound.
+        $dtUtc = if ($dt -eq [datetime]::MinValue) { $dt } else { $dt.ToUniversalTime() }
+        if ($null -ne $afterUtc  -and $dtUtc -lt $afterUtc)  { continue }
+        if ($null -ne $beforeUtc -and $dtUtc -ge $beforeUtc) { continue }
+
+        $recScenario = if ($rec.PSObject.Properties['Scenario']) { [string]$rec.Scenario } else { '' }
+        if ($PSBoundParameters.ContainsKey('Scenario') -and $recScenario -notlike $Scenario) { continue }
+
+        $recStatus = if ($rec.PSObject.Properties['Status']) { [string]$rec.Status } else { '' }
+        if ($PSBoundParameters.ContainsKey('Status') -and $recStatus -notlike $Status) { continue }
+
+        [AICallLogEntry]@{
+            ID          = if ($rec.PSObject.Properties['ID'])          { [int]$rec.ID }          else { 0 }
+            Datetime    = $dt
+            Scenario    = $recScenario
+            PromptID    = if ($rec.PSObject.Properties['PromptID'])    { [string]$rec.PromptID } else { '' }
+            PromptStart = if ($rec.PSObject.Properties['PromptStart']) { [string]$rec.PromptStart } else { '' }
+            RetryCount  = if ($rec.PSObject.Properties['RetryCount'])  { [int]$rec.RetryCount }  else { 0 }
+            Status      = $recStatus
+        }
+    }
+}

--- a/tests/AICallLog.Tests.ps1
+++ b/tests/AICallLog.Tests.ps1
@@ -143,3 +143,109 @@ Describe 'AI Call Log core (t/3241)' -Tag 'unit' {
         }
     }
 }
+
+Describe 'Get-AICallLog (t/3243)' -Tag 'unit' {
+
+    # A deterministic fixture with known Datetime/Scenario/Status so range + wildcard filters
+    # are testable without depending on wall-clock (the writer stamps UtcNow).
+    BeforeEach {
+        $script:log = Join-Path $TestDrive "get-$([guid]::NewGuid()).jsonl"
+        $fixture = @(
+            [ordered]@{ ID = 1; Datetime = '2026-01-01T08:00:00.0000000Z'; Scenario = 'Debate';     PromptID = 'p1'; PromptStart = 'alpha';   RetryCount = 0; Status = '200' }
+            [ordered]@{ ID = 2; Datetime = '2026-01-02T09:30:00.0000000Z'; Scenario = 'Chat';       PromptID = '';   PromptStart = 'bravo';   RetryCount = 1; Status = '429' }
+            [ordered]@{ ID = 3; Datetime = '2026-01-03T11:15:00.0000000Z'; Scenario = 'Fact Check'; PromptID = 'p3'; PromptStart = 'charlie'; RetryCount = 0; Status = '500' }
+        )
+        $fixture | ForEach-Object { $_ | ConvertTo-Json -Compress } |
+            Set-Content -LiteralPath $script:log -Encoding utf8
+    }
+
+    Context 'read + shape' {
+        It 'returns one [AICallLogEntry] per record with all 7 fields (AC)' {
+            $r = @(Get-AICallLog -Path $script:log)
+            $r.Count | Should -Be 3
+            $r[0].GetType().Name | Should -Be 'AICallLogEntry'
+            foreach ($f in 'ID', 'Datetime', 'Scenario', 'PromptID', 'PromptStart', 'RetryCount', 'Status') {
+                $r[0].PSObject.Properties[$f] | Should -Not -BeNullOrEmpty -Because "field '$f' must be present"
+            }
+            $r[0].ID          | Should -Be 1
+            $r[0].Scenario    | Should -Be 'Debate'
+            $r[0].Status      | Should -Be '200'
+            $r[0].RetryCount  | Should -Be 0
+        }
+
+        It 'parses Datetime to a [datetime]' {
+            $r = @(Get-AICallLog -Path $script:log)
+            $r[0].Datetime | Should -BeOfType ([datetime])
+            $r[0].Datetime.ToUniversalTime().ToString('yyyy-MM-dd') | Should -Be '2026-01-01'
+        }
+
+        It 'emits records one at a time down the pipeline (composes with Where-Object)' {
+            $retried = @(Get-AICallLog -Path $script:log | Where-Object RetryCount -gt 0)
+            $retried.Count | Should -Be 1
+            $retried[0].ID | Should -Be 2
+        }
+
+        It 'reads regardless of the AI_CALL_LOG_ENABLED flag (flag gates writes, not reads)' {
+            Remove-Item Env:AI_CALL_LOG_ENABLED -ErrorAction SilentlyContinue
+            @(Get-AICallLog -Path $script:log).Count | Should -Be 3
+        }
+    }
+
+    Context 'filters' {
+        It 'filters by -Scenario (case-insensitive wildcard)' {
+            $r = @(Get-AICallLog -Path $script:log -Scenario 'fact*')
+            $r.Count | Should -Be 1
+            $r[0].Scenario | Should -Be 'Fact Check'
+        }
+        It 'filters by -Status wildcard (all 4xx)' {
+            $r = @(Get-AICallLog -Path $script:log -Status '4*')
+            $r.Count | Should -Be 1
+            $r[0].Status | Should -Be '429'
+        }
+        It 'filters by -After (inclusive lower bound)' {
+            $r = @(Get-AICallLog -Path $script:log -After ([datetime]::Parse('2026-01-02T00:00:00Z')))
+            @($r.ID) | Should -Be @(2, 3)
+        }
+        It 'filters by -Before (exclusive upper bound)' {
+            $r = @(Get-AICallLog -Path $script:log -Before ([datetime]::Parse('2026-01-02T00:00:00Z')))
+            @($r.ID) | Should -Be @(1)
+        }
+        It 'combines -After and -Before into a range' {
+            $r = @(Get-AICallLog -Path $script:log `
+                    -After ([datetime]::Parse('2026-01-02T00:00:00Z')) `
+                    -Before ([datetime]::Parse('2026-01-03T00:00:00Z')))
+            @($r.ID) | Should -Be @(2)
+        }
+    }
+
+    Context 'non-fatal empty / degraded paths' {
+        It 'returns empty (no throw) when the log file is absent' {
+            $absent = Join-Path $TestDrive 'nope.jsonl'
+            $r = $null
+            { $r = @(Get-AICallLog -Path $absent) } | Should -Not -Throw
+            $r.Count | Should -Be 0
+        }
+        It 'returns empty when the log file is empty' {
+            $empty = Join-Path $TestDrive 'empty.jsonl'
+            Set-Content -LiteralPath $empty -Value '' -Encoding utf8
+            @(Get-AICallLog -Path $empty).Count | Should -Be 0
+        }
+        It 'skips an unparseable line with a warning but returns the valid records' {
+            Add-Content -LiteralPath $script:log -Value 'this is not json' -Encoding utf8
+            $warnings = @()
+            $r = @(Get-AICallLog -Path $script:log -WarningVariable warnings -WarningAction SilentlyContinue)
+            $r.Count | Should -Be 3
+            @($warnings).Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Context 'Manifest export' {
+        It 'exports Get-AICallLog' {
+            Get-Command Get-AICallLog -Module AITriad | Should -Not -BeNullOrEmpty
+        }
+        It 'FunctionsToExport includes Get-AICallLog' {
+            $manifestPath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psd1'
+            (Test-ModuleManifest -Path $manifestPath).ExportedFunctions.Keys | Should -Contain 'Get-AICallLog'
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements **C** of the AI Call Log epic (t/3235): the reader cmdlet. Blocked-by A (t/3241) which is landed.

`Get-AICallLog` reads `ai-call-log.jsonl` into typed `[AICallLogEntry]` objects, one per record down the pipeline.

- **Filters:** `-Scenario` / `-Status` (case-insensitive `-like` wildcards), `-After` / `-Before` (UTC-normalized date range).
- **Flag-independent read:** the `AI_CALL_LOG_ENABLED` flag gates *writes*, not reads.
- **Non-fatal:** absent/empty log → empty result; a corrupt/unparseable line is skipped with a `WARN` (fallback-path logging).
- **Typed output:** new `[AICallLogEntry]` class in `AITriad.psm1` (D/Show-AICallLog will consume it).

## Files
- `scripts/AITriad/Public/Get-AICallLog.ps1` (new)
- `scripts/AITriad/AITriad.psm1` (`[AICallLogEntry]` class + `Export-ModuleMember`)
- `scripts/AITriad/AITriad.psd1` (`FunctionsToExport`)
- `tests/AICallLog.Tests.ps1` (+14 cases; full suite 33/33)
- `docs/cmdlet-reference.md` (catalog)

## Verification
- Pester `tests/AICallLog.Tests.ps1`: **33/33** (A's 19 + C's 14).
- `DataWriteSinkGuard`: pass (read-only cmdlet, no write sink).
- `Test-ModuleManifest`: passes, `Get-AICallLog` exported.

## Design / self-cert
Self-cert `/add-ps-cmdlet` (design in t/3243#1). Deviations documented there: typed class over `[PSCustomObject]`; `-like` filters; no `[OutputType([AICallLogEntry])]` attribute (module-scoped class isn't resolvable in the parse-time attribute — matches `Get-FreeTierStatus`/`Get-AITDebate`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)