### PR TITLE
feat(lib): register degraded-return gate over lib at warn + Shared Lib cleanup (t/3224 Phase A)

### DIFF
--- a/lib/electron-shared/embeddingIO.ts
+++ b/lib/electron-shared/embeddingIO.ts
@@ -40,6 +40,7 @@ export function createEmbeddingIO(deps: EmbeddingIODeps) {
       cachePath = filePath;
       console.log(`[embeddings] Loaded ${cache.node_count} local embeddings (${cache.dimension}d)`);
       return cache;
+      // eslint-disable-next-line local/require-warn-on-degraded-catch-return -- observable, not silent: the null fallback records via the injected recordError(err) seam AND console.warn. electron-shared is dependency-injected shared code and cannot use getGlobalRecorder/log.* (the transports the rule recognizes) — recordError IS its structured-logging seam (t/3224 Phase A).
     } catch (err) {
       deps.recordError?.(err);
       console.warn('[embeddings] Could not load embeddings.json:', err);

--- a/lib/electron-shared/utils/searchRegex.ts
+++ b/lib/electron-shared/utils/searchRegex.ts
@@ -37,6 +37,7 @@ export function buildSearchRegex(
       pattern = query;
     }
     return new RegExp(pattern, caseSensitive ? 'g' : 'gi');
+    // eslint-disable-next-line local/require-warn-on-degraded-catch-return -- false positive + benign guard: the try matches DATA_IO_SIGNAL_RE only via the local `query` name (a search string, NOT a DB query); the actual op is a synchronous `new RegExp` compile on user input. `return null` = "not a valid filter" (caller shows no regex match), a user-input guard, not a silent data/IO fallback — nothing to record (t/3224 Phase A).
   } catch {
     return null;
   }

--- a/lib/eslint.config.mjs
+++ b/lib/eslint.config.mjs
@@ -16,6 +16,7 @@
 
 import tseslint from 'typescript-eslint';
 import noActionableErrorMessageNesting from './eslint-rules/no-actionable-error-message-nesting.js';
+import requireWarnOnDegradedCatchReturn from './eslint-rules/require-warn-on-degraded-catch-return.js';
 
 // max-lines is not type-aware, so the .tsx and test blocks parse syntactically
 // (no projectService) — those files are outside lib/tsconfig.json's `**/*.ts` project.
@@ -72,7 +73,10 @@ export default tseslint.config(
         tsconfigRootDir: import.meta.dirname,
       },
     },
-    plugins: { budget: budgetPlugin, local: { rules: { 'no-actionable-error-message-nesting': noActionableErrorMessageNesting } } },
+    plugins: { budget: budgetPlugin, local: { rules: {
+      'no-actionable-error-message-nesting': noActionableErrorMessageNesting,
+      'require-warn-on-degraded-catch-return': requireWarnOnDegradedCatchReturn,
+    } } },
     rules: {
       '@typescript-eslint/no-floating-promises': 'error',
       '@typescript-eslint/no-misused-promises': ['error', {
@@ -85,6 +89,15 @@ export default tseslint.config(
       // and unwrap TSAsExpression casts — preventing false positives on data.message from
       // HTTP response bodies.
       'local/no-actionable-error-message-nesting': 'error',
+      // Silent-fallback gate for lib (t/3224 Phase A, TL ruling t/3224#5). Flags a catch that
+      // returns a SILENT empty/no-data default (`[]`/`{}`/`null`/`undefined`) from a DATA/IO path
+      // without a WARN/ERROR record — the t/3165 invisible-degradation class the fleet hardened in
+      // taxonomy-editor (t/3169/t/3200); lib was previously unguarded. Ships at 'warn' (non-blocking
+      // visibility); the GV-gated flip to 'error' follows once the genuine sites (Shared Lib +
+      // DebateTool's lib/debate) each carry a WARN or a reasoned disable and the count reaches zero
+      // (TL t/3224#5). Scope is degraded-RETURN only — the base require-flight-recorder-in-catch is
+      // deliberately NOT extended whole-lib (Phase B t/3263 scopes it to IO subtrees; pure/CLI exempt).
+      'local/require-warn-on-degraded-catch-return': 'warn',
     },
   },
 


### PR DESCRIPTION
Phase A of t/3224 (TL ruling t/3224#5): extend the degraded-return silent-fallback gate to lib, which was previously unguarded (the rule ran only over `taxonomy-editor/src`). High-signal/low-churn arm; the base flight-recorder rule is deliberately **not** extended whole-lib — Phase B (t/3263) scopes that to IO subtrees only.

## What
- **`lib/eslint.config.mjs`** — register `local/require-warn-on-degraded-catch-return` at **`warn`** (Block A, non-test `.ts`) with a co-located rationale + the flip-to-error plan. Non-blocking: `lib-lint` gates on **errors only** (no `--max-warnings=0`), so the interim DebateTool warnings don't fail CI.
- **Genuine count over lib: 9** — 2 Shared Lib + 7 DebateTool (`lib/debate`).
- **Shared Lib cleanup (both reasoned disables — observable/FP, not silent):**
  - `electron-shared/embeddingIO.ts` — the null fallback IS observable (injected `recordError` seam + `console.warn`); electron-shared is DI shared code and can't use `getGlobalRecorder`/`log.*` (the transports the rule recognizes).
  - `electron-shared/utils/searchRegex.ts` — false positive: the try matches `DATA_IO_SIGNAL_RE` only via the local `query` name (a search string, not a DB query); the op is a synchronous `new RegExp` compile on user input → `null` = "no filter", a user-input guard not a data/IO fallback.

## Verify
Shared Lib degraded-return warnings: **2 → 0**; both files lint clean (exit 0, no unused-disable-directive). Remaining 7 are DebateTool's (`lib/debate`), coordinated separately.

## Follow-ups
- DebateTool cleans their 7 `lib/debate` sites (warn is non-blocking meanwhile).
- Flip `warn` → `error` at zero-noise → TL GV (separate PR, once DebateTool's sites land).
- Phase B (base flight-recorder → lib IO subtrees) = t/3263, measure-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
