### PR TITLE
feat(entities): canonical logical_form Zod schema — one definition for claim + node frames (t/3250)

### DIFF
--- a/lib/entities/logicalForm.test.ts
+++ b/lib/entities/logicalForm.test.ts
@@ -1,0 +1,135 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Definition-level tests for the canonical logical_form schema (t/3250). Both arms:
+// the doc's canonical example PARSES; every closed vocabulary REJECTS an out-of-vocab value;
+// required-field omission rejects (schema doc rule 4 "an absent field is a formalization bug");
+// modality:null (factual) is accepted; passthrough forgives additive unknown keys. The
+// bidirectional type-equality guards are compile-time (they fail `tsc`, not vitest) — a note
+// documents that so a future reader knows drift is caught at build, not here.
+import { describe, it, expect } from 'vitest';
+import { logicalFormSchema, type LogicalForm } from './logicalForm.js';
+
+// The canonical example from research/comp-linguist/docs/logical-form-schema.md §Schema, verbatim.
+const CANONICAL: LogicalForm = {
+  predicate: 'acquire',
+  event_ref: 'e1',
+  args: [
+    { role: 'agent', ref: 'ent-034', sort: 'agentive-physical-object', match_level: 'exact' },
+    { role: 'patient', ref: 'ent-055', sort: 'non-agentive-functional-artifact', match_level: 'exact' },
+  ],
+  polarity: 'positive',
+  modality: { holder: 'camp:acc', attitude: 'belief' },
+  temporal: { type: 'at', value: '2025-02' },
+  about: [{ ref: 'ent-055', match_level: 'exact' }],
+  formalization_confidence: 0.85,
+  status: 'proposed',
+};
+
+describe('logicalFormSchema — valid arm', () => {
+  it('parses the canonical doc example', () => {
+    const r = logicalFormSchema.safeParse(CANONICAL);
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts modality: null (factual_claims — unattributed fact)', () => {
+    const r = logicalFormSchema.safeParse({ ...CANONICAL, modality: null });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts temporal.value: null when type is unspecified', () => {
+    const r = logicalFormSchema.safeParse({
+      ...CANONICAL,
+      temporal: { type: 'unspecified', value: null },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts an omitted about[] (additive/optional)', () => {
+    const { about: _drop, ...noAbout } = CANONICAL;
+    const r = logicalFormSchema.safeParse(noAbout);
+    expect(r.success).toBe(true);
+  });
+
+  it('passthrough: forgives an additive unknown key (forward-compat)', () => {
+    const r = logicalFormSchema.safeParse({ ...CANONICAL, some_future_field: 42 });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('logicalFormSchema — reject arm (closed vocabularies strictly validated)', () => {
+  it('rejects an out-of-vocab args[].role', () => {
+    const r = logicalFormSchema.safeParse({
+      ...CANONICAL,
+      args: [{ role: 'experiencer', ref: 'ent-034', sort: 'agentive-physical-object', match_level: 'exact' }],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects an out-of-vocab args[].sort (DolceCategory)', () => {
+    const r = logicalFormSchema.safeParse({
+      ...CANONICAL,
+      args: [{ role: 'agent', ref: 'ent-034', sort: 'physical-object', match_level: 'exact' }],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects an out-of-vocab args[].match_level (EntityMatchLevel)', () => {
+    const r = logicalFormSchema.safeParse({
+      ...CANONICAL,
+      args: [{ role: 'agent', ref: 'ent-034', sort: 'agentive-physical-object', match_level: 'fuzzy' }],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects an out-of-vocab polarity', () => {
+    const r = logicalFormSchema.safeParse({ ...CANONICAL, polarity: 'neutral' });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects a bad modality.attitude', () => {
+    const r = logicalFormSchema.safeParse({
+      ...CANONICAL,
+      modality: { holder: 'camp:acc', attitude: 'hope' },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects a bad modality.holder', () => {
+    const r = logicalFormSchema.safeParse({
+      ...CANONICAL,
+      modality: { holder: 'camp:xyz', attitude: 'belief' },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects an out-of-vocab temporal.type', () => {
+    const r = logicalFormSchema.safeParse({
+      ...CANONICAL,
+      temporal: { type: 'whenever', value: '2025-02' },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects an out-of-vocab status (formalization lifecycle)', () => {
+    const r = logicalFormSchema.safeParse({ ...CANONICAL, status: 'linked' });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects a required-field omission (missing predicate — rule 4)', () => {
+    const { predicate: _drop, ...noPredicate } = CANONICAL;
+    const r = logicalFormSchema.safeParse(noPredicate);
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects an omitted (not just null) modality — present-but-nullable, never absent', () => {
+    const { modality: _drop, ...noModality } = CANONICAL;
+    const r = logicalFormSchema.safeParse(noModality);
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects formalization_confidence out of [0,1]', () => {
+    const r = logicalFormSchema.safeParse({ ...CANONICAL, formalization_confidence: 1.5 });
+    expect(r.success).toBe(false);
+  });
+});

--- a/lib/entities/logicalForm.ts
+++ b/lib/entities/logicalForm.ts
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Canonical `logical_form` Zod schema — ONE definition for both claim and node frames
+// (t/3250, from TL G6 t/3162#5). Node-formalization (`formalize_node_lf.py`, Python) and
+// claim-formalization (`Invoke-LogicalFormPass`, PS) are two ports of the same neo-Davidsonian
+// pass; this is the TS embodiment of the shape doc so the four conformance points —
+//   1. the schema DOC  `research/comp-linguist/docs/logical-form-schema.md` (source of record)
+//   2. the PS pass      `scripts/AITriad/Private/LogicalFormPass.ps1`
+//   3. the Python pass  `research/comp-linguist/tools/formalize_node_lf.py`
+//   4. THIS file        (the TS validator, consumed by taxonomy-editor node validation)
+// — cannot silently drift. A formalization change must update all four (see the prompt-port
+// coupling note in the schema doc, CL-owned).
+//
+// Consumed now by `taxonomy-editor` `povNodeSchema` (node frames); a future TS claim-frame
+// validator consumes the SAME definition (TL t/3250#2(3): node-now / claim-when-TS-validates).
+//
+// Field shape mirrors the doc's §Schema exactly. Objects are `.passthrough()` (TL t/3250#2(2)):
+// every DEFINED field is still strictly validated (required-present + enums in-vocab) — that is
+// the win over today's total silence — while additive unknown keys are forgiven for forward-compat
+// (matches the `entityLinkRefSchema` convention). Vocabulary anti-drift lives in the bidirectional
+// type-equality guards below + the coupling doc, NOT in inner-strictness.
+import { z } from 'zod';
+import type { DolceCategory, EntityMatchLevel } from './types.js';
+
+/** Thematic role of an event participant (neo-Davidsonian participation predicate). Closed set;
+ *  extend only with CL sign-off + a register note (schema doc §args[].role). */
+export const lfRoleSchema = z.enum([
+  'agent', 'patient', 'theme', 'recipient', 'instrument',
+  'location', 'source', 'goal', 'beneficiary', 'cause', 'manner',
+]);
+
+// DOLCE-lite sort + match-level value lists are kept LOCAL (so the Zod enums are first-class),
+// then pinned to the `lib/entities/types.ts` types by the bidirectional `Equals` guards at the
+// bottom of this file — `tsc` fails if either list drifts from its type in EITHER direction
+// (TL t/3250#2(1): exact equality, not one-way `satisfies`).
+const DOLCE_CATEGORIES = [
+  'agentive-physical-object', 'non-agentive-functional-artifact',
+  'perdurant', 'normative-description', 'non-agentive-social-object',
+] as const;
+/** The referenced entity's DOLCE-lite sort — copied verbatim from the entity register
+ *  (`dolce_category`), never re-judged per claim (schema doc rule 2). */
+export const lfSortSchema = z.enum(DOLCE_CATEGORIES);
+
+const MATCH_LEVELS = ['exact', 'instance_of', 'subclass', 'superclass', 'related'] as const;
+/** How the ref matched its target relative to the register — copied verbatim from the
+ *  entity_ref; load-bearing for the prover (schema doc §args[].match_level). */
+export const lfMatchLevelSchema = z.enum(MATCH_LEVELS);
+
+/** One event participant. `ref` is an `ent-*` id from the claim's `entity_refs[]`, or a
+ *  `lit:"…"` / event var for an unresolved participant (schema doc rule 1). */
+export const lfArgSchema = z.object({
+  role: lfRoleSchema,
+  ref: z.string(),
+  sort: lfSortSchema,
+  match_level: lfMatchLevelSchema,
+}).passthrough();
+
+/** Topical grounding entry — an `ent-*` id the claim is *about* (schema doc §about[]).
+ *  Superset convention: a topical participant appears in BOTH `args[]` and `about[]`. */
+export const lfAboutSchema = z.object({
+  ref: z.string(),
+  match_level: lfMatchLevelSchema,
+}).passthrough();
+
+/** BDI attribution — present for POV/BDI claims, `null` for `factual_claims` (unattributed
+ *  fact). The whole object is nullable, not its fields (schema doc §modality). */
+export const lfModalitySchema = z.object({
+  holder: z.enum(['camp:acc', 'camp:saf', 'camp:skp']),
+  attitude: z.enum(['belief', 'desire', 'intention']),
+}).passthrough();
+
+/** Event time. `value` is null ⟺ `type: 'unspecified'` (an explicit "no time" reading is
+ *  first-class, never a silent omission — schema doc rule 4). */
+export const lfTemporalSchema = z.object({
+  type: z.enum(['at', 'before', 'after', 'during', 'unspecified']),
+  value: z.string().nullable(),
+}).passthrough();
+
+/**
+ * A neo-Davidsonian event frame on a claim or BDI node. The canonical shape — see
+ * `research/comp-linguist/docs/logical-form-schema.md` for full field semantics and the
+ * reification rules the FOL track (t/3127/t/3128) consumes.
+ *
+ * NOTE: `status` here is the FORMALIZATION lifecycle (`proposed|accepted|rejected`) and is
+ * DELIBERATELY DISTINCT from `EntityLinkStatus` (`linked|proposed`) in `./types.ts` — do not
+ * conflate the two (TL t/3250#2(3)).
+ */
+export const logicalFormSchema = z.object({
+  /** Lemma of the reified event/relation the proposition asserts (lowercase verb/relation lemma). */
+  predicate: z.string(),
+  /** The Davidsonian event variable (`e1`, `e2`, …), unique within the frame. */
+  event_ref: z.string(),
+  /** Event participants (may be empty). */
+  args: z.array(lfArgSchema),
+  /** Negation of the core predication (`¬predicate(e)`), NOT attitude negation. */
+  polarity: z.enum(['positive', 'negative']),
+  /** BDI attribution; `null` for unattributed `factual_claims`. Present (nullable), never absent. */
+  modality: lfModalitySchema.nullable(),
+  /** Event time; `unspecified`/`null` is a valid reading, not an omission. */
+  temporal: lfTemporalSchema,
+  /** Topical index (additive, optional) — the complete set of `ent-*` ids the claim is about. */
+  about: z.array(lfAboutSchema).optional(),
+  /** [0,1] — the pass's self-rated fidelity of the frame to the proposition; the downstream gate lever. */
+  formalization_confidence: z.number().min(0).max(1),
+  /** Formalization lifecycle (see NOTE above — distinct from EntityLinkStatus). */
+  status: z.enum(['proposed', 'accepted', 'rejected']),
+}).passthrough();
+
+/** The canonical logical_form type — inferred from the schema so the runtime validator and the
+ *  static type can never diverge. */
+export type LogicalForm = z.infer<typeof logicalFormSchema>;
+
+// ── Bidirectional anti-drift guards (TL t/3250#2(1)) ─────────────────────────────────────────
+// Exact type-equality: fails `tsc` if the Zod enum and the `types.ts` type diverge in EITHER
+// direction (a one-way `satisfies` would miss `types.ts` gaining a member the enum lacks). These
+// are compile-time only — erased at runtime.
+type Equals<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+type Assert<T extends true> = T;
+
+// If either line errors, a closed vocabulary drifted from its `lib/entities/types.ts` type —
+// reconcile this file with types.ts (and the schema doc) before shipping.
+export type _AssertSortMatchesDolceCategory =
+  Assert<Equals<z.infer<typeof lfSortSchema>, DolceCategory>>;
+export type _AssertMatchLevelMatchesEntityMatchLevel =
+  Assert<Equals<z.infer<typeof lfMatchLevelSchema>, EntityMatchLevel>>;


### PR DESCRIPTION
Canonical `logical_form` Zod schema — the single TS source of truth for both claim and node frames (t/3250, from TL G6 ruling t/3162#5). Node-formalization (`formalize_node_lf.py`, Python) and claim-formalization (`Invoke-LogicalFormPass`, PS) are two ports of the same neo-Davidsonian pass; this lands the one definition so they can't silently drift.

## What
- **`lib/entities/logicalForm.ts`** — `logicalFormSchema` (+ `lfArg`/`lfAbout`/`lfModality`/`lfTemporal` sub-schemas), mirroring `research/comp-linguist/docs/logical-form-schema.md` §Schema exactly.
- **`lib/entities/logicalForm.test.ts`** — 16 tests, both arms.

## Per TL design GV (t/3250#2)
- **Passthrough-inner** objects: every *defined* field is strictly validated (required-present, enums in-vocab) — the win over today's silent `.passthrough()` acceptance — while additive unknown keys are forgiven for fwd-compat (matches the existing `entityLinkRefSchema` convention).
- **Bidirectional `Equals` guards** pin `lfSort`/`lfMatchLevel` to `lib/entities/types.ts` `DolceCategory`/`EntityMatchLevel` — `tsc` fails on drift in **either** direction (not a one-way `satisfies`).
- **`status`** (`proposed|accepted|rejected`) kept **distinct** from `EntityLinkStatus` (`linked|proposed`).

## Verify
16/16 tests pass (taxonomy-editor vitest) · `entities/` tsc errors = 0 (guards compile) · eslint 0. (Standalone lib `tsc` shows only pre-existing `electron-shared/` react/electron-type noise — a worktree install artifact absent in CI's full install; unrelated to this change.)

## Scope / follow-ups
- This is the Shared Lib half. The `povNodeSchema` change (replace silent passthrough with `logical_form: logicalFormSchema.optional()`, plus a **graceful-degrade `safeParse`** so a malformed proposed frame WARNs + omits the field instead of dropping the node — TL hard condition) routes to **Rosetta Stone** with the exact diff.
- `entityLinkRef`/`conceptLinkRef` hand-mirror migration filed as **t/3253**.
- CL owns the prompt-port coupling doc (ties doc + PS + Python + this Zod).

Closes the Shared Lib portion of t/3250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
