### PR TITLE
infra(g8a): enable GROUNDING_RECONCILE_INLINE=1 in bicep baseEnv (t/3163, staged)

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -586,6 +586,7 @@ jobs:
               AZURE_KEYVAULT_URL                 = '${{ steps.deploy.outputs.keyVaultUri }}'
               AZURE_STORAGE_ACCOUNT_URL          = '${{ steps.deploy.outputs.storageAccountBlobUrl }}'
               EMBEDDING_WORKER_OFFLOAD           = '1'  # t/3165 durable close — gate verifies the offload flag is deployed
+              GROUNDING_RECONCILE_INLINE         = '1'  # t/3163 G8a — gate verifies the staged inline-reconcile flag is deployed
             } `
             -CheckFirewall `
             -StorageAccountName '${{ steps.deploy.outputs.storageAccountName }}' `

--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -540,6 +540,12 @@ var baseEnv = [
   // green (loop max 39.6ms under 1536 concurrent computes). MUST stay in sync with deploy-azure.yml's
   // ExpectedEnvVars config-drift gate (Gate Co-Location — the gate verifies this value is deployed).
   { name: 'EMBEDDING_WORKER_OFFLOAD', value: '1' }
+  // t/3163 G8a (STAGED enable, TL GO): enable inline grounding reconcile on the write path.
+  // Deployed AHEAD of G8b (GROUNDING_SWEEP_ENABLED), which TL holds until this deploy's real
+  // write-cycle lock telemetry is clean (grounding_lock held ≤~2s, zero stale-break/contention).
+  // baseEnv — never a CLI --set-env-vars (wiped by the next template apply). MUST stay in sync with
+  // deploy-azure.yml ExpectedEnvVars (Gate Co-Location — the config-drift gate verifies it's deployed).
+  { name: 'GROUNDING_RECONCILE_INLINE', value: '1' }
 ]
 var envWithToken = githubTokenProvided
   ? concat(baseEnv, [ { name: 'GITHUB_TOKEN', secretRef: githubTokenSecretName } ])


### PR DESCRIPTION
**G8 staged enable — Step 1 (G8a).** TL GO at t/3163; jsnover deploy-auth confirmed (p/350#31).

## What
Adds `GROUNDING_RECONCILE_INLINE = '1'` to `main.bicep` `baseEnv` (durable — never a CLI `--set-env-vars`, wiped by the next template apply). Plus the mandatory Gate Co-Location sync: added to `deploy-azure.yml` `ExpectedEnvVars` config-drift gate.

## Staging discipline
- **G8a only.** G8b (`GROUNDING_SWEEP_ENABLED`) is NOT here — TL holds it until this deploy''s real write-cycle lock telemetry is clean: `grounding_lock held ≤~2s`, zero stale-break/contention.
- Blue-green (bicep baseEnv), never a single-rev UUID flip.

## Sequence
1. Land this PR. 2. Owner-authorized prod deploy (separate gated step) → activates the flag on a new revision. 3. Observe one real write cycle → report lock telemetry to TL → TL clears G8b.

Bicep compiles clean (only pre-existing cosmetic BCP318 runner warning). This deploy is also the first real exercise of the t/3247 WARN-only boot-flag gate — I''ll capture its ingestion-lag number for the later blocking-flip GV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013iv1toUh9SurtepKUd8hpG