### PR TITLE
fix(ai-call-log): Get-AICallLog preserves Datetime sub-seconds + Utc kind (t/3245)

### DIFF
--- a/scripts/AITriad/Public/Get-AICallLog.ps1
+++ b/scripts/AITriad/Public/Get-AICallLog.ps1
@@ -109,14 +109,27 @@ function Get-AICallLog {
         # A missing/unparseable Datetime yields [datetime]::MinValue (never matches a real range).
         $dt = [datetime]::MinValue
         if ($rec.PSObject.Properties['Datetime'] -and -not [string]::IsNullOrWhiteSpace([string]$rec.Datetime)) {
-            $parsed = [datetime]::MinValue
-            if ([datetime]::TryParse(
-                    [string]$rec.Datetime, [cultureinfo]::InvariantCulture,
-                    [System.Globalization.DateTimeStyles]::RoundtripKind, [ref]$parsed)) {
-                $dt = $parsed
+            if ($rec.Datetime -is [datetime]) {
+                # ConvertFrom-Json already parsed the ISO-8601 string to a DateTime (Kind=Utc for a
+                # 'Z' suffix), preserving sub-seconds. Use it DIRECTLY. Re-stringifying + re-parsing
+                # (the old path) rendered default-culture text with no fractional seconds and
+                # downgraded Kind Utc->Unspecified — dropping ms for BOTH JS 3-digit and PS 7-digit
+                # records, and shifting -After/-Before on non-UTC hosts (ToUniversalTime treats
+                # Unspecified as local). See t/3245.
+                $dt = $rec.Datetime
             }
             else {
-                Write-Warning "Get-AICallLog: line $lineNo has an unparseable Datetime '$($rec.Datetime)' in '$logPath'; treating as MinValue."
+                # Fallback: a Datetime value ConvertFrom-Json did NOT coerce (non-ISO / unusual
+                # form) — parse the raw string, round-trip-kind aware.
+                $parsed = [datetime]::MinValue
+                if ([datetime]::TryParse(
+                        [string]$rec.Datetime, [cultureinfo]::InvariantCulture,
+                        [System.Globalization.DateTimeStyles]::RoundtripKind, [ref]$parsed)) {
+                    $dt = $parsed
+                }
+                else {
+                    Write-Warning "Get-AICallLog: line $lineNo has an unparseable Datetime '$($rec.Datetime)' in '$logPath'; treating as MinValue."
+                }
             }
         }
 

--- a/tests/AICallLog.Tests.ps1
+++ b/tests/AICallLog.Tests.ps1
@@ -191,6 +191,31 @@ Describe 'Get-AICallLog (t/3243)' -Tag 'unit' {
         }
     }
 
+    Context 'Datetime fidelity — cross-writer precision + Kind (t/3245)' {
+        # The old reader did [string]$rec.Datetime + TryParse, which dropped sub-seconds and
+        # downgraded Kind Utc->Unspecified (→ -After/-Before shift on non-UTC hosts). The fix uses
+        # the ConvertFrom-Json-coerced [datetime] directly. Guards both JS (3-digit) and PS (7-digit).
+        It 'preserves sub-second precision from a JS 3-digit toISOString Datetime' {
+            $p = Join-Path $TestDrive "js-$([guid]::NewGuid()).jsonl"
+            Set-Content -LiteralPath $p -Encoding utf8 -Value '{"ID":1,"Datetime":"2026-09-03T08:48:00.123Z","Scenario":"Debate","PromptID":"u","PromptStart":"x","RetryCount":0,"Status":"200"}'
+            $r = @(Get-AICallLog -Path $p)
+            $r.Count | Should -Be 1
+            $r[0].Datetime.Millisecond | Should -Be 123
+        }
+        It 'preserves the 7-digit fractional second from a PS-written Datetime' {
+            $p = Join-Path $TestDrive "ps-$([guid]::NewGuid()).jsonl"
+            Set-Content -LiteralPath $p -Encoding utf8 -Value '{"ID":1,"Datetime":"2026-09-03T08:48:00.1234567Z","Scenario":"Chat","PromptID":"u","PromptStart":"x","RetryCount":0,"Status":"200"}'
+            $r = @(Get-AICallLog -Path $p)
+            ($r[0].Datetime.Ticks % 10000000) | Should -Not -Be 0 -Because 'the sub-second (100ns) component must survive'
+        }
+        It 'emits a UTC-kind Datetime (not Unspecified) so -After/-Before do not tz-shift on non-UTC hosts' {
+            $p = Join-Path $TestDrive "kind-$([guid]::NewGuid()).jsonl"
+            Set-Content -LiteralPath $p -Encoding utf8 -Value '{"ID":1,"Datetime":"2026-09-03T08:48:00.123Z","Scenario":"Debate","PromptID":"u","PromptStart":"x","RetryCount":0,"Status":"200"}'
+            $r = @(Get-AICallLog -Path $p)
+            $r[0].Datetime.Kind | Should -Be ([System.DateTimeKind]::Utc)
+        }
+    }
+
     Context 'filters' {
         It 'filters by -Scenario (case-insensitive wildcard)' {
             $r = @(Get-AICallLog -Path $script:log -Scenario 'fact*')


### PR DESCRIPTION
Surfaced during the **t/3245** TS-capture reader sign-off (readers must tolerate JS vs PS Datetime serialization — TL condition t/3245#3 item 1). Fixes a pre-existing bug in **`Get-AICallLog`** (t/3243), writer-agnostic.

## Bug
The reader did `[string]$rec.Datetime` then `TryParse`. But `ConvertFrom-Json` has **already** coerced an ISO-8601 `Z` string to a `[DateTime]` **Kind=Utc, full precision**. The re-stringify rendered default-culture text (`"09/03/2026 08:48:00"`) → **dropped sub-seconds** for both JS 3-digit and PS 7-digit records, and the re-parse **downgraded Kind Utc→Unspecified** → `-After`/`-Before` **shift on a non-UTC host** (`ToUniversalTime` treats Unspecified as local).

## Fix
When `$rec.Datetime` is already `[datetime]` (the ConvertFrom-Json path), use it **directly**; only `TryParse` the string fallback for a value ConvertFrom-Json didn't coerce.

## Tests
New `Datetime fidelity` context in `AICallLog.Tests.ps1`: JS 3-digit ms preserved, PS 7-digit fractional preserved, emitted `Kind=Utc`. Full AICallLog suite **43/43** green.

## Notes
- **Self-cert:** PS-scope bug fix (single reader function + test), no new API/schema.
- PowerShell 2 (owns C/t3243) confirmed no WIP + agreed the diagnosis/fix (p/191#68).
- Unblocks the t/3245 reader-tolerance condition for ServerAPI's TS-writer PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)