### PR TITLE
feat(server): AI Call Log — capture TS-originated AI calls (t/3245)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/aiCallLog.test.ts
+++ b/taxonomy-editor/src/server/__tests__/aiCallLog.test.ts
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3245 — TS-originated AI Call Log writer. Verifies the SCHEMA CONTRACT (t/3245#3) the PS reader
+// (Get-AICallLog) parses: 7 named fields, correct types, ISO-8601 Datetime, PromptStart≤160, plus the
+// flag-off no-op, advisory monotonic ID, and the atomic single-line append (sub-PIPE_BUF, newline-terminated).
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { writeAICallLogEntry, isAICallLogEnabled, type AICallLogEntry } from '../ai/aiCallLog.js';
+
+const SCHEMA_FIELDS = ['ID', 'Datetime', 'Scenario', 'PromptID', 'PromptStart', 'RetryCount', 'Status'];
+
+const sample: AICallLogEntry = {
+  scenario: 'Debate', promptId: 'usage.debate.turn', promptStart: 'Argue the accelerationist case',
+  retryCount: 0, status: '200',
+};
+
+let tmpDir: string;
+let logPath: string;
+const priorFlag = process.env.AI_CALL_LOG_ENABLED;
+
+function readLines(): string[] {
+  return fs.readFileSync(logPath, 'utf8').split('\n').filter(l => l.length > 0);
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aicalllog-'));
+  logPath = path.join(tmpDir, 'ai-call-log.jsonl');
+});
+
+afterEach(() => {
+  if (priorFlag === undefined) delete process.env.AI_CALL_LOG_ENABLED;
+  else process.env.AI_CALL_LOG_ENABLED = priorFlag;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('isAICallLogEnabled', () => {
+  it('is true only for truthy tokens (1|true|yes|on, case-insensitive), default off', () => {
+    for (const v of ['1', 'true', 'TRUE', 'yes', 'On']) {
+      process.env.AI_CALL_LOG_ENABLED = v;
+      expect(isAICallLogEnabled(), `"${v}" should enable`).toBe(true);
+    }
+    for (const v of ['0', 'false', 'no', 'off', '', '  ', 'enabled']) {
+      process.env.AI_CALL_LOG_ENABLED = v;
+      expect(isAICallLogEnabled(), `"${v}" should NOT enable`).toBe(false);
+    }
+    delete process.env.AI_CALL_LOG_ENABLED;
+    expect(isAICallLogEnabled(), 'unset → off').toBe(false);
+  });
+});
+
+describe('writeAICallLogEntry', () => {
+  it('flag off → no-op, writes nothing', () => {
+    delete process.env.AI_CALL_LOG_ENABLED;
+    writeAICallLogEntry(sample, logPath);
+    expect(fs.existsSync(logPath)).toBe(false);
+  });
+
+  it('flag on → one JSONL record with the 7 schema fields in order and correct types', () => {
+    process.env.AI_CALL_LOG_ENABLED = '1';
+    writeAICallLogEntry(sample, logPath);
+    const lines = readLines();
+    expect(lines).toHaveLength(1);
+
+    const rec = JSON.parse(lines[0]);
+    expect(Object.keys(rec)).toEqual(SCHEMA_FIELDS); // insertion order == schema order
+    expect(typeof rec.ID).toBe('number');
+    expect(typeof rec.Datetime).toBe('string');
+    expect(typeof rec.Scenario).toBe('string');
+    expect(typeof rec.PromptID).toBe('string');
+    expect(typeof rec.PromptStart).toBe('string');
+    expect(typeof rec.RetryCount).toBe('number');
+    expect(typeof rec.Status).toBe('string');
+    expect(rec.Scenario).toBe('Debate');
+    expect(rec.PromptID).toBe('usage.debate.turn');
+    expect(rec.Status).toBe('200');
+  });
+
+  it('Datetime is ISO-8601 UTC and round-trip parseable (PS TryParse(RoundtripKind))', () => {
+    process.env.AI_CALL_LOG_ENABLED = 'true';
+    writeAICallLogEntry(sample, logPath);
+    const { Datetime } = JSON.parse(readLines()[0]);
+    expect(Datetime).toMatch(/Z$/);
+    expect(Number.isNaN(Date.parse(Datetime))).toBe(false);
+  });
+
+  it('PromptStart is truncated to 160 chars', () => {
+    process.env.AI_CALL_LOG_ENABLED = '1';
+    writeAICallLogEntry({ ...sample, promptStart: 'x'.repeat(300) }, logPath);
+    const { PromptStart } = JSON.parse(readLines()[0]);
+    expect(PromptStart).toHaveLength(160);
+  });
+
+  it('ID is advisory-monotonic within the file (1,2,3), restarting at 1 on a fresh file', () => {
+    process.env.AI_CALL_LOG_ENABLED = 'on';
+    writeAICallLogEntry(sample, logPath);
+    writeAICallLogEntry(sample, logPath);
+    writeAICallLogEntry(sample, logPath);
+    expect(readLines().map(l => JSON.parse(l).ID)).toEqual([1, 2, 3]);
+  });
+
+  it('each line is an atomic-append candidate: sub-PIPE_BUF and newline-terminated', () => {
+    process.env.AI_CALL_LOG_ENABLED = '1';
+    writeAICallLogEntry({ ...sample, promptStart: 'y'.repeat(300) }, logPath); // largest realistic record
+    writeAICallLogEntry(sample, logPath);
+    const raw = fs.readFileSync(logPath, 'utf8');
+    expect(raw.endsWith('\n')).toBe(true);
+    for (const line of raw.split('\n').filter(l => l.length > 0)) {
+      expect(Buffer.byteLength(line + '\n', 'utf8')).toBeLessThan(4096); // PIPE_BUF floor
+    }
+  });
+
+  it('an IO error is swallowed (fail-safe) — never throws', () => {
+    process.env.AI_CALL_LOG_ENABLED = '1';
+    // Point at a path whose parent is a FILE, so mkdir/open fails; the write must not throw.
+    const filePath = path.join(tmpDir, 'not-a-dir');
+    fs.writeFileSync(filePath, 'x');
+    const badPath = path.join(filePath, 'nested', 'ai-call-log.jsonl');
+    expect(() => writeAICallLogEntry(sample, badPath)).not.toThrow();
+  });
+});

--- a/taxonomy-editor/src/server/ai/aiBackends.ts
+++ b/taxonomy-editor/src/server/ai/aiBackends.ts
@@ -17,6 +17,7 @@ import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 
 const require = createRequire(import.meta.url);
 import { getApiKey, getApiKeys, getProjectRoot, EMBED_SCRIPT, resolveDataPath, isEmbeddingWorkerOffloadEnabled, type AIBackend } from '../config.js';
+import { writeAICallLogEntry, isAICallLogEnabled } from './aiCallLog.js';
 import { ActionableError } from '../../../../lib/debate/errors.js';
 import { parseJsonRobust } from '../../../../lib/debate/helpers.js';
 import { extractProviderReason, deriveKeyErrorMessage } from './providerErrors.js';
@@ -496,6 +497,18 @@ export async function generateTextWithSearch(
 
 // ── UsageID wrappers (t/1262) ──
 
+/** t/3245: classify a generateText failure into an AI-call-log Status string — the HTTP/API status when
+ *  the error carries one, else a coarse aborted/timeout/error class. Never throws (used on a catch path). */
+function deriveCallLogStatus(err: unknown): string {
+  const e = err as { statusCode?: number; status?: number; name?: string; message?: string };
+  const code = e?.statusCode ?? e?.status;
+  if (typeof code === 'number' && Number.isFinite(code)) return String(code);
+  const msg = (e?.message ?? '').toLowerCase();
+  if (e?.name === 'AbortError' || msg.includes('abort')) return 'aborted';
+  if (msg.includes('timeout') || msg.includes('timed out')) return 'timeout';
+  return 'error';
+}
+
 /**
  * Resolve AI call parameters from the UsageID registry, then delegate to
  * generateText(). Tier-based model overrides and key rotation are preserved —
@@ -523,7 +536,22 @@ export async function generateTextByUsage(
     data: { usageId, model: merged.model, hasOverrides: !!overrides, valueKeys: Object.keys(values) },
   });
 
-  return generateText(prompt, merged.model, onRetry, merged.timeoutMs, explicitApiKey, { temperature: merged.temperature, signal });
+  // t/3245: AI Call Log capture (TS side of t/3242's PS hook). Logs ONE record per call with the final
+  // status + total retry count — PS logs per-attempt, a documented granularity divergence (t/3245 PR).
+  // Flag off → the onRetry wrap and the write are both skipped (zero overhead). Scenario defaults to
+  // usageId, mirroring the PS -Scenario default.
+  if (!isAICallLogEnabled()) {
+    return generateText(prompt, merged.model, onRetry, merged.timeoutMs, explicitApiKey, { temperature: merged.temperature, signal });
+  }
+  let retryCount = 0;
+  const countingOnRetry = (p: GenerateTextProgress): void => { retryCount++; onRetry?.(p); };
+  // .then(onFulfilled, onRejected), not try/catch: the audit write is a settle-time side effect and the
+  // error is re-thrown UNCHANGED. generateText already records its own failures, so this wrapper must not
+  // double-record — the error propagates to the existing recorder (ADR-003: no swallow).
+  return await generateText(prompt, merged.model, countingOnRetry, merged.timeoutMs, explicitApiKey, { temperature: merged.temperature, signal }).then(
+    (result) => { writeAICallLogEntry({ scenario: usageId, promptId: usageId, promptStart: prompt, retryCount, status: '200' }); return result; },
+    (err: unknown) => { writeAICallLogEntry({ scenario: usageId, promptId: usageId, promptStart: prompt, retryCount, status: deriveCallLogStatus(err) }); throw err; },
+  );
 }
 
 /**
@@ -552,7 +580,15 @@ export async function generateTextWithSearchByUsage(
     data: { usageId, model: merged.model, hasOverrides: !!overrides, valueKeys: Object.keys(values) },
   });
 
-  return generateTextWithSearch(prompt, merged.model, explicitApiKey);
+  // t/3245: AI Call Log capture. generateTextWithSearch exposes no retry callback → RetryCount 0. Same
+  // .then(onFulfilled, onRejected) settle-side-effect pattern as generateTextByUsage (no double-record).
+  if (!isAICallLogEnabled()) {
+    return generateTextWithSearch(prompt, merged.model, explicitApiKey);
+  }
+  return await generateTextWithSearch(prompt, merged.model, explicitApiKey).then(
+    (result) => { writeAICallLogEntry({ scenario: usageId, promptId: usageId, promptStart: prompt, retryCount: 0, status: '200' }); return result; },
+    (err: unknown) => { writeAICallLogEntry({ scenario: usageId, promptId: usageId, promptStart: prompt, retryCount: 0, status: deriveCallLogStatus(err) }); throw err; },
+  );
 }
 
 // ── Embeddings ──

--- a/taxonomy-editor/src/server/ai/aiCallLog.ts
+++ b/taxonomy-editor/src/server/ai/aiCallLog.ts
@@ -73,14 +73,15 @@ export function getAICallLogPath(): string {
  * the same value; that's acceptable, no reader joins on ID. A missing/unparseable tail restarts at 1.
  */
 function nextAdvisoryId(logPath: string): number {
-  if (!fs.existsSync(logPath)) return 1; // fresh/rotated file — normal, not an error path
+  // Race-free (no existsSync/statSync check-then-open TOCTOU, js/file-system-race): open the fd FIRST —
+  // a fresh/rotated file throws ENOENT, handled silently below — then fstat/read on that same fd only.
   let fd: number | null = null;
   try {
-    const size = fs.statSync(logPath).size;
+    fd = fs.openSync(logPath, 'r');
+    const size = fs.fstatSync(fd).size;
     if (size === 0) return 1;
     const readLen = Math.min(size, TAIL_READ_BYTES);
     const buf = Buffer.alloc(readLen);
-    fd = fs.openSync(logPath, 'r');
     fs.readSync(fd, buf, 0, readLen, size - readLen);
     const lastLine = buf.toString('utf8').trimEnd().split('\n').pop();
     if (!lastLine) return 1;
@@ -88,6 +89,7 @@ function nextAdvisoryId(logPath: string): number {
     const prevId = typeof prev.ID === 'number' ? prev.ID : Number(prev.ID);
     return Number.isFinite(prevId) ? prevId + 1 : 1;
   } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return 1; // fresh/rotated file — normal, silent
     // Fallback-path logging: an unreadable/corrupt tail shouldn't wedge the counter — restart at 1 + record why.
     getGlobalRecorder()?.record({
       type: 'system.error', component: 'ai-call-log', level: 'warn',
@@ -112,8 +114,9 @@ export function writeAICallLogEntry(entry: AICallLogEntry, pathOverride?: string
   const logPath = pathOverride ?? getAICallLogPath();
   let fd: number | null = null;
   try {
+    // recursive mkdir is idempotent (no-op if the dir exists) — no existsSync check-then-create race.
     const dir = path.dirname(logPath);
-    if (dir && !fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    if (dir) fs.mkdirSync(dir, { recursive: true });
 
     const promptStart = entry.promptStart.length > PROMPT_START_MAX
       ? entry.promptStart.slice(0, PROMPT_START_MAX)
@@ -142,7 +145,12 @@ export function writeAICallLogEntry(entry: AICallLogEntry, pathOverride?: string
       });
     }
     fd = fs.openSync(logPath, 'a'); // 'a' → O_APPEND on POSIX
-    fs.writeSync(fd, line);
+    // js/http-to-file-access: writing request-derived data (PromptStart) to the audit log is the
+    // TL-approved feature itself (t/3245#3) — the PS writer does the identical thing. Injection is
+    // prevented: the whole record is one JSON.stringify line (escapes newlines/control chars, so a
+    // crafted prompt cannot forge a second JSONL line), PromptStart is truncated to 160 chars, and the
+    // path is a fixed constant (getAICallLogPath), never derived from the data. No harm sink remains.
+    fs.writeSync(fd, line); // codeql[js/http-to-file-access]
   } catch (err) {
     // Fail-safe (t/3235#1, Fallback-Path Logging): audit logging must never break the call it audits.
     getGlobalRecorder()?.record({

--- a/taxonomy-editor/src/server/ai/aiCallLog.ts
+++ b/taxonomy-editor/src/server/ai/aiCallLog.ts
@@ -1,0 +1,156 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// AI Call Log — TS-originated capture (t/3245; epic t/3235, core t/3241, TL ruling t/3245#3).
+//
+// The TS counterpart to the PowerShell writer (scripts/AITriad/Private/AICallLog.ps1). It appends
+// TS-originated AI calls to the SAME append-only `ai-call-log.jsonl` under the resolved data root, so
+// Get-/Show-AICallLog read a UNIFIED PS+TS log. Per TL ruling t/3245#3 the interface is a SCHEMA
+// CONTRACT (field names + types), NOT byte-identity with PS `ConvertTo-Json` — the PS reader already
+// parses each line as JSON and reads fields by property presence (Get-AICallLog), so JS `JSON.stringify`
+// output conforms as long as the 7 field names + types match. Datetime is ISO-8601 ('Z'), which the PS
+// reader parses via TryParse(RoundtripKind) regardless of fractional-second precision.
+//
+// Record schema (7 fields, in order): ID, Datetime, Scenario, PromptID, PromptStart, RetryCount, Status.
+//
+// Two TL conditions (t/3245#3):
+//  1. Schema contract, not serializer-mimicry (above).
+//  2. ID is ADVISORY (no reader joins on it) → no cross-process uniqueness coordination. The real
+//     integrity guarantee is ATOMIC SINGLE-LINE APPEND: one O_APPEND write per record, record < PIPE_BUF,
+//     so a concurrent PS append and a TS append can never interleave a line. Every field is bounded
+//     (PromptStart ≤160), so a record is always well under PIPE_BUF (4096 on Linux).
+//
+// Fail-safe (mirrors the PS writer): an IO error is recorded as a WARN and swallowed — enabling the
+// audit log must NEVER break the AI call it audits.
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { getDataRoot } from '../config.js';
+import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
+
+/** Conservative PIPE_BUF floor (Linux = 4096; POSIX minimum = 512). A single write() of a buffer
+ *  below this to an O_APPEND fd is atomic, so concurrent PS+TS appends can't interleave a line. */
+const PIPE_BUF = 4096;
+
+/** Max PromptStart length — matches the PS writer's 160-char truncation (schema of record). */
+const PROMPT_START_MAX = 160;
+
+/** Bytes read from the file tail to derive the next advisory ID (avoids reading the whole log). */
+const TAIL_READ_BYTES = 8192;
+
+export interface AICallLogEntry {
+  /** Caller tag (e.g. a UsageID, or Debate/Chat/Fact Check/Logical Form). Never blank in practice. */
+  scenario: string;
+  /** UsageID from ai-usages.json, or '' when absent. */
+  promptId: string;
+  /** The rendered prompt; truncated to the first 160 chars on write. */
+  promptStart: string;
+  /** 0 on the first attempt, N for the Nth retry. */
+  retryCount: number;
+  /** HTTP/API status (e.g. '200', '429', '500', 'timeout', 'error'). */
+  status: string;
+}
+
+/**
+ * Is the AI call log enabled? True iff `AI_CALL_LOG_ENABLED` is truthy (1|true|yes|on, case-insensitive).
+ * Default OFF — unset/empty/anything-else → false, so the capture hook is a single early-return with
+ * zero overhead. Mirrors the PS `Test-AICallLogEnabled` contract exactly.
+ */
+export function isAICallLogEnabled(): boolean {
+  const v = process.env.AI_CALL_LOG_ENABLED;
+  return !!v && /^(1|true|yes|on)$/i.test(v.trim());
+}
+
+/** Absolute path to `ai-call-log.jsonl` under the resolved data root — the SAME file the PS writer
+ *  targets (`Get-DataRoot` ⟷ `getDataRoot()`). Parent dir is created lazily on first append. */
+export function getAICallLogPath(): string {
+  return path.join(getDataRoot(), 'ai-call-log.jsonl');
+}
+
+/**
+ * Next advisory record ID: last record's ID + 1, else 1 (mirrors PS `Get-AICallLogNextId`). Reads only
+ * the file's tail (not the whole log). ID is ADVISORY (t/3245#3) — a concurrent PS/TS append may race to
+ * the same value; that's acceptable, no reader joins on ID. A missing/unparseable tail restarts at 1.
+ */
+function nextAdvisoryId(logPath: string): number {
+  if (!fs.existsSync(logPath)) return 1; // fresh/rotated file — normal, not an error path
+  let fd: number | null = null;
+  try {
+    const size = fs.statSync(logPath).size;
+    if (size === 0) return 1;
+    const readLen = Math.min(size, TAIL_READ_BYTES);
+    const buf = Buffer.alloc(readLen);
+    fd = fs.openSync(logPath, 'r');
+    fs.readSync(fd, buf, 0, readLen, size - readLen);
+    const lastLine = buf.toString('utf8').trimEnd().split('\n').pop();
+    if (!lastLine) return 1;
+    const prev = JSON.parse(lastLine) as { ID?: unknown };
+    const prevId = typeof prev.ID === 'number' ? prev.ID : Number(prev.ID);
+    return Number.isFinite(prevId) ? prevId + 1 : 1;
+  } catch (err) {
+    // Fallback-path logging: an unreadable/corrupt tail shouldn't wedge the counter — restart at 1 + record why.
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'ai-call-log', level: 'warn',
+      message: 'AI call-log: could not read last-line ID — restarting advisory ID at 1',
+      data: { logPath, error: err instanceof Error ? err.message : String(err) },
+    });
+    return 1;
+  } finally {
+    if (fd !== null) { try { fs.closeSync(fd); } catch { /* silent by design — fd already released, nothing to record */ } }
+  }
+}
+
+/**
+ * Append one 7-field JSONL record to the AI call log — a no-op when the flag is off.
+ *
+ * @param entry  the call metadata (scenario/promptId/promptStart/retryCount/status).
+ * @param pathOverride  test/fixture override for the log path (never touches the real data root).
+ */
+export function writeAICallLogEntry(entry: AICallLogEntry, pathOverride?: string): void {
+  if (!isAICallLogEnabled()) return; // default-off: single early-return, zero overhead
+
+  const logPath = pathOverride ?? getAICallLogPath();
+  let fd: number | null = null;
+  try {
+    const dir = path.dirname(logPath);
+    if (dir && !fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+
+    const promptStart = entry.promptStart.length > PROMPT_START_MAX
+      ? entry.promptStart.slice(0, PROMPT_START_MAX)
+      : entry.promptStart;
+
+    // Build in schema order (JS preserves string-key insertion order → JSONL field order matches PS).
+    const record = {
+      ID: nextAdvisoryId(logPath),
+      Datetime: new Date().toISOString(), // ISO-8601 'Z' — PS reader parses via TryParse(RoundtripKind)
+      Scenario: entry.scenario,
+      PromptID: entry.promptId,
+      PromptStart: promptStart,
+      RetryCount: entry.retryCount,
+      Status: entry.status,
+    };
+
+    // Atomic single-line append (t/3245#3 condition 2): one O_APPEND write of a sub-PIPE_BUF buffer so a
+    // concurrent PS append can't interleave. Bounded fields keep the record well under PIPE_BUF; if a
+    // pathological record ever exceeded it we still write (best-effort) but note the lost guarantee.
+    const line = Buffer.from(JSON.stringify(record) + '\n', 'utf8');
+    if (line.length >= PIPE_BUF) {
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'ai-call-log', level: 'warn',
+        message: 'AI call-log record exceeds PIPE_BUF — atomic-append guarantee not held for this line',
+        data: { bytes: line.length, pipeBuf: PIPE_BUF, scenario: entry.scenario },
+      });
+    }
+    fd = fs.openSync(logPath, 'a'); // 'a' → O_APPEND on POSIX
+    fs.writeSync(fd, line);
+  } catch (err) {
+    // Fail-safe (t/3235#1, Fallback-Path Logging): audit logging must never break the call it audits.
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'ai-call-log', level: 'warn',
+      message: 'AI call-log append failed — continuing (audit log is non-fatal)',
+      data: { logPath, error: err instanceof Error ? err.message : String(err) },
+    });
+  } finally {
+    if (fd !== null) { try { fs.closeSync(fd); } catch { /* silent by design — fd already released, nothing to record */ } }
+  }
+}


### PR DESCRIPTION
## What
TS counterpart to the PowerShell AI Call Log writer (t/3241/t/3242). New `ai/aiCallLog.ts` appends TS-originated AI calls to the SAME `ai-call-log.jsonl` under the resolved data root (`getDataRoot()` ⟷ PS `Get-DataRoot`), behind the same `AI_CALL_LOG_ENABLED` flag (default off, zero overhead). Hooked at `generateTextByUsage` / `generateTextWithSearchByUsage` in `aiBackends.ts`.

## Per TL ruling (t/3245#3)
1. **Schema contract, not byte-mimicry.** Emits the 7 named fields (ID, Datetime, Scenario, PromptID, PromptStart, RetryCount, Status) via `JSON.stringify`. The PS reader `Get-AICallLog` already parses **by schema** (property presence + `TryParse(RoundtripKind)`), so JS output conforms — verified. Datetime = `toISOString()` (ISO-8601 'Z').
2. **ID advisory + atomic append.** No reader joins on ID; the integrity guarantee is an **atomic single-line append** (one `O_APPEND` write per record, record < PIPE_BUF). Bounded fields (PromptStart ≤160) keep records well under PIPE_BUF (4096).
3. **Fail-safe:** IO errors are recorded (WARN) and swallowed — audit logging never breaks the call it audits.

Capture uses `.then(onFulfilled, onRejected)` (not a swallowing catch): the error re-throws unchanged and `generateText` already records its own failures (no double-record).

## Documented divergence
TS logs **one record per call** (final status + total retries); PS logs **per-attempt**. Acceptable — no reader joins on that.

## Verification
- `npx vitest run src/server/__tests__/aiCallLog.test.ts` → **8 passed** (flag-off no-op, 7-field schema order+types, ISO Datetime, PromptStart≤160, advisory-monotonic ID, sub-PIPE_BUF newline-terminated, fail-safe no-throw)
- `npx eslint` → clean (ADR-003 satisfied)
- tsc: my files clean (3 pre-existing `../lib` module-resolution errors, unrelated)

## Gate — DRAFT until PS sign-off
Self-cert against t/3241's schema (TL t/3245#3). **Held draft pending PowerShell sign-off** that Get-/Show-AICallLog tolerate TS-written records (they do — both parse by schema; Show delegates to Get-AICallLog) + documenting the 7-field schema in t/3241. Un-draft on PS confirmation.

Relates t/3235, t/3241, t/3242. Closes t/3245 on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)