### PR TITLE
fix(server): synthetic-embeddings corpus GET → AUTH-ONLY (t/3259 T4)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/accessControl.test.ts
+++ b/taxonomy-editor/src/server/__tests__/accessControl.test.ts
@@ -308,6 +308,31 @@ describe('isPathWithinDir (L3)', () => {
   });
 });
 
+describe('isAnonAllowedRoute — synthetic-embeddings corpus is AUTH-ONLY (t/3259 + t/3260)', () => {
+  const SYNTH = '/api/taxonomy/synthetic-embeddings';
+
+  it('BLOCKS anon GET of the ~400MB corpus unconditionally (PM t/3260, TL-confirmed p/522#192)', () => {
+    expect(isAnonAllowedRoute('GET', SYNTH)).toBe(false);
+  });
+
+  it('is bypass-safe — trailing-slash + query vectors are all blocked', () => {
+    // Trailing slash(es): canonicalized here → blocked at the gate (matchRoute would 404 them anyway).
+    expect(isAnonAllowedRoute('GET', SYNTH + '/')).toBe(false);
+    expect(isAnonAllowedRoute('GET', SYNTH + '///')).toBe(false);
+    // Query string: server.ts strips it via normalizedRequestPath (new URL().pathname) BEFORE this fn,
+    // for BOTH the gate and the router — prove the composition sees the canonical path → blocked.
+    const stripped = new URL('http://x' + SYNTH + '?x=1&y=2').pathname;
+    expect(stripped).toBe(SYNTH);
+    expect(isAnonAllowedRoute('GET', stripped)).toBe(false);
+  });
+
+  it('does NOT over-match — sibling GET routes stay anon-allowed', () => {
+    expect(isAnonAllowedRoute('GET', '/api/taxonomy/accelerationist')).toBe(true);
+    expect(isAnonAllowedRoute('GET', '/api/taxonomy/synthetic/acc')).toBe(true); // the :pov route, distinct
+    expect(isAnonAllowedRoute('GET', '/api/edges')).toBe(true);
+  });
+});
+
 describe('isAnonAllowedRoute (t/763 anon_route_blocked classification)', () => {
   it('allows read-only GETs', () => {
     expect(isAnonAllowedRoute('GET', '/api/taxonomy/accelerationist')).toBe(true);

--- a/taxonomy-editor/src/server/security/accessControl.ts
+++ b/taxonomy-editor/src/server/security/accessControl.ts
@@ -340,6 +340,10 @@ const ANON_SAFE_POST_PATHS = [
   '/debug/events',
 ];
 
+/** t/3259: the debate-only ~400MB synthetic-embeddings corpus GET — anon access is gated on the
+ *  anon-debates flag rather than the blanket GET-allow below. */
+const SYNTHETIC_EMBEDDINGS_PATH = '/api/taxonomy/synthetic-embeddings';
+
 /**
  * Whether an anonymous (signed-out) user may call `method urlPath` in
  * AUTH_OPTIONAL mode. Anonymous users get read-only, non-AI access plus
@@ -352,7 +356,17 @@ export function isAnonAllowedRoute(method: string, urlPath: string): boolean {
   if (ANON_SAFE_AI_ROUTES.includes(urlPath)) return true;
   if (isAnonBlockedRoute(urlPath)) return false;
 
-  if (method === 'GET') return true;
+  if (method === 'GET') {
+    // t/3259 + t/3260 (PM ruling, TL-confirmed p/522#192): the ~400MB synthetic-embeddings corpus export
+    // is AUTH-ONLY — never anon-reachable, independent of any flag. This is the SOLE always-on protection:
+    // anon debates, when later enabled, MUST route through the tiny /relevant-nodes endpoint (T2/t/3257),
+    // never the corpus. Bypass-safe: server.ts feeds BOTH this gate and the router (matchRoute) the
+    // identical normalizedRequestPath (new URL().pathname), so a `?query` is stripped for both (=== matches
+    // → blocked) and a trailing slash makes matchRoute's exact segment-count match 404 (nothing served);
+    // the trailing-slash strip here blocks `/synth/` at the gate too.
+    if (urlPath.replace(/\/+$/, '') === SYNTHETIC_EMBEDDINGS_PATH) return false;
+    return true;
+  }
 
   const isMutation = method === 'POST' || method === 'PUT' || method === 'DELETE';
   if (isMutation && isAnonUserContentRoute(urlPath)) return true;


### PR DESCRIPTION
## What
Closes the standing anon-full-corpus exposure (t/3248 T4). `isAnonAllowedRoute` returned `true` for EVERY GET → `GET /api/taxonomy/synthetic-embeddings` (the ~400MB debate corpus) was anon-reachable. Carve it out of the blanket GET-allow: **anon always blocked** (403 `anon_route_blocked`); authed clients unaffected; route + #1832 cache stay (**gate, not retirement**).

## AUTH-ONLY (PM t/3260, TL-confirmed p/522#192)
Supersedes the initial flag-gated design (t/3259#2). Auth-only **permanently** closes the exposure; flag-gating re-opened it whenever `anon-debates` flipped on. End-state: anon debates (when enabled) route through the tiny `/relevant-nodes` (T2/t/3257), **never** the corpus. (So enabling anon debates later now requires T2/T3 first — the correct constraint.)

## Bypass-robust (TL hard condition)
The gate and the router (`matchRoute`) both operate on the identical `normalizedRequestPath` (`new URL().pathname`): `?query` is stripped for both (→ `===` matches → blocked), and a trailing slash makes `matchRoute`'s exact segment-count match **404** (nothing served). The gate also trailing-slash-strips so `/synth/` is blocked at the gate too.

## Tests (63/63, eslint clean)
anon GET synth → blocked; trailing-slash (`/`, `///`) + query (`?x=1&y=2` via `normalizedRequestPath`) bypass vectors → blocked; sibling routes (`/synthetic/:pov`, `/accelerationist`, `/edges`) unaffected.

## Scope
`security/accessControl.ts` (+ test) = Server Auth scope; TL authorized ServerAPI to implement (t/3259#2). Auth-surface → **Main (TL) GV**.

Relates t/3248, t/3260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)