### PR TITLE
tools(cl): wire universal sort into formalize_node_lf + score_lf_golden (t/3251)

### DIFF
--- a/research/comp-linguist/docs/logical-form-schema.md
+++ b/research/comp-linguist/docs/logical-form-schema.md
@@ -62,7 +62,7 @@ for both the argument bindings and the `about[]` projection. It never re-extract
 | `args[]` | array | Participants in the event. |
 | `args[].role` | enum | Thematic role: `agent \| patient \| theme \| recipient \| instrument \| location \| source \| goal \| beneficiary \| cause \| manner`. (Neo-Davidsonian participation predicates; extend only with CL sign-off + register note.) |
 | `args[].ref` | string | **MUST be an `ent-*` id drawn from this claim's `entity_refs[].ref`** — never a re-invented id (t/2294). If the participant is not a registered entity, use a literal `lit:"…"` or an event var; record `sort` regardless. |
-| `args[].sort` | enum | The entity's DOLCE-lite sort, **pinned to the register's `DolceCategory` closed set** (`lib/entities/types.ts`): `agentive-physical-object \| non-agentive-functional-artifact \| perdurant \| normative-description \| non-agentive-social-object`. Copied verbatim from the referenced entity's `dolce_category`; for a `lit:`/event arg, CL-assigned from the same 5-value set. Copy-not-judge (rule 2). |
+| `args[].sort` | enum | The entity's DOLCE-lite sort, **pinned to the register's `DolceCategory` closed set** (`lib/entities/types.ts`): `agentive-physical-object \| non-agentive-functional-artifact \| perdurant \| normative-description \| non-agentive-social-object`. Copied verbatim from the referenced entity's `dolce_category`; for a `lit:`/event arg, CL-assigned from the same 5-value set. Copy-not-judge (rule 2). A `term:*` **concept** ref (node `logical_form`) instead takes sort **`universal`** — the 6th arg-slot sort for kinds, distinct from the 5 particular values (t/3251). |
 | `args[].match_level` | enum | Copied verbatim from the entity_ref: `exact \| instance_of \| subclass \| superclass \| related`. Load-bearing for the prover — a claim about a superclass matched to an instance is a different assertion (§6, R4). **⚠️ Exact-only in practice (t/3238):** the resolver (`ClaimEntityResolution.ps1`) hardcodes `match_level="exact"` and surface-matches only — **540/540** entity_refs corpus-wide are `exact`. The non-exact values are an **aspirational vocabulary** until a hierarchical/taxonomic resolver exists; the prover's match_level-sensitivity (§6/R4) and the t/3127/t/3128 axiom modules are therefore **untested on real data** and testable only via constructed golden cases (`analyses/logical-form-golden/` con-2..con-5). Making resolution ontology-aware is a separate resolution-strategy initiative, out of the FOL-track scope. |
 | `about[]` | array | **Topical grounding (additive, optional):** `[{ref, match_level}]` — the `ent-*` ids the claim is *about* (its topical subject). **Superset convention (pinned, D3b):** `about[]` is the **complete** topical index — every resolved entity the claim is about, **including** those that also fill an `args[]` role (a participant that is topical appears in *both*). Same ids as the claim's `entity_refs[]` (a logical-form projection, **no new resolution**). Governed by the `about[]` conditions below. |
 | `polarity` | enum | `positive \| negative`. Negation of the core predication (`¬acquire(e1)`), not attitude negation. |
