### PR TITLE
ci(deploy): in-process offload-flag assert gate — WARN-only (t/3247)

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -600,6 +600,52 @@ jobs:
           }
           Write-Host "Config verification passed ($($ConfigChecks.Count) checks)"
 
+      - name: Assert in-process offload flag (WARN-only, t/3247)
+        # Prevention for t/3165. The Verify-Bicep-config step above proves EMBEDDING_WORKER_OFFLOAD
+        # is PRESENT in ACA config; this asserts the RUNNING process EVALUATED it truthy, via
+        # ServerAPI's #1828 boot log (server.ts:1316 -> "embedding offload flag at boot"
+        # {embeddingWorkerOffload:bool}). "Config present" != "flag effective" (t/3165).
+        #
+        # GATE PROMOTION (t/3247 GV cond 1): ships WARN-only (continue-on-error: true) for >=1 green
+        # deploy to CALIBRATE the Log Analytics ingestion-lag retry ceiling below; the flip to
+        # blocking (drop continue-on-error) is a SEPARATE TL GV. Predicate is DOT-SOURCED from
+        # operations/devops/Test-BootFlagEffective.ps1 — the single source its Pester both-arms test
+        # also uses (t/3010 co-location). Cond 2: present+false = 'drift'; absent-after-retry is a
+        # DISTINCT 'boot line not found' diagnostic (ingestion/#1828), NOT drift.
+        if: steps.acceptance.outputs.accepted == 'true' && steps.persona.outputs.accepted == 'true'
+        continue-on-error: true
+        shell: pwsh
+        env:
+          NEW_REVISION: ${{ steps.new_revision.outputs.revision }}
+        run: |
+          . ./operations/devops/Test-BootFlagEffective.ps1
+          $ws = az monitor log-analytics workspace list -g '${{ env.RESOURCE_GROUP }}' --query '[0].customerId' -o tsv
+          if (-not $ws) {
+            Write-Host '::warning::t/3247: no Log Analytics workspace in ${{ env.RESOURCE_GROUP }} — cannot assert in-process flag'
+            exit 0
+          }
+          # Query the NEW revision's boot line only. Bounded retry absorbs LA ingestion lag
+          # (~1-3 min typical). Ceiling deliberately generous in WARN phase — calibrate down from the
+          # observed 'found on attempt N' before the blocking flip (GV cond 1).
+          $q = "ContainerAppConsoleLogs_CL | where RevisionName_s == '$env:NEW_REVISION' | where Log_s has 'embedding offload flag at boot' | project TimeGenerated, Log_s | order by TimeGenerated desc | take 5"
+          $lines = @(); $maxAttempts = 8
+          for ($i = 1; $i -le $maxAttempts; $i++) {
+            $lines = @(az monitor log-analytics query --workspace $ws --analytics-query $q --query '[].Log_s' -o tsv 2>$null | Where-Object { $_ })
+            if ($lines.Count -gt 0) { Write-Host "t/3247: boot line found on attempt $i (~$([int](($i-1)*30))s ingest lag)"; break }
+            if ($i -lt $maxAttempts) { Write-Host "t/3247: boot line not yet ingested (attempt $i/$maxAttempts) — wait 30s"; Start-Sleep -Seconds 30 }
+          }
+          $r = Test-BootFlagEffective -BootLogLines $lines
+          Write-Host "t/3247 in-process flag assert: Status=$($r.Status) Pass=$($r.Pass) — $($r.Detail)"
+          if (-not $r.Pass) {
+            if ($r.Status -eq 'Drift') {
+              Write-Host "::warning::t/3247 CONFIG DRIFT (present in ACA config but process not effective) — $($r.Detail)"
+            } else {
+              Write-Host "::warning::t/3247 BOOT LINE NOT FOUND (ingestion/calibration, NOT drift) — $($r.Detail)"
+            }
+            exit 1   # WARN-only this phase: continue-on-error keeps it non-blocking (visible-yellow)
+          }
+          Write-Host "::notice::t/3247 in-process offload flag EFFECTIVE — $($r.Detail)"
+
       - name: Collect failure diagnostics
         # t/3148: warm_gate is a peer failure trigger — a warm-timeout (warm=='false') collects
         # diagnostics on the same footing as an acceptance/persona failure.

