### PR TITLE
fix(debate): Beliefs attribution reframe — remove absolutist 'what you take as true' (t/3262)

### DIFF
--- a/lib/debate/taxonomyContext.ts
+++ b/lib/debate/taxonomyContext.ts
@@ -47,11 +47,18 @@ export interface TaxonomyContext {
   nodeScores?: Map<string, number>;
 }
 
+// t/3262: attribution reframe — on by default; set DEBATE_BELIEFS_ATTRIBUTION_REFRAME=0 to restore old text
+const BELIEFS_ATTRIBUTION_REFRAME = process.env.DEBATE_BELIEFS_ATTRIBUTION_REFRAME !== '0';
+
 /** Map taxonomy categories to BDI sections */
 export const CATEGORY_TO_BDI: Record<string, { header: string; framing: string }> = {
   'Beliefs': {
-    header: '=== YOUR EMPIRICAL GROUNDING (what you take as true) ===',
-    framing: 'These are the factual claims and empirical observations that ground your worldview.',
+    header: BELIEFS_ATTRIBUTION_REFRAME
+      ? '=== YOUR CAMP\'S EMPIRICAL GROUNDING (the evidentiary basis your camp argues from) ==='
+      : '=== YOUR EMPIRICAL GROUNDING (what you take as true) ===',
+    framing: BELIEFS_ATTRIBUTION_REFRAME
+      ? 'These are the factual claims and empirical observations your camp treats as its evidentiary foundation — argue from them with conviction. They are your camp\'s established positions, not incontrovertible facts: if a specific claim here is one you cannot support or that contradicts what you know, you are not obligated to assert it as established fact.'
+      : 'These are the factual claims and empirical observations that ground your worldview.',
   },
   'Desires': {
     header: '=== YOUR NORMATIVE COMMITMENTS (what you argue should happen) ===',


### PR DESCRIPTION
## Summary

- Replaces `CATEGORY_TO_BDI['Beliefs']` header/framing with CL-authored attribution language (t/3262#3)
- Removes the absolutist \"what you take as true\" framing measured driving misaligned false-claim resistance to 0/24 in the t/3147 probe
- New text attributes claims to \"your camp's evidentiary foundation,\" preserves confident argumentation, and adds a targeted escape hatch for anomalous injected claims
- Flag: `DEBATE_BELIEFS_ATTRIBUTION_REFRAME=0` restores old text for A/B baseline; default ON

## Gate: DRAFT — awaiting CL mandatory review + t/3147 probe re-validation

Per t/3262#3: CL re-runs the t/3147 probe against this branch (both arms: `=1` default ON and `=0` baseline) to confirm misaligned adoption drops while aligned stays high. Do NOT un-draft or merge until CL signs off.

## Test plan

- [x] `npx vitest run taxonomyContext` — 8/8 passed at 638e3d31
- [ ] CL t/3147 probe re-validation (two-sided: misaligned drops, aligned stable)
- [ ] CL mandatory review sign-off

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxTgvajJ6AtoqBLufJbQSr