@@ -171,8 +171,9 @@ of one schema). Port-specific behavior that does NOT change the shape:
 
 - The **node port (#3b)** forces `modality.holder` = camp (from the node-id prefix) and `attitude` =
   category mechanically, and grounds args one-identity from node `entity_refs[]` (register `dolce_category`)
-  + `concept_refs[]` (universals). Concept-ref (universal) sorts are the **blanket `non-agentive-social-object`
-  placeholder** pending the t/3251 refinement — "universal, sort unrefined," never a committed leaf (t/3162#5(b)).
+  + `concept_refs[]`. Concept-ref participants are typed **`universal`** (the 6th arg-slot sort, t/3251
+  ratified / lib #1856), distinct from the 5 particular `DolceCategory` sorts; `lit:`/event args take a
+  particular sort. Universal sub-typing (`universal:kind` etc.) is a deferred monotone v2 (t/3162#5(b)).
 - The **claim port (#3a)** reads `canonical_proposition` (BDI) / `point`+`verbatim` (factual) and sets
   `modality: null` for `factual_claims`.
 

--- a/research/comp-linguist/tools/formalize_node_lf.py
+++ b/research/comp-linguist/tools/formalize_node_lf.py
@@ -39,9 +39,9 @@ def refs_block(n):
         lines.append(f"- {eid} ({nm}) sort={sort} match_level={ml}")
         allowed[eid] = (sort, ml)
     for r in (n.get("concept_refs") or []):
-        cid = r["ref"]  # term:cf ; universal/kind -> abstract DOLCE-lite sort
-        lines.append(f"- {cid} ({r.get('surface','')}) sort=non-agentive-social-object match_level=exact")
-        allowed[cid] = ("non-agentive-social-object", "exact")
+        cid = r["ref"]  # term:cf — a concept is a UNIVERSAL (kind), the 6th arg-slot sort (t/3251),
+        lines.append(f"- {cid} ({r.get('surface','')}) sort=universal match_level=exact")
+        allowed[cid] = ("universal", "exact")  # distinct from the 5 particular DolceCategory sorts
     return ("\n".join(lines) if lines else "(none)"), allowed
 
 def build_prompt(tmpl, n):
@@ -61,20 +61,53 @@ def parse_lf(text):
     try: return json.loads(t[s:e+1])
     except Exception: return None
 
+PARTICULAR_SORTS = frozenset({"agentive-physical-object", "non-agentive-functional-artifact",
+                              "perdurant", "normative-description", "non-agentive-social-object"})
+
+
+def _repair_bare(ref, allowed):
+    """A bare cf-name that IS a node concept -> its `term:` id (t/3239: LLM dropped the prefix)."""
+    if isinstance(ref, str) and ref and not ref.startswith(("ent-", "term:", "lit:")) \
+       and not re.fullmatch(r"e\d+", ref):
+        cand = "term:" + ref
+        if cand in allowed:
+            return cand
+    return ref
+
+
 def validate(lf, allowed, camp, cat):
-    """One-identity §7.4: grounded refs must be in `allowed`; copy sort/match_level authoritatively;
-    drop any hallucinated ent-/term: ref (keep lit:). Force mechanical modality."""
+    """One-identity §7.4: grounded refs (ent-/term:) copy sort/match_level authoritatively from
+    `allowed`; a bare cf-name matching a node concept is repaired to its term: id (t/3239); lit:/event
+    args keep a VALID particular sort + non-empty match_level (t/3239#6 hardening); hallucinated
+    grounded ids are dropped. Concept sorts are `universal` (via `allowed`, t/3251). Mechanical modality."""
     if not isinstance(lf, dict): return None
-    args = []
-    for a in (lf.get("args") or []):
-        ref = a.get("ref", "")
+
+    def fix(a):
+        ref = _repair_bare(a.get("ref", ""), allowed)
+        a["ref"] = ref
         if isinstance(ref, str) and (ref.startswith("ent-") or ref.startswith("term:")):
             if ref not in allowed:
-                continue  # hallucinated grounded id -> drop (never mint)
-            a["sort"], a["match_level"] = allowed[ref][0], allowed[ref][1]
-        args.append(a)
-    lf["args"] = args
-    lf["about"] = [x for x in (lf.get("about") or []) if isinstance(x, dict) and x.get("ref") in allowed]
+                return None  # hallucinated grounded id -> drop (never mint)
+            a["sort"], a["match_level"] = allowed[ref]
+            return a
+        # lit: / event / unresolved: a particular; force a valid sort + non-empty match_level
+        if a.get("sort") not in PARTICULAR_SORTS:
+            a["sort"] = "non-agentive-social-object"  # clamp off-enum to the abstract-particular default
+        if not a.get("match_level"):
+            a["match_level"] = "exact"
+        return a
+
+    lf["args"] = [x for x in (fix(a) for a in (lf.get("args") or [])) if x]
+    kept_about = []
+    for ab in (lf.get("about") or []):
+        if not isinstance(ab, dict):
+            continue
+        ab["ref"] = _repair_bare(ab.get("ref", ""), allowed)
+        if ab.get("ref") in allowed:
+            if not ab.get("match_level"):
+                ab["match_level"] = "exact"
+            kept_about.append(ab)
+    lf["about"] = kept_about
     lf["modality"] = {"holder": f"camp:{POV.get(camp, camp)}", "attitude": CAT_ATT.get(cat, "belief")}
     lf.setdefault("status", "proposed")
     return lf

--- a/research/comp-linguist/tools/score_lf_golden.py
+++ b/research/comp-linguist/tools/score_lf_golden.py
@@ -28,6 +28,8 @@ ORIGIN_FILES = ("accelerationist.json", "safetyist.json", "skeptic.json")
 VALID_SORTS = frozenset({
     "agentive-physical-object", "non-agentive-functional-artifact",
     "perdurant", "normative-description", "non-agentive-social-object",
+    "universal",  # t/3251: concept_refs (term:*) are universals — a 6th arg-slot sort, distinct
+                  # from the 5 particular DolceCategory values (ratified TL t/3251#5, lib #1856).
 })
 VERDICTS = ("correct", "minor", "wrong")
 
@@ -58,7 +60,7 @@ def off_enum_gate():
                 violations.append((nid, a.get("ref"), sort))
     print(f"\n=== off-enum-sort gate (all frames, no labels) ===")
     if not violations:
-        print("PASS — every arg sort is in the 5-value DOLCE-lite set.")
+        print("PASS — every arg sort is in the DOLCE-lite set (5 particular + universal).")
         return True
     print(f"FAIL — {len(violations)} arg(s) with off-enum sort:")
     for nid, ref, sort in violations:


### PR DESCRIPTION
Wires the ratified universal-sort scheme (TL t/3251#5, lib #1856) into the CL tools. formalize_node_lf: concept_refs emit sort `universal`; validate() hardened (repairs bare cf-name concept refs → term:, forces valid particular sort + non-empty match_level on lit:/event args, covers about[] — closes the t/3239#6 defect class so re-runs stay clean). score_lf_golden off-enum gate accepts `universal` as the 6th arg-slot sort. Schema doc updated. Data migration already landed on ai-triad-data (5261c9a6): 360 concept-ref args now `universal`, off-enum gate PASSES. Research tooling, no production path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)