### PR TITLE
fix(debate): WARN on all 7 degraded-return catch sites in lib/debate (t/3224 Phase A)

### DIFF
--- a/lib/debate/calibrationLogger/history.ts
+++ b/lib/debate/calibrationLogger/history.ts
@@ -13,6 +13,7 @@ import path from 'node:path';
 import { DEFAULT_TEMPERATURE } from '../../ai-client/defaults.js';
 import { DEFAULT_ATTACK_WEIGHTS } from '../qbaf.js';
 import { POLARITY_RESOLVED_THRESHOLD, SEMANTIC_RECYCLING_THRESHOLD, ATTACK_DEDUP_THRESHOLD } from '../constants.js';
+import { getGlobalRecorder } from '../../flight-recorder/index.js';
 
 // ── Parameter snapshots & history ────────────────────────────
 
@@ -148,7 +149,8 @@ export function readParameterHistory(dataRoot: string): ParameterHistoryEntry[] 
 
   try {
     return JSON.parse(fs.readFileSync(histPath, 'utf-8'));
-  } catch {
+  } catch (err) {
+    getGlobalRecorder()?.record({ type: 'system.error', component: 'calibration-history', level: 'warn', message: 'parameter-history.json unreadable — returning empty history. err=' + String(err) });
     return [];
   }
 }

--- a/lib/debate/calibrationLogger/io.ts
+++ b/lib/debate/calibrationLogger/io.ts
@@ -15,6 +15,7 @@ import { createHash } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import type { CalibrationDataPoint } from './schema.js';
+import { getGlobalRecorder } from '../../flight-recorder/index.js';
 
 // ── File I/O ────────────────────────────────────────────────
 
@@ -136,7 +137,8 @@ export function readCalibrationLog(dataRoot: string): CalibrationDataPoint[] {
       .split('\n')
       .filter(line => line.trim().length > 0)
       .map(line => JSON.parse(line));
-  } catch {
+  } catch (err) {
+    getGlobalRecorder()?.record({ type: 'system.error', component: 'calibration-io', level: 'warn', message: 'calibration log unreadable — returning empty. err=' + String(err) });
     return [];
   }
 }

--- a/lib/debate/cli.ts
+++ b/lib/debate/cli.ts
@@ -428,6 +428,7 @@ async function main(): Promise<void> {
       enabled: !disableTurnValidation,
       ...(maxTurnRetries !== undefined ? { maxRetries: maxTurnRetries } : {}),
     },
+    // eslint-disable-next-line local/require-warn-on-degraded-catch-return -- best-effort version read; undefined appVersion is observable in config output
     appVersion: (() => { try { return JSON.parse(fs.readFileSync(path.resolve(__dirname, '../../taxonomy-editor/package.json'), 'utf-8')).version; } catch { return undefined; } })(),
     audience,
     moderatorMode,

--- a/lib/debate/corpusCoverage.ts
+++ b/lib/debate/corpusCoverage.ts
@@ -135,7 +135,8 @@ export function loadCoverageMap(dataRoot: string): CorpusCoverageMap | null {
     const raw = JSON.parse(fs.readFileSync(p, 'utf-8'));
     if (raw && raw.version === 1 && raw.node_stats) return raw as CorpusCoverageMap;
     return null;
-  } catch {
+  } catch (err) {
+    getGlobalRecorder()?.record({ type: 'system.error', component: 'corpus-coverage', level: 'warn', message: 'corpus coverage file unreadable or invalid — returning null. err=' + String(err) });
     return null;
   }
 }

--- a/lib/debate/debateIndex.ts
+++ b/lib/debate/debateIndex.ts
@@ -4,6 +4,7 @@
 import fs from 'fs';
 import path from 'path';
 import { renameSyncWithRetry } from './persistence.js';
+import { getGlobalRecorder } from '../flight-recorder/index.js';
 
 export interface DebateSessionSummary {
   id: string;
@@ -108,7 +109,8 @@ function readIndex(debatesDir: string): DebateIndex | null {
     const raw = JSON.parse(fs.readFileSync(indexPath, 'utf-8')) as DebateIndex;
     if (raw.version !== 1) return null;
     return raw;
-  } catch {
+  } catch (err) {
+    getGlobalRecorder()?.record({ type: 'system.error', component: 'debate-index', level: 'warn', message: 'debate index unreadable or invalid — returning null. err=' + String(err) });
     return null;
   }
 }

--- a/lib/debate/evidenceRetriever.ts
+++ b/lib/debate/evidenceRetriever.ts
@@ -12,6 +12,7 @@
 import fs from 'fs';
 import path from 'path';
 import { cosineSimilarity } from './taxonomyRelevance.js';
+import { getGlobalRecorder } from '../flight-recorder/index.js';
 
 // ── Types ─────────────────────────────────────────────────
 
@@ -135,7 +136,8 @@ function extractRelevantParagraphs(
   let content: string;
   try {
     content = fs.readFileSync(snapshotPath, 'utf-8');
-  } catch {
+  } catch (err) {
+    getGlobalRecorder()?.record({ type: 'system.error', component: 'evidence-retriever', level: 'warn', message: 'snapshot file unreadable — returning empty evidence. err=' + String(err) });
     return [];
   }
 

--- a/lib/debate/taxonomyLoader.ts
+++ b/lib/debate/taxonomyLoader.ts
@@ -159,7 +159,8 @@ export function loadSituationStatements(dataRoot: string): SituationStatements |
       return out;
     }
     return null;
-  } catch {
+  } catch (err) {
+    getGlobalRecorder()?.record({ type: 'system.error', component: 'taxonomy-loader', level: 'warn', message: 'situation statements unreadable — returning null. err=' + String(err) });
     return null;
   }
 }


### PR DESCRIPTION
## Summary

- Adds flight recorder WARN records to all 7 catch sites in `lib/debate` flagged by the `local/require-warn-on-degraded-catch-return` ESLint gate (Phase A of t/3224)
- 6 sites get a `getGlobalRecorder()?.record(...)` with `level: 'warn'` before returning the degraded value
- 1 site (`cli.ts` best-effort version read) gets a reasoned `eslint-disable-next-line` comment (degraded value `undefined` is observable in output)
- 4 files needed `getGlobalRecorder` import added; 2 already had it

## Files changed

| File | Fix |
|------|-----|
| `calibrationLogger/history.ts` | import + WARN: parameter-history.json unreadable |
| `calibrationLogger/io.ts` | import + WARN: calibration log unreadable |
| `cli.ts` | reasoned eslint-disable: best-effort version read |
| `corpusCoverage.ts` | WARN: coverage file unreadable or invalid |
| `debateIndex.ts` | import + WARN: debate index unreadable or invalid |
| `evidenceRetriever.ts` | import + WARN: snapshot file unreadable |
| `taxonomyLoader.ts` | WARN: situation statements unreadable |

## Test plan

- [x] `npx vitest run` in `lib/debate` — 127/128 files pass, 1 skipped (pre-existing)
- [x] Self-certifying under /trivial-change — 17 lines changed, single scope, no new exports, no interface changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mDXUBnNuJ1wBED66RPewk