### PR TITLE
fix(settings): widen help modal default to 900x520, fix right-edge resize (t/3249)

### DIFF
--- a/taxonomy-editor/src/renderer/components/settings/HelpDialog.css
+++ b/taxonomy-editor/src/renderer/components/settings/HelpDialog.css
@@ -125,7 +125,7 @@
 .helpdialog-tab-nav { border-left: 2px solid transparent; color: var(--text-secondary); }
 .helpdialog-tab-nav:hover { color: var(--text-primary); }
 
-.helpdialog-resize-e { position: absolute; right: -4px; top: 0; width: 14px; height: 100%; cursor: ew-resize; z-index: 10; }
+.helpdialog-resize-e { position: absolute; right: 0; top: 0; width: 8px; height: 100%; cursor: ew-resize; z-index: 10; }
 .helpdialog-resize-s { position: absolute; bottom: -4px; left: 0; width: 100%; height: 14px; cursor: ns-resize; z-index: 10; }
 .helpdialog-resize-se { position: absolute; right: -4px; bottom: -4px; width: 20px; height: 20px; cursor: nwse-resize; opacity: 0.4; z-index: 11; }
 .helpdialog-resize-icon { display: block; }

--- a/taxonomy-editor/src/renderer/components/settings/HelpDialog.tsx
+++ b/taxonomy-editor/src/renderer/components/settings/HelpDialog.tsx
@@ -358,7 +358,7 @@ export function HelpDialog({ onClose, initialTab }: HelpDialogProps) {
   const [showSupportForm, setShowSupportForm] = useState(false);
   const { unreadCount, fetchCases: fetchSupportCases } = useSupportStore();
   const [pos, setPos] = useState({ x: 0, y: 0 });
-  const [size, setSize] = useState({ w: 700, h: 480 });
+  const [size, setSize] = useState({ w: 900, h: 520 });
   const [centered, setCentered] = useState(true);
   const dialogRef = useRef<HTMLDivElement>(null);
   const dragging = useRef<{ startX: number; startY: number; origX: number; origY: number } | null>(null);


### PR DESCRIPTION
## Summary

- Widen help modal default from 700×480 → 900×520: content no longer clips on any tab section (AC1)
- Fix right-edge resize handle: was `right: -4px; width: 14px` (4px outside dialog box, intercepted by overlay), changed to `right: 0; width: 8px` (fully inside dialog hit area) — horizontal resize now works (AC2)

Cross-scope note: files are Settings-owned; trivial 1-line change per file, PM-assigned ticket.

## Test plan

- [ ] Open help modal — content not clipped on Overview, Shortcuts, Methods, SBOM tabs
- [ ] Drag right edge of modal → width increases
- [ ] Drag SE corner → both dimensions resize
- [ ] Drag bottom edge → height increases
- [ ] Modal still drags by title bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)
