### PR TITLE
fix(validation): validate node.logical_form via canonical schema + graceful degrade (t/3250)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore.test.ts
@@ -68,6 +68,7 @@ vi.mock('../utils/validation', () => ({
   conflictFileSchema: { safeParse: vi.fn().mockReturnValue({ success: true }) },
   extractPovErrors: vi.fn().mockReturnValue({}),
   extractConflictErrors: vi.fn().mockReturnValue({}),
+  stripInvalidLogicalForm: vi.fn().mockReturnValue({ removed: false }), // t/3250: loadAll calls this per node
 }));
 
 vi.mock('../utils/similarity', () => ({

--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/taxonomyDataSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/taxonomyDataSlice.ts
@@ -28,6 +28,7 @@ import {
   extractPovErrors,
   extractConflictErrors,
   ValidationErrors,
+  stripInvalidLogicalForm,
 } from '../../../utils/validation';
 import {
   generatePovNodeId,
@@ -258,7 +259,11 @@ export const createTaxonomyDataSlice: StateCreator<TaxonomyStore, [], [], Taxono
       const accFile = acc as PovTaxonomyFile;
       if (accFile?.nodes) {
         for (const node of accFile.nodes) {
-          normalizeNodeProperties(node as unknown as Record<string, unknown>);
+          const rec = node as unknown as Record<string, unknown>;
+          normalizeNodeProperties(rec);
+          // t/3250: graceful-degrade a malformed proposed logical_form (WARN + omit, never drop the node).
+          const lf = stripInvalidLogicalForm(rec);
+          if (lf.removed) getGlobalRecorder()?.record({ type: 'system.error', component: 'taxonomy-store', level: 'warn', message: 'Stripped malformed node.logical_form (t/3250)', data: { pov: 'accelerationist', node_id: rec.id, issue: lf.issue } });
         }
       }
       set({
@@ -304,7 +309,11 @@ export const createTaxonomyDataSlice: StateCreator<TaxonomyStore, [], [], Taxono
       for (const povFile of [saf, skp] as PovTaxonomyFile[]) {
         if (povFile?.nodes) {
           for (const node of povFile.nodes) {
-            normalizeNodeProperties(node as unknown as Record<string, unknown>);
+            const rec = node as unknown as Record<string, unknown>;
+            normalizeNodeProperties(rec);
+            // t/3250: graceful-degrade a malformed proposed logical_form (WARN + omit, never drop the node).
+            const lf = stripInvalidLogicalForm(rec);
+            if (lf.removed) getGlobalRecorder()?.record({ type: 'system.error', component: 'taxonomy-store', level: 'warn', message: 'Stripped malformed node.logical_form (t/3250)', data: { pov: povFile.pov, node_id: rec.id, issue: lf.issue } });
           }
         }
       }

--- a/taxonomy-editor/src/renderer/utils/validation.test.ts
+++ b/taxonomy-editor/src/renderer/utils/validation.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { describe, it, expect } from 'vitest';
-import { povTaxonomyFileSchema, extractPovErrors } from './validation';
+import { povTaxonomyFileSchema, extractPovErrors, stripInvalidLogicalForm } from './validation';
 
 function validNode(overrides: Record<string, unknown> = {}) {
   return {
@@ -212,5 +212,60 @@ describe('extractPovErrors', () => {
       expect(msg).toBeDefined();
       expect(msg.length).toBeGreaterThan(5);
     }
+  });
+});
+
+// t/3250: canonical logical_form is now validated (not silently .passthrough()'d), with a
+// graceful-degrade at load so a malformed *proposed* frame never drops the whole node.
+const validLogicalForm = {
+  predicate: 'resolve',
+  event_ref: 'e1',
+  args: [{ role: 'agent', ref: 'ent-001', sort: 'agentive-physical-object', match_level: 'exact' }],
+  polarity: 'positive',
+  modality: { holder: 'camp:acc', attitude: 'desire' },
+  temporal: { type: 'unspecified', value: null },
+  formalization_confidence: 0.9,
+  status: 'proposed',
+};
+
+describe('povNodeSchema.logical_form (t/3250) — validated, not silently accepted', () => {
+  it('accepts a node carrying a valid logical_form', () => {
+    const result = povTaxonomyFileSchema.safeParse(validFile({ logical_form: validLogicalForm }));
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an out-of-vocab enum (was silently passed through before)', () => {
+    const result = povTaxonomyFileSchema.safeParse(validFile({ logical_form: { ...validLogicalForm, polarity: 'maybe' } }));
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a logical_form missing a required field', () => {
+    const noPredicate = { ...validLogicalForm } as Record<string, unknown>;
+    delete noPredicate.predicate;
+    const result = povTaxonomyFileSchema.safeParse(validFile({ logical_form: noPredicate }));
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('stripInvalidLogicalForm (t/3250) — graceful degrade at load', () => {
+  it('keeps a valid logical_form untouched (removed:false)', () => {
+    const node: Record<string, unknown> = { id: 'acc-desires-001', logical_form: { ...validLogicalForm } };
+    const r = stripInvalidLogicalForm(node);
+    expect(r.removed).toBe(false);
+    expect(node.logical_form).toBeDefined();
+  });
+
+  it('strips a malformed frame + reports the issue, node survives with field omitted (NOT dropped)', () => {
+    const node: Record<string, unknown> = { id: 'acc-desires-002', logical_form: { ...validLogicalForm, status: 'bogus' } };
+    const r = stripInvalidLogicalForm(node);
+    expect(r.removed).toBe(true);
+    expect(r.issue).toBeTruthy();
+    expect(node.logical_form).toBeUndefined(); // field omitted
+    expect(node.id).toBe('acc-desires-002');   // rest of the node intact
+  });
+
+  it('is a no-op when the node has no logical_form', () => {
+    const node: Record<string, unknown> = { id: 'acc-desires-003' };
+    expect(stripInvalidLogicalForm(node).removed).toBe(false);
   });
 });

--- a/taxonomy-editor/src/renderer/utils/validation.ts
+++ b/taxonomy-editor/src/renderer/utils/validation.ts
@@ -3,6 +3,7 @@
 
 import { z } from 'zod';
 import { POV_KEYS } from '@lib/debate/types';
+import { logicalFormSchema } from '@lib/entities/logicalForm';
 
 const categoryEnum = z.enum(['Desires', 'Beliefs', 'Intentions']);
 
@@ -40,6 +41,11 @@ const povNodeSchema = z.object({
   operationality: z.number().int().min(1).max(5).nullish(),
   entity_refs: z.array(entityLinkRefSchema).optional(),   // t/3157 forward grounding
   concept_refs: z.array(conceptLinkRefSchema).optional(), // t/3157 forward grounding
+  // t/3250 (TL G6): the canonical neo-Davidsonian frame, ONE definition shared with the claim path
+  // (`@lib/entities/logicalForm`). Replaces silent `.passthrough()` acceptance — defined fields are
+  // now strictly validated. A malformed frame is degraded gracefully at load (see
+  // stripInvalidLogicalForm), so it never reaches this schema to drop the node.
+  logical_form: logicalFormSchema.optional(),
 }).passthrough();
 
 export const povTaxonomyFileSchema = z.object({
@@ -50,6 +56,26 @@ export const povTaxonomyFileSchema = z.object({
   last_modified: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   nodes: z.array(povNodeSchema),
 });
+
+/**
+ * t/3250 graceful-degrade (TL hard condition, t/3250#2): a malformed *proposed* `logical_form`
+ * must NOT drop the whole node from the editor. Runs a SEPARATED `logicalFormSchema.safeParse` on
+ * the field only; on failure it strips `logical_form` from the node (mutated in place, matching the
+ * load-path normalize convention) so the node still loads, and returns the first issue for the
+ * caller to WARN (fallback-logging rule — observable, not silent). A node with no `logical_form`,
+ * or a valid one, is left untouched. This decouples node loading from frame validation, so one bad
+ * proposed frame can never reject the whole `povNode` (blast-radius + the t/3165 anti-silent lesson).
+ */
+export function stripInvalidLogicalForm(node: Record<string, unknown>): { removed: boolean; issue?: string } {
+  const lf = node.logical_form;
+  if (lf === undefined || lf === null) return { removed: false };
+  const result = logicalFormSchema.safeParse(lf);
+  if (result.success) return { removed: false };
+  delete node.logical_form;
+  const first = result.error.issues[0];
+  const issue = first ? `${first.path.join('.') || '(root)'}: ${first.message}` : 'invalid logical_form';
+  return { removed: true, issue };
+}
 
 const bdiInterpretation = z.object({ belief: z.string().optional(), desire: z.string().optional(), intention: z.string().optional(), summary: z.string().optional() });
 const interpretationField = z.union([z.string(), bdiInterpretation]);


### PR DESCRIPTION
Rosetta half of **t/3250** (TL G6 t/3162#5). Self-cert against TL's approved shape + the graceful-degrade hard condition (t/3250#2); consumes Shared Lib's canonical `@lib/entities/logicalForm` (#1851, now on main).

## Change
- **`validation.ts`**: import `logicalFormSchema`; add `logical_form: logicalFormSchema.optional()` to `povNodeSchema` (outer `.passthrough()` kept) — replaces silent passthrough acceptance with real validation. Export `stripInvalidLogicalForm(node)` doing a **separated `safeParse`** on the field.
- **`taxonomyDataSlice.loadAll`** (the node-read path): per node, on a malformed `logical_form` emit a **WARN** (fallback-logging) and **strip** the field so the node still loads — never a dropped/crashed node (TL hard condition; blast-radius + t/3165 anti-silent-degradation). Sanitizing at load means state never holds an invalid frame, so the save-path parse never trips on it either.

## Spec clarification (flagged to Shared Lib, acked p/10#109)
The degrade lives in **renderer `taxonomyDataSlice`, not server `fileIO.ts`** — the server route (`GET /api/taxonomy/:pov`) returns JSON with **no Zod**; the only `povNodeSchema` enforcement is renderer-side.

## Consequence (flagged)
A malformed *proposed* frame is dropped on the next save (regeneratable by the Python pass; the WARN records it) — consistent with TL's "omit + WARN" intent.

## Tests (both-arms)
- `povNodeSchema.logical_form`: **rejects** an out-of-vocab enum / required-missing frame (validated, not silently accepted); **accepts** a valid one.
- `stripInvalidLogicalForm`: strips a malformed frame (node survives, field omitted) + keeps a valid one + no-op when absent.
- `validation.test.ts` **30/30**, `useTaxonomyStore` **134/134** (added the mock export the load path now calls). eslint 0 errors; renderer-tsc 0 errors in changed files (the 3 `../lib` errors are the known worktree pnpm-hoist artifact, absent in CI).

Closes the Rosetta arm of t/3250 on merge.

Commit: 9c7ae1fb

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>
Co-Authored-By: Main (Shared Lib) <main.lib@ai-triad-research.orca.local>