### PR TITLE
obs(server): computeEmbeddings stdout logs → component:'api'+subsystem (t/3246)

### DIFF
--- a/taxonomy-editor/src/server/ai/aiBackends.ts
+++ b/taxonomy-editor/src/server/ai/aiBackends.ts
@@ -821,8 +821,11 @@ export async function computeEmbeddings(
   // (in-process, main-thread — the t/3165 starvation shape) vs offloadFlag=true +
   // chain=['onnx-batch-worker'] (engaged). Unconditional + pre-compute → can't be masked by a
   // swallowed downstream error.
+  // t/3246: emit under the established component:'api' (proven to reach Log Analytics) with the
+  // subsystem identity in a `subsystem` field — the earlier novel component:'ai-backends' kept
+  // offloadFlag/chainMembers invisible in LA (same drop as the synth serialize_ms lines).
   log.api.info({
-    component: 'ai-backends', requester,
+    component: 'api', subsystem: 'ai-backends', requester,
     offloadFlag: isEmbeddingWorkerOffloadEnabled(),
     chainMembers: chain.map(c => c.name),
     inputCount: texts.length, cacheHits, cacheMisses,
@@ -851,7 +854,7 @@ export async function computeEmbeddings(
     // logs — the offload NO-GO was diagnosable ONLY by inference (zero worker/fallback lines reached
     // stdout). The real cause (e.g. the worker's ERR_MODULE_NOT_FOUND surfaced through resolveEmbeddings)
     // is now greppable instead of masked by the generic ActionableError below.
-    log.api.error({ component: 'ai-backends', inputCount: texts.length, elapsedMs, chainMembers: chain.map(c => c.name), err: String(err) }, 'computeEmbeddings failed');
+    log.api.error({ component: 'api', subsystem: 'ai-backends', inputCount: texts.length, elapsedMs, chainMembers: chain.map(c => c.name), err: String(err) }, 'computeEmbeddings failed');
     // t/2985: distinguish a per-chunk timeout from an empty-chain init failure so triage
     // isn't misdirected to a packaging cause when the encoder worked but timed out.
     const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## What
Completes **t/3246** (sibling to #1844). The two Pino/stdout `log.api.*` lines in `computeEmbeddings` used the novel `component:'ai-backends'` that never surfaced in Log Analytics — the same drop as the synth `serialize_ms` lines:
- `chain resolved` info (`offloadFlag`/`chainMembers`, #1828)
- `computeEmbeddings failed` error (#3209)

Both → established `component:'api'` + `subsystem:'ai-backends'` (keeps `offloadFlag`/`chainMembers` greppable). FR-ring `record(...)` calls unchanged (separate taxonomy).

## Why
The error line is the one that matters most: container-side compute failures were ungreppable in LA — the exact **"offload silently wasn't engaged"** diagnosis gap from t/3165. Now `offloadFlag=true|false` + chain membership + failures are all visible under the proven-landing component.

## Scope / risk
Log-only, single file (`ai/aiBackends.ts`, ServerAPI scope per resolve_owner). No behavior change; no new branches (pre-existing complexity-18 warning unchanged). **Self-cert `/trivial-change`.**

## Verify
- `npx eslint src/server/ai/aiBackends.ts` → 0 errors (1 pre-existing complexity warning)
- tsc: aiBackends clean
- No test asserts the old component on these lines

Rides the t/3165 redeploy-from-main bundle. Relates t/3165, t/3236; sibling #1844.

🤖 Generated with [Claude Code](https://claude.com/claude-code)