### PR TITLE
feat(entities): canonical Zod for EntityLinkRef/ConceptLinkRef (t/3253 drift-prevention)

### DIFF
--- a/lib/entities/linkRefs.test.ts
+++ b/lib/entities/linkRefs.test.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Definition-level tests for the canonical link-ref schemas (t/3253). Mirrors logicalForm.test.ts:
+// valid parses; every closed vocabulary rejects an out-of-vocab value; required-field omission
+// rejects; passthrough forgives additive unknown keys. The bidirectional type-equality guards are
+// compile-time (they fail tsc, not vitest).
+import { describe, it, expect } from 'vitest';
+import { entityLinkRefSchema, conceptLinkRefSchema } from './linkRefs.js';
+
+const ENTITY = {
+  ref: 'ent-034',
+  surface: 'OpenAI',
+  method: 'exact',
+  link_confidence: 1.0,
+  match_level: 'exact',
+  status: 'linked',
+};
+const CONCEPT = {
+  ref: 'term:frontier-model',
+  surface: 'frontier models',
+  method: 'surface',
+  link_confidence: 0.82,
+  status: 'proposed',
+};
+
+describe('entityLinkRefSchema — valid + reject arms', () => {
+  it('parses a canonical entity link ref', () => {
+    expect(entityLinkRefSchema.safeParse(ENTITY).success).toBe(true);
+  });
+  it('passthrough: forgives an additive unknown key', () => {
+    expect(entityLinkRefSchema.safeParse({ ...ENTITY, future_field: 1 }).success).toBe(true);
+  });
+  it('rejects an out-of-vocab method', () => {
+    expect(entityLinkRefSchema.safeParse({ ...ENTITY, method: 'surface' }).success).toBe(false);
+  });
+  it('rejects an out-of-vocab match_level', () => {
+    expect(entityLinkRefSchema.safeParse({ ...ENTITY, match_level: 'fuzzy' }).success).toBe(false);
+  });
+  it('rejects an out-of-vocab status', () => {
+    expect(entityLinkRefSchema.safeParse({ ...ENTITY, status: 'accepted' }).success).toBe(false);
+  });
+  it('rejects a required-field omission (missing match_level)', () => {
+    const { match_level: _drop, ...noMl } = ENTITY;
+    expect(entityLinkRefSchema.safeParse(noMl).success).toBe(false);
+  });
+});
+
+describe('conceptLinkRefSchema — valid + reject arms', () => {
+  it('parses a canonical concept link ref', () => {
+    expect(conceptLinkRefSchema.safeParse(CONCEPT).success).toBe(true);
+  });
+  it('passthrough: forgives an additive unknown key', () => {
+    expect(conceptLinkRefSchema.safeParse({ ...CONCEPT, future_field: 1 }).success).toBe(true);
+  });
+  it('rejects the entity-only method "alias" (concepts have no alias table)', () => {
+    expect(conceptLinkRefSchema.safeParse({ ...CONCEPT, method: 'alias' }).success).toBe(false);
+  });
+  it('rejects an out-of-vocab status', () => {
+    expect(conceptLinkRefSchema.safeParse({ ...CONCEPT, status: 'accepted' }).success).toBe(false);
+  });
+  it('rejects a stray match_level? no — passthrough tolerates extra keys, but a bad status still fails', () => {
+    // concept refs have no match_level field; an extra one is an additive key (tolerated),
+    // so this asserts the schema still validates the DEFINED fields on such an object.
+    expect(conceptLinkRefSchema.safeParse({ ...CONCEPT, match_level: 'exact' }).success).toBe(true);
+    expect(conceptLinkRefSchema.safeParse({ ...CONCEPT, match_level: 'exact', status: 'nope' }).success).toBe(false);
+  });
+});