--- a/operations/devops/Test-BootFlagEffective.ps1
+++ b/operations/devops/Test-BootFlagEffective.ps1
@@ -1,0 +1,68 @@
+# Config-drift in-process-flag-assert predicate (t/3247 — prevention for the t/3165 incident).
+#
+# PURE predicate (Guard Testability, t/2971): given the boot-log line(s) for a target revision,
+# decides whether the RUNNING process evaluated EMBEDDING_WORKER_OFFLOAD truthy. The #1793
+# config-drift gate proves the env var is PRESENT in ACA config; this proves the process
+# EVALUATED it — "config present" != "flag effective" (the t/3165 whipsaw hypothesis: a durable
+# rev could mint the env var in a form process.env reads differently than the CLI-flip did).
+#
+# CONTRACT COUPLING (t/3247 GV cond 3) — keys on ServerAPI's #1828 boot line emitted at
+#   taxonomy-editor/src/server/server.ts:1316:
+#     log.server.info({ embeddingWorkerOffload: isEmbeddingWorkerOffloadEnabled() }, 'embedding offload flag at boot')
+#   -> Pino JSON: {..., "embeddingWorkerOffload": true|false, "msg":"embedding offload flag at boot"}
+#   If that emit changes (field name OR message), update BOTH ends (here + server.ts) and the fixture.
+#
+# CO-LOCATION (t/3010 pattern): the deploy-azure.yml gate step AND
+# tests/Test-BootFlagEffective.Tests.ps1 both dot-source THIS file — single source of truth, so
+# the gate and its proof can never diverge.
+
+function Test-BootFlagEffective {
+    [CmdletBinding()]
+    param(
+        # Console-log lines (raw Pino JSON strings) for the target revision. Scans for the #1828
+        # boot line and reads the flag from the LAST such line (restart/scale emits one per replica
+        # — latest wins).
+        [Parameter(Mandatory)][AllowEmptyCollection()][AllowNull()][AllowEmptyString()][string[]]$BootLogLines,
+        [Parameter()][string]$FlagField   = 'embeddingWorkerOffload',
+        [Parameter()][string]$BootMessage = 'embedding offload flag at boot',
+        [Parameter()][bool]$Expected      = $true
+    )
+
+    # Regex extraction (not ConvertFrom-Json): robust to Pino duplicate-key lines and to unrelated
+    # malformed console output the platform may interleave (a JSON parse would throw on those).
+    $pattern = '"' + [regex]::Escape($FlagField) + '"\s*:\s*(true|false)'
+    $last = $null
+    foreach ($line in ($BootLogLines | Where-Object { $_ })) {
+        if ($line -notlike "*$BootMessage*") { continue }   # only the #1828 boot line counts
+        $m = [regex]::Match($line, $pattern)
+        if ($m.Success) { $last = $m.Groups[1].Value }
+    }
+
+    if ($null -eq $last) {
+        # DISTINCT from drift (GV cond 2): the boot line/field was not found. Fail-closed, but the
+        # cause is likely Log Analytics ingestion lag or a changed #1828 emit — NOT a flag regression.
+        return [pscustomobject]@{
+            Status = 'NotFound'
+            Value  = $null
+            Pass   = $false
+            Detail = "boot line not found (field '$FlagField' in msg '$BootMessage') — check Log Analytics ingestion lag or the #1828 emit at server.ts:1316; this is NOT config drift"
+        }
+    }
+
+    $value = ($last -eq 'true')
+    if ($value -eq $Expected) {
+        return [pscustomobject]@{
+            Status = 'Effective'
+            Value  = $value
+            Pass   = $true
+            Detail = "in-process flag effective: $FlagField=$value (expected $Expected)"
+        }
+    }
+
+    return [pscustomobject]@{
+        Status = 'Drift'
+        Value  = $value
+        Pass   = $false
+        Detail = "config drift: EMBEDDING_WORKER_OFFLOAD present in ACA config but the process evaluated $FlagField=$value (expected $Expected) — present != effective (t/3165)"
+    }
+}