--- a/lib/entities/linkRefs.ts
+++ b/lib/entities/linkRefs.ts
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Canonical Zod schemas for the forward-grounding link refs (t/3157) — the SINGLE source of truth
+// for validating an `EntityLinkRef` / `ConceptLinkRef` (see ./types.ts). Previously taxonomy-editor's
+// `validation.ts` hand-copied these as inline Zod, a drift risk (t/3253, the same class t/3250 fixed
+// for `logical_form`). Consumers (povNodeSchema in validation.ts) import from here instead of
+// re-declaring, so the runtime validator can never drift from the persisted shape.
+//
+// Objects are `.passthrough()` (matches the prior hand-mirror + the entity/logical_form convention):
+// every DEFINED field is strictly validated (required-present, enums in-vocab) while additive unknown
+// keys are forgiven for forward-compat. Vocabulary anti-drift lives in the bidirectional `Equals`
+// guards at the bottom (a value list that diverges from its `types.ts` type fails `tsc`).
+import { z } from 'zod';
+import type { EntityLinkRef, ConceptLinkRef, EntityMatchLevel, EntityLinkStatus } from './types.js';
+
+// Closed vocabularies kept LOCAL so the Zod enums are first-class, then pinned to the `types.ts`
+// types by the guards below (drift in EITHER direction fails tsc — TL t/3250#2(1)).
+const ENTITY_METHODS = ['exact', 'alias', 'embedding'] as const;      // how an ent-* ref was found
+const CONCEPT_METHODS = ['surface', 'embedding'] as const;            // concepts have no alias table
+const MATCH_LEVELS = ['exact', 'instance_of', 'subclass', 'superclass', 'related'] as const;
+const LINK_STATUSES = ['linked', 'proposed'] as const;
+
+export const entityMethodSchema = z.enum(ENTITY_METHODS);
+export const conceptMethodSchema = z.enum(CONCEPT_METHODS);
+export const linkMatchLevelSchema = z.enum(MATCH_LEVELS);
+export const linkStatusSchema = z.enum(LINK_STATUSES);
+
+/** Zod mirror of {@link EntityLinkRef} — a resolved link from a container's `entity_refs[]` to a
+ *  register entity. `match_level` is load-bearing for the prover; `status` gates whether it counts. */
+export const entityLinkRefSchema = z.object({
+  ref: z.string(),
+  surface: z.string(),
+  method: entityMethodSchema,
+  link_confidence: z.number(),
+  match_level: linkMatchLevelSchema,
+  status: linkStatusSchema,
+}).passthrough();
+
+/** Zod mirror of {@link ConceptLinkRef} — a resolved link to a dictionary concept (`term:*`).
+ *  No `match_level` (a concept already names a kind, so there is no subsumption hop). */
+export const conceptLinkRefSchema = z.object({
+  ref: z.string(),
+  surface: z.string(),
+  method: conceptMethodSchema,
+  link_confidence: z.number(),
+  status: linkStatusSchema,
+}).passthrough();
+
+// ── Bidirectional anti-drift guards (TL t/3250#2(1)) ─────────────────────────────────────────
+// Exact type-equality: fails `tsc` if a closed vocabulary diverges from its `types.ts` type in
+// EITHER direction. Compile-time only (erased at runtime). If a line errors, reconcile this file
+// with types.ts (the interface is the source of truth for the shape).
+type Equals<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+type Assert<T extends true> = T;
+
+export type _AssertEntityMethod = Assert<Equals<z.infer<typeof entityMethodSchema>, EntityLinkRef['method']>>;
+export type _AssertConceptMethod = Assert<Equals<z.infer<typeof conceptMethodSchema>, ConceptLinkRef['method']>>;
+export type _AssertMatchLevel = Assert<Equals<z.infer<typeof linkMatchLevelSchema>, EntityMatchLevel>>;
+export type _AssertLinkStatus = Assert<Equals<z.infer<typeof linkStatusSchema>, EntityLinkStatus>>;


### PR DESCRIPTION
Drift-prevention follow-up from t/3250: `taxonomy-editor/validation.ts` hand-copied the `EntityLinkRef`/`ConceptLinkRef` Zod schemas inline (a drift risk vs the `lib/entities/types.ts` interfaces — the same class t/3250 fixed for `logical_form`). This lands the single source of truth in lib.

## What (Shared Lib half)
- **`lib/entities/linkRefs.ts`** — `entityLinkRefSchema` + `conceptLinkRefSchema`, **byte-equivalent** to the current `validation.ts` hand-mirrors (same fields, inline `method` enums, inner `.passthrough()` for fwd-compat), plus **bidirectional `Equals` guards** pinning `method`→`EntityLinkRef['method']`/`ConceptLinkRef['method']`, `match_level`→`EntityMatchLevel`, `status`→`EntityLinkStatus` (tsc fails on drift either way).
- **`lib/entities/linkRefs.test.ts`** — 11 tests.

## Verify
11/11 tests (taxonomy-editor vitest) · entities tsc 0 (guards compile) · eslint 0. Self-cert against the TL-approved t/3250 `logicalForm.ts` pattern — no data-model change, no deviations.

## Scope
Additive/safe — nothing imports it yet. **Rosetta** swaps `validation.ts` to `import { entityLinkRefSchema, conceptLinkRefSchema } from '@lib/entities/linkRefs'` and drops the two local declarations (behavior-identical, self-cert diff supplied separately).

Closes the Shared Lib arm of t/3253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