--- a/tests/Test-BootFlagEffective.Tests.ps1
+++ b/tests/Test-BootFlagEffective.Tests.ps1
@@ -1,0 +1,69 @@
+# Both-arms proof for the config-drift in-process-flag-assert predicate (t/3247, prevention for
+# t/3165). Dot-sources the SAME predicate file the deploy-azure.yml gate step uses (t/3010
+# co-location — gate and proof cannot diverge).
+#
+# GV cond 3 (couple to #1828 contract): the CLEAN fixture is a REAL boot line captured from Log
+# Analytics (revision taxonomy-editor--deploy-b5f65c3-77580, 2026-09-02). The FALSE/drift fixture
+# is that same line with the flag flipped — so the test breaks if ServerAPI's #1828 emit shape
+# (field name / message) ever changes, forcing a co-update.
+
+BeforeAll {
+    . "$PSScriptRoot/../operations/devops/Test-BootFlagEffective.ps1"
+
+    # REAL #1828 boot line (captured from Log Analytics — do not synthesize this one).
+    $script:RealTrueLine  = '{"level":30,"time":1788377646519,"pid":7,"hostname":"taxonomy-editor--deploy-b5f65c3-77580-64f77fcbb4-n6hkl","component":"server","embeddingWorkerOffload":true,"msg":"embedding offload flag at boot"}'
+    # Same shape, flag evaluated FALSE — the drift regression (present-in-config but ineffective).
+    $script:RealFalseLine = $script:RealTrueLine -replace '"embeddingWorkerOffload":true', '"embeddingWorkerOffload":false'
+}
+
+Describe 'Test-BootFlagEffective — in-process flag assert (t/3247)' {
+
+    It 'CLEAN: real boot line embeddingWorkerOffload=true -> Effective / Pass' {
+        $r = Test-BootFlagEffective -BootLogLines @($script:RealTrueLine)
+        $r.Status | Should -Be 'Effective'
+        $r.Pass   | Should -BeTrue
+        $r.Value  | Should -BeTrue
+    }
+
+    It 'FIRE (drift): embeddingWorkerOffload=false -> Drift / Fail — present but NOT effective' {
+        $r = Test-BootFlagEffective -BootLogLines @($script:RealFalseLine)
+        $r.Status | Should -Be 'Drift'
+        $r.Pass   | Should -BeFalse
+        $r.Value  | Should -BeFalse
+        $r.Detail | Should -Match 'present != effective'
+    }
+
+    It 'FIRE (not-found): no boot lines -> NotFound / Fail, DISTINCT diagnostic (not drift)' {
+        $r = Test-BootFlagEffective -BootLogLines @()
+        $r.Status | Should -Be 'NotFound'
+        $r.Pass   | Should -BeFalse
+        $r.Detail | Should -Match 'ingestion'
+        $r.Detail | Should -Match 'NOT config drift'
+    }
+
+    It 'FIRE (not-found): field present but NOT the #1828 boot message -> NotFound (message-coupled)' {
+        $r = Test-BootFlagEffective -BootLogLines @('{"msg":"some other log","embeddingWorkerOffload":true}')
+        $r.Status | Should -Be 'NotFound'
+    }
+
+    It 'latest-wins: multiple boot lines, last is false -> Drift' {
+        $r = Test-BootFlagEffective -BootLogLines @($script:RealTrueLine, $script:RealFalseLine)
+        $r.Status | Should -Be 'Drift'
+    }
+
+    It 'latest-wins: multiple boot lines, last is true -> Effective' {
+        $r = Test-BootFlagEffective -BootLogLines @($script:RealFalseLine, $script:RealTrueLine)
+        $r.Status | Should -Be 'Effective'
+    }
+
+    It 'symmetry: Expected=$false + false line -> Effective (predicate is generic over expected)' {
+        $r = Test-BootFlagEffective -BootLogLines @($script:RealFalseLine) -Expected $false
+        $r.Status | Should -Be 'Effective'
+        $r.Pass   | Should -BeTrue
+    }
+
+    It 'tolerates a null/empty entry interleaved with the real line' {
+        $r = Test-BootFlagEffective -BootLogLines @($null, '', $script:RealTrueLine)
+        $r.Status | Should -Be 'Effective'
+    }
+}


### PR DESCRIPTION
Prevention for t/3165 (close-out #56). TL GV-approved the design at t/3247#2 with 3 conditions — all met here.

## What
The #1793 config-drift step proves `EMBEDDING_WORKER_OFFLOAD` is **present** in ACA config; this asserts the **running process evaluated it truthy** via ServerAPI #1828''s boot log (`server.ts:1316` → `embedding offload flag at boot {embeddingWorkerOffload:bool}`). "Config present" ≠ "flag effective" — the exact t/3165 whipsaw hypothesis.

- **`operations/devops/Test-BootFlagEffective.ps1`** — pure predicate (Guard Testability, t/2971). Dot-sourced by both the gate step and its Pester test (t/3010 co-location).
- **`tests/Test-BootFlagEffective.Tests.ps1`** — both-arms, **8/8 green** locally.
- **`deploy-azure.yml`** — new WARN-only step after traffic shift.

## TL conditions
1. **Gate promotion:** ships **WARN-only** (`continue-on-error: true`). The flip to blocking is a **separate TL GV** once the LA ingestion-lag retry ceiling is calibrated over ≥1 real deploy (step logs `found on attempt N`).
2. **Absent-line disambiguation:** predicate returns 3 statuses — `Effective` (pass) / `Drift` (present+false → FIRE "config drift") / `NotFound` (absent-after-retry → FIRE but **distinct** "boot line not found — ingestion/#1828", not drift).
3. **#1828 contract coupling:** the CLEAN Pester fixture is a **real captured boot line** (LA, revision b5f65c3); the FALSE fixture is that line flipped, so any change to #1828''s emit shape breaks the test.

## Deviation from design (flagging)
Predicate lives at `operations/devops/Test-BootFlagEffective.ps1` (dot-sourced, my scope, t/3010 pattern) rather than the `scripts/AITriad/Private/` named in the design — keeps it in DevOps scope + out of the PowerShell tree, no functional change.

Routing to **Main (TL)** to confirm it matches the approved design + conditions before merge (WARN-only, non-blocking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013iv1toUh9SurtepKUd8hpG