### PR TITLE
feat(debate): extract relevance-selection to lib-pure selectRelevantTaxonomy (t/3257)

### DIFF
--- a/lib/debate/relevanceSelection.ts
+++ b/lib/debate/relevanceSelection.ts
@@ -1,0 +1,316 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Canonical, framework-agnostic taxonomy relevance-selection pipeline (t/3248 / t/3257,
+// relocation-first). ONE pure implementation called by BOTH the debate client (renderer
+// thin-wrapper, T3) and the server endpoint (`POST /api/taxonomy/relevant-nodes`, T2) —
+// parity holds by construction when inputs match (order-preserving; the T2 parity fixture
+// asserts it). Extracted from the renderer `getRelevantTaxonomyContext` orchestration
+// (taxonomyContext.ts) per Rosetta's extraction read (t/3258#3) + the TL-approved
+// decomposition (t/3257#7/#8).
+//
+// PURITY CONTRACT (load-bearing — this is why it can be a second server caller):
+//   • NO store reads, NO module-singleton caches (they break server determinism/multi-tenancy),
+//     NO flight-recorder/console output. All state crosses via `input`; all diagnostics are the
+//     CALLER's job (server→pino, client→FR+warnings) reconstructed from the returned result.
+//   • `povNodes` is treated READ-ONLY — doctrinal anchoring runs on CLONES (see below), so the
+//     server's cached taxonomy is never mutated across requests (W2, t/3257#10).
+//   • Embedding IO is the injected `embed` cb (server: its computeEmbeddings; fixture: a
+//     deterministic stub) — used ONLY for the doctrinal-boundary strings + the topic-query
+//     fallback. The corpus `nodeEmbeddings` is pre-built by the caller.
+
+import type { PovNode, SituationNode } from './taxonomyTypes.js';
+import { cosineSimilarity } from '../embeddings/similarity.js';
+import {
+  scoreNodesViaAN,
+  scoreNodeRelevanceMeanTopN,
+  buildRelevanceQuery,
+  selectRelevantNodes,
+  selectRelevantSituationNodes,
+  type ANClaimEmbedding,
+  type RelevanceOptions,
+  type ScoredPovNode,
+  type ScoredSituationNode,
+} from './taxonomyRelevance.js';
+import { computeDoctrinalAnchoring } from './doctrinalAnchoring.js';
+
+/** Corpus embedding map (single vector + optional synthetic multi-vectors), keyed by node id. */
+export type NodeEmbeddingMap = Record<string, { pov: string; vector: number[]; vectors?: number[][] }>;
+
+/**
+ * Per-node scoring provenance: whether the node was surfaced by AN-claim similarity or the topic
+ * query, plus the best-matching AN claim. Relocated from the renderer debate-store types so BOTH
+ * the lib fn and the server T2 caller can type against it without a renderer path (DebateTool
+ * t/3257#14). The renderer `useDebateStore/types.ts` re-exports this (source of truth is here).
+ */
+export interface NodeScoringSource {
+  source: 'an' | 'topic';
+  anScore: number;
+  topicScore: number;
+  bestClaimId?: string;
+  bestClaimText?: string;
+  bestClaimSim?: number;
+}
+
+/** AN claim embedding + its text (text needed for `bestClaimText` provenance; `ANClaimEmbedding` alone lacks it). */
+export type ANClaimInput = ANClaimEmbedding & { text?: string };
+// Re-exported so the server T2 caller types against `@lib/debate/relevanceSelection` alone (ServerAPI t/3257#15).
+export type { ANClaimEmbedding } from './taxonomyRelevance.js';
+
+/**
+ * Doctrinal-anchoring adjustment for one Belief node — the client thin-wrapper re-applies these to
+ * the store (today's in-place side-effect: `doctrinally_anchored` + a confidence floor for anchored
+ * Beliefs); the server passes them through and does not apply. `floorApplied` distinguishes an
+ * anchored-but-not-floored node (confidence/evidential unchanged) from a floored one, so the
+ * re-apply mirrors today's behaviour EXACTLY (only floored nodes get their confidence rewritten).
+ */
+export interface DoctrinalAdjustment {
+  nodeId: string;
+  doctrinallyAnchored: boolean;
+  floorApplied: boolean;
+  /** The (post-floor) confidence to write when floorApplied; the node's current value otherwise. */
+  confidence: number;
+  /** The pre-floor confidence preserved when floorApplied; equals `confidence` otherwise. */
+  evidentialConfidence: number;
+}
+
+export interface SelectRelevantTaxonomyInput {
+  // ── static (server-derivable; the client passes them from its store) ──
+  povNodes: PovNode[];
+  situationNodes: SituationNode[];
+  policyRegistry: { id: string; action: string; source_povs?: string[] }[];
+  /** Corpus map, caller-built (incl. synthetic multi-vector merge). */
+  nodeEmbeddings: NodeEmbeddingMap;
+  /** Static lineage name→L2 map. `undefined` ⇒ no lineage boost (subsumes the old `isLineageDataLoaded()`). */
+  lineageMapping?: Record<string, { l2: string }>;
+  /** The current POV's doctrinal boundary strings (from POVER_INFO). Embedded inside via `embed`. */
+  doctrinalBoundaries?: { strings: string[]; isRejection?: boolean[] };
+  // ── per-session (MUST cross the wire — the server cannot reconstruct these) ──
+  session: {
+    /** `argument_network.nodes[]` with embeddings — the PRIMARY scoring signal; `text` for provenance. */
+    anClaimEmbeddings: ANClaimInput[];
+    lineageFrame?: { cluster_id: string; label?: string }[];
+    /** `debate.source_type`; lineage frame is only "expected" for `'topic'` debates. */
+    sourceType?: string;
+    excludeGreatestHits?: boolean;
+    /** Fetched by the caller (renderer: bridge; server: its own) and passed as an array. */
+    greatestHitsList?: string[];
+  };
+  params: {
+    pov: string;
+    topic: string;
+    recentTranscript: string;
+    threshold?: number;      // default 0.45
+    minPerCategory?: number; // default 3
+    maxTotal?: number;       // default 35
+    topN?: number;           // mean-top-N for multi-vector nodes; default 3
+    scoringMode?: 'embedding' | 'lexical';
+    // NOTE: `minPerPov` is deliberately NOT a param — selectRelevantNodes reads `opts.minPerPov ?? 2`,
+    // so leaving it unset keeps BOTH callers at the default 2 (ServerAPI parity note, t/3257#15).
+  };
+  /** Injected embedding fn — boundary strings + topic-query fallback ONLY (never the corpus). */
+  embed: (texts: string[], ids?: string[]) => Promise<number[][]>;
+}
+
+export interface RelevantTaxonomyResult {
+  /** Selected POV nodes, IN `selectRelevantNodes` ORDER (W3 — the client injects in this order). */
+  povNodes: { nodeId: string; score: number }[];
+  situationNodes: { nodeId: string; score: number }[];
+  policyRegistry: { id: string; action: string; source_povs?: string[] }[];
+  /** Per-node provenance — a plain object (a Map serializes to `{}` over the wire; ServerAPI t/3257#15). */
+  nodeSourceMap: Record<string, NodeScoringSource>;
+  injectionManifest: Record<string, unknown>;
+  /** Doctrinal-anchoring adjustments for the client to re-apply; server passes through. */
+  anchoring: DoctrinalAdjustment[];
+}
+
+/** Doctrinal anchoring WITHOUT mutating the input `povNodes` (W2): clone the Beliefs, let
+ *  computeDoctrinalAnchoring mutate the clones in place, and derive explicit adjustments. */
+async function computeAnchoringAdjustments(
+  povNodes: PovNode[],
+  nodeEmbeddings: NodeEmbeddingMap,
+  doctrinalBoundaries: SelectRelevantTaxonomyInput['doctrinalBoundaries'],
+  embed: SelectRelevantTaxonomyInput['embed'],
+): Promise<DoctrinalAdjustment[]> {
+  if (!doctrinalBoundaries || doctrinalBoundaries.strings.length === 0) return [];
+  const boundaryVectors = await embed(doctrinalBoundaries.strings);
+  if (boundaryVectors.length === 0) return [];
+
+  const beliefs = povNodes.filter(n => n.category === 'Beliefs');
+  // Shallow clone is sufficient: computeDoctrinalAnchoring only writes scalar fields
+  // (doctrinally_anchored, confidence, evidential_confidence) on the node objects.
+  const clones = beliefs.map(n => ({ ...n }));
+  const results = computeDoctrinalAnchoring(
+    clones, boundaryVectors, nodeEmbeddings, undefined, undefined, doctrinalBoundaries.isRejection,
+  );
+
+  const adjustments: DoctrinalAdjustment[] = [];
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i];
+    const clone = clones[i]; // clones are all Beliefs → 1:1 with results, in order
+    if (!r.anchored && !r.floorApplied) continue;
+    adjustments.push({
+      nodeId: r.nodeId,
+      doctrinallyAnchored: r.anchored,
+      floorApplied: r.floorApplied,
+      confidence: clone.confidence ?? 0,
+      evidentialConfidence: r.floorApplied ? (clone.evidential_confidence ?? clone.confidence ?? 0) : (clone.confidence ?? 0),
+    });
+  }
+  return adjustments;
+}
+
+/** Score nodes: AN-claim similarity (primary, with per-node provenance) when AN claim embeddings
+ *  exist, else the topic-query fallback. Mirrors the renderer computeRelevanceScores exactly. */
+async function computeScores(
+  anClaimEmbeddings: ANClaimInput[],
+  nodeEmbeddings: NodeEmbeddingMap,
+  allNodeIds: string[],
+  params: SelectRelevantTaxonomyInput['params'],
+  embed: SelectRelevantTaxonomyInput['embed'],
+): Promise<{ scores: Map<string, number>; nodeSourceMap: Record<string, NodeScoringSource> }> {
+  const embedded = anClaimEmbeddings.filter(n => n.vector && n.vector.length > 0);
+  const query = buildRelevanceQuery(params.topic, params.recentTranscript);
+  const [queryVector] = await embed([query]);
+  const topN = params.topN ?? 3;
+
+  if (embedded.length > 0) {
+    const scores = scoreNodesViaAN(embedded, nodeEmbeddings, undefined, true);
+    const topicScores = scoreNodeRelevanceMeanTopN(queryVector, nodeEmbeddings, topN);
+    const nodeSourceMap = buildNodeSourceMap(allNodeIds, scores, topicScores, nodeEmbeddings, embedded);
+    return { scores, nodeSourceMap };
+  }
+  // No AN claims yet (pre-opening) — single topic query, no provenance.
+  const scores = scoreNodeRelevanceMeanTopN(queryVector, nodeEmbeddings, topN);
+  return { scores, nodeSourceMap: {} };
+}
+
+/** Per-node provenance: best-matching AN claim + AN-vs-topic comparison. Pure (moved verbatim from
+ *  the renderer buildNodeSourceMap; returns a plain object instead of a Map for wire-serialization). */
+function buildNodeSourceMap(
+  allNodeIds: string[],
+  scores: Map<string, number>,
+  topicScores: Map<string, number>,
+  nodeEmbeddings: NodeEmbeddingMap,
+  claimEmbeddings: ANClaimInput[],
+): Record<string, NodeScoringSource> {
+  const out: Record<string, NodeScoringSource> = {};
+  for (const nodeId of allNodeIds) {
+    const anScore = scores.get(nodeId) ?? 0;
+    const topicScore = topicScores.get(nodeId) ?? 0;
+    const entry = nodeEmbeddings[nodeId];
+    if (!entry?.vector) continue;
+    let bestSim = 0;
+    let bestClaim: ANClaimInput | null = null;
+    for (const claim of claimEmbeddings) {
+      const sim = cosineSimilarity(entry.vector, claim.vector);
+      if (sim > bestSim) { bestSim = sim; bestClaim = claim; }
+    }
+    out[nodeId] = {
+      source: anScore >= topicScore * 0.5 ? 'an' : 'topic',
+      anScore,
+      topicScore,
+      bestClaimId: bestClaim?.id,
+      bestClaimText: bestClaim?.text,
+      bestClaimSim: bestSim,
+    };
+  }
+  return out;
+}
+
+/** Build relevance-selection options, applying the lineage-tradition boost when a frame + static
+ *  lineage map are present. Pure (lineage comes from params, not renderer singletons; no logging). */
+function buildOptions(
+  threshold: number,
+  params: SelectRelevantTaxonomyInput['params'],
+  povNodes: PovNode[],
+  lineageFrame: SelectRelevantTaxonomyInput['session']['lineageFrame'],
+  lineageMapping: SelectRelevantTaxonomyInput['lineageMapping'],
+): RelevanceOptions {
+  const opts: RelevanceOptions = {
+    threshold,
+    minPerCategory: params.minPerCategory ?? 3,
+    maxTotal: params.maxTotal ?? 35,
+    // minPerPov intentionally unset → selectRelevantNodes defaults it to 2 (parity, t/3257#15).
+  };
+  if (params.scoringMode) opts.scoringMode = params.scoringMode;
+  if (lineageFrame && lineageFrame.length > 0 && lineageMapping) {
+    const lineageByNode: Record<string, string[]> = {};
+    for (const node of povNodes) {
+      const lineage = (node as { graph_attributes?: { intellectual_lineage?: (string | { name: string })[] } })
+        .graph_attributes?.intellectual_lineage;
+      if (lineage && lineage.length > 0) {
+        lineageByNode[node.id] = lineage.map(v => (typeof v === 'string' ? v : v.name));
+      }
+    }
+    const nameToCluster: Record<string, string> = {};
+    for (const [name, val] of Object.entries(lineageMapping)) nameToCluster[name] = val.l2;
+    opts.lineageBoost = {
+      traditions: lineageFrame.map(f => f.cluster_id),
+      boost: 0.08,
+      lineageByNode,
+      nameToCluster,
+    };
+  }
+  return opts;
+}
+
+/** Diagnostics-free injection manifest (the FR/console logging that wrapped this in the renderer is
+ *  the caller's job now; the `_lineageBoost` promotion data ships in the manifest for that). */
+function buildManifest(
+  scoredPov: ScoredPovNode[],
+  scoredCC: ScoredSituationNode[],
+  threshold: number,
+): Record<string, unknown> {
+  const lb = (scoredPov as unknown as { _lineageBoost?: { boostedNodeIds: string[]; promotedNodeIds: string[]; promotedCount: number } })._lineageBoost;
+  const manifest: Record<string, unknown> = {
+    povNodeIds: scoredPov.map(s => s.node.id),
+    povPrimaryIds: scoredPov.filter(s => s.score >= threshold + 0.1).map(s => s.node.id).slice(0, 5),
+    situationNodeIds: scoredCC.map(s => s.node.id),
+  };
+  if (lb && lb.boostedNodeIds.length > 0) {
+    manifest.lineage_boost = {
+      boosted: lb.boostedNodeIds.length,
+      promoted: lb.promotedCount,
+      boostedNodeIds: lb.boostedNodeIds.slice(0, 20),
+      promotedNodeIds: lb.promotedNodeIds.slice(0, 20),
+    };
+  }
+  return manifest;
+}
+
+/**
+ * The single relevance-selection pipeline. Deterministic given its inputs; the T2 parity fixture
+ * asserts server selection === today's client selection (same nodes, same ORDER, same
+ * nodeSourceMap/injectionManifest).
+ */
+export async function selectRelevantTaxonomy(input: SelectRelevantTaxonomyInput): Promise<RelevantTaxonomyResult> {
+  const { povNodes, situationNodes, policyRegistry, nodeEmbeddings, lineageMapping, doctrinalBoundaries, session, params, embed } = input;
+  const threshold = params.threshold ?? 0.45;
+
+  // 1. Doctrinal anchoring (read-only in; adjustments out — W2).
+  const anchoring = await computeAnchoringAdjustments(povNodes, nodeEmbeddings, doctrinalBoundaries, embed);
+
+  // 2. Relevance scores + per-node provenance (AN-primary, topic-query fallback).
+  const allNodeIds = [...povNodes.map(n => n.id), ...situationNodes.map(n => n.id)];
+  const { scores, nodeSourceMap } = await computeScores(session.anClaimEmbeddings, nodeEmbeddings, allNodeIds, params, embed);
+
+  // 3. Selection options (+ lineage boost) and greatest-hits exclusion (pure — list passed in).
+  const opts = buildOptions(threshold, params, povNodes, session.lineageFrame, lineageMapping);
+  if (session.excludeGreatestHits && session.greatestHitsList && session.greatestHitsList.length > 0) {
+    opts.greatestHitsExclude = new Set(session.greatestHitsList);
+  }
+
+  // 4. Order-preserving selection (W3).
+  const scoredPov = selectRelevantNodes(povNodes, scores, opts);
+  const scoredCC = selectRelevantSituationNodes(situationNodes, scores, threshold, 3, 15);
+
+  return {
+    povNodes: scoredPov.map(s => ({ nodeId: s.node.id, score: s.score })),
+    situationNodes: scoredCC.map(s => ({ nodeId: s.node.id, score: s.score })),
+    policyRegistry,
+    nodeSourceMap,
+    injectionManifest: buildManifest(scoredPov, scoredCC, threshold),
+    anchoring,
+  };
+}

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/taxonomyContext.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/taxonomyContext.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import type { PovNode, CrossCuttingNode as SituationNode } from '../../../types/taxonomy';
-import { AI_POVERS, POVER_INFO, POV_KEYS } from '../../../types/debate';
+import { POVER_INFO, POV_KEYS } from '../../../types/debate';
 import { useTaxonomyStore } from '../../useTaxonomyStore';
 // Circular import — safe because all references are at call-time, never at module init
 import { useDebateStore } from '../store';
@@ -10,23 +10,18 @@ import type { NodeScoringSource, RelevanceSourceEntry } from '../types';
 
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { nodeTypeFromId } from '@lib/debate/nodeIdUtils';
-import { embedDoctrinalBoundaries, computeDoctrinalAnchoring, checkThresholdAnomalies } from '@lib/debate/doctrinalAnchoring';
-import type { BoundaryEmbeddings } from '@lib/debate/doctrinalAnchoring';
 import { computeLineageDistribution, formatLineageContext } from '@lib/debate/topicCritique';
-import { cosineSimilarity, scoreNodeRelevanceMeanTopN, selectRelevantNodes, selectRelevantSituationNodes, buildRelevanceQuery, scoreNodesViaAN } from '../../../utils/taxonomyRelevance';
-import type { ANClaimEmbedding, RelevanceOptions } from '../../../utils/taxonomyRelevance';
+// t/3257: the relevance-selection pipeline moved to lib-pure; this file is now the thin CLIENT
+// wrapper (build corpus embeddings + fetch greatest-hits + assemble session state → call the pure
+// fn → re-apply anchoring + emit diagnostics + map the result). The server calls the SAME fn (T2).
+import { selectRelevantTaxonomy } from '@lib/debate/relevanceSelection';
+import type { ANClaimInput } from '@lib/debate/relevanceSelection';
 import type { TaxonomyContext } from '../../../utils/taxonomyContext';
-import { applyGreatestHitsExclusion } from './getGreatestHits';
+import { getGreatestHits } from './getGreatestHits';
 import { getLineageMapping, getL2Categories, isLineageDataLoaded } from '../../../data/lineageCategories';
 import { api } from '@bridge';
 
 export type { TaxonomyContext };
-
-// ── Doctrinal anchoring cache ────────────────────────────────────────
-// Tracks which POVs have had doctrinal anchoring applied in this session.
-// Once anchored, PovNode objects are mutated in place (doctrinally_anchored, confidence floor).
-let _doctrinalAnchoringApplied = new Set<string>();
-let _boundaryEmbeddingsCache: BoundaryEmbeddings | null = null;
 
 // ── Synthetic embeddings cache ───────────────────────────────────────
 // Loaded once per session from synthetic_embeddings.json via the bridge.
@@ -34,9 +29,10 @@ let _syntheticVectorsCache: Record<string, number[][]> | null = null;
 let _syntheticVectorsLoaded = false;
 
 /** Reset doctrinal anchoring cache (call when debate changes or taxonomy reloads). */
+/** Reset the session embedding caches (call when the debate changes or the taxonomy reloads).
+ *  t/3257: doctrinal anchoring is now stateless in the lib fn (re-applied idempotently per call),
+ *  so there is no longer an anchoring cache to clear — only the synthetic-vector cache remains. */
 export function resetDoctrinalAnchoringCache(): void {
-  _doctrinalAnchoringApplied = new Set();
-  _boundaryEmbeddingsCache = null;
   _syntheticVectorsCache = null;
   _syntheticVectorsLoaded = false;
 }
@@ -229,140 +225,6 @@ export async function buildNodeEmbeddingMap(pov: string, allPovNodes: PovNode[],
   return { nodeEmbeddings, allNodeIds };
 }
 
-/** Doctrinal anchoring: embed boundary strings once, then apply confidence floors to Beliefs (once per POV). */
-/** Embed doctrinal boundary strings into the shared cache once (across POVs). */
-async function ensureBoundaryEmbeddingsCache(): Promise<void> {
-  if (_boundaryEmbeddingsCache) return;
-  const boundaries: Record<string, string[]> = {};
-  for (const p of AI_POVERS) {
-    const info = POVER_INFO[p];
-    if ((info?.doctrinal_boundaries?.length ?? 0) > 0) {
-      boundaries[info.pov] = info.doctrinal_boundaries ?? [];
-    }
-  }
-  if (Object.keys(boundaries).length > 0) {
-    _boundaryEmbeddingsCache = await embedDoctrinalBoundaries(
-      boundaries,
-      async (text: string) => {
-        const { vector } = await api.computeQueryEmbedding(text);
-        return vector;
-      },
-    );
-  }
-}
-
-async function applyDoctrinalAnchoring(pov: string, allPovNodes: PovNode[], nodeEmbeddings: NodeEmbeddingMap): Promise<void> {
-  if (_doctrinalAnchoringApplied.has(pov)) return;
-  try {
-    // Embed boundary strings (cached across POVs)
-    await ensureBoundaryEmbeddingsCache();
-
-    const povBoundary = _boundaryEmbeddingsCache?.[pov];
-    if (povBoundary && povBoundary.vectors.length > 0) {
-      const beliefs = allPovNodes.filter(n => n.category === 'Beliefs');
-      const results = computeDoctrinalAnchoring(beliefs, povBoundary.vectors, nodeEmbeddings, undefined, undefined, povBoundary.isRejection);
-      const anomaly = checkThresholdAnomalies(results, beliefs.length);
-      if (anomaly) console.warn(anomaly.warning);
-      const anchoredCount = results.filter(r => r.anchored).length;
-      const floorCount = results.filter(r => r.floorApplied).length;
-      if (anchoredCount > 0) {
-        console.log(`[doctrinal] ${pov}: ${anchoredCount}/${beliefs.length} Beliefs anchored, ${floorCount} floor-applied`);
-      }
-    }
-    _doctrinalAnchoringApplied.add(pov);
-  } catch (err) {
-    getGlobalRecorder()?.record({
-      type: 'system.error',
-      component: 'debate-store',
-      level: 'warn',
-      message: 'Doctrinal anchoring failed',
-      error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
-    });
-    console.warn('[doctrinal] Anchoring failed (non-blocking):', err);
-    _doctrinalAnchoringApplied.add(pov); // don't retry on failure
-  }
-}
-
-/** Per-node source attribution: best-matching AN claim + AN-vs-topic comparison for each node. */
-function buildNodeSourceMap(
-  allNodeIds: string[],
-  scores: Map<string, number>,
-  topicScores: Map<string, number>,
-  nodeEmbeddings: NodeEmbeddingMap,
-  claimEmbeddings: ANClaimEmbedding[],
-  anNodes: { id: string; text?: string }[],
-): Map<string, NodeScoringSource> {
-  const nodeSourceMap = new Map<string, NodeScoringSource>();
-  for (const nodeId of allNodeIds) {
-    const anScore = scores.get(nodeId) ?? 0;
-    const topicScore = topicScores.get(nodeId) ?? 0;
-    const entry = nodeEmbeddings[nodeId];
-    if (!entry?.vector) continue;
-
-    // Find best matching AN claim for this node
-    let bestSim = 0;
-    let bestClaim: typeof claimEmbeddings[0] | null = null;
-    for (const claim of claimEmbeddings) {
-      const sim = cosineSimilarity(entry.vector, claim.vector);
-      if (sim > bestSim) { bestSim = sim; bestClaim = claim; }
-    }
-
-    const anNode = bestClaim ? anNodes.find(n => n.id === bestClaim!.id) : null;
-    nodeSourceMap.set(nodeId, {
-      source: anScore >= topicScore * 0.5 ? 'an' : 'topic',
-      anScore,
-      topicScore,
-      bestClaimId: bestClaim?.id,
-      bestClaimText: anNode?.text,
-      bestClaimSim: bestSim,
-    });
-  }
-  return nodeSourceMap;
-}
-
-/** Score nodes by relevance: AN-claim similarity when embeddings exist (with per-node source tracking), else topic query. */
-async function computeRelevanceScores(
-  topic: string,
-  recentTranscript: string,
-  nodeEmbeddings: NodeEmbeddingMap,
-  allNodeIds: string[],
-): Promise<{ scores: Map<string, number>; nodeSourceMap?: Map<string, NodeScoringSource> }> {
-  const debate = useDebateStore.getState().activeDebate;
-  const anNodes = debate?.argument_network?.nodes ?? [];
-  let scores: Map<string, number>;
-  let nodeSourceMap: Map<string, NodeScoringSource> | undefined;
-
-  // Use pre-computed embeddings from AN nodes (set by t/442 on extraction)
-  const embeddedAnNodes = anNodes.filter(n => n.embedding && n.embedding.length > 0);
-
-  if (embeddedAnNodes.length > 0) {
-    // AN-based scoring: use cached embeddings from extraction, score nodes by max similarity
-    const claimEmbeddings: ANClaimEmbedding[] = embeddedAnNodes.map(n => ({
-      id: n.id,
-      vector: n.embedding!,
-      strength: n.computed_strength,
-    }));
-
-    scores = scoreNodesViaAN(claimEmbeddings, nodeEmbeddings, undefined, true);
-    console.log(`[taxonomy] AN-based scoring: ${claimEmbeddings.length}/${anNodes.length} claims (with embeddings) against ${allNodeIds.length} nodes`);
-
-    // Also compute topic-only scores for hybrid source tracking
-    const query = buildRelevanceQuery(topic, recentTranscript);
-    const { vector: queryVector } = await api.computeQueryEmbedding(query);
-    const topicScores = scoreNodeRelevanceMeanTopN(queryVector, nodeEmbeddings);
-
-    // Build per-node source tracking: which AN claim matched best, AN vs topic comparison
-    nodeSourceMap = buildNodeSourceMap(allNodeIds, scores, topicScores, nodeEmbeddings, claimEmbeddings, anNodes);
-  } else {
-    // No AN yet (pre-opening) — fall back to single topic query
-    const query = buildRelevanceQuery(topic, recentTranscript);
-    const { vector: queryVector } = await api.computeQueryEmbedding(query);
-    scores = scoreNodeRelevanceMeanTopN(queryVector, nodeEmbeddings);
-    console.log(`[taxonomy] Topic-query scoring (no AN claims yet): ${allNodeIds.length} nodes`);
-  }
-  return { scores, nodeSourceMap };
-}
-
 /** Build the lineage→node map (intellectual_lineage graph attribute) for the given nodes. */
 function buildLineageByNode(nodes: PovNode[]): Record<string, string[]> {
   const lineageByNode: Record<string, string[]> = {};
@@ -406,49 +268,6 @@ function recordLineageBoostCheck(lineageFrame: { cluster_id: string }[] | undefi
   });
 }
 
-/** Build relevance-selection options, applying a lineage-tradition boost when a frame + lineage data are available. */
-function buildRelevanceOptions(threshold: number, debate: ReturnType<typeof useDebateStore.getState>['activeDebate'], allPovNodes: PovNode[]): RelevanceOptions {
-  const relevanceOpts: RelevanceOptions = { threshold, minPerCategory: 3, maxTotal: 35 };
-  const lineageFrame = debate?.topic?.critique?.lineage_frame;
-  recordLineageBoostCheck(lineageFrame, debate?.source_type === 'topic');
-  if (lineageFrame && lineageFrame.length > 0 && isLineageDataLoaded()) {
-    const mapping = getLineageMapping();
-    const lineageByNode = buildLineageByNode(allPovNodes);
-    const nameToCluster = buildNameToCluster(mapping);
-    relevanceOpts.lineageBoost = {
-      traditions: lineageFrame.map(f => f.cluster_id),
-      boost: 0.08,
-      lineageByNode,
-      nameToCluster,
-    };
-    getGlobalRecorder()?.record({
-      type: 'lineage.boost-applied',
-      component: 'debate-store',
-      level: 'info',
-      message: 'Lineage boost applied',
-      data: {
-        traditions: lineageFrame.map((f: { cluster_id: string; label?: string }) => f.label ?? f.cluster_id),
-        node_count_with_lineage: Object.keys(lineageByNode).length,
-        cluster_count: Object.keys(nameToCluster).length,
-        boost_value: 0.08,
-      },
-    });
-  } else if (lineageFrame) {
-    getGlobalRecorder()?.record({
-      type: 'lineage.boost-skipped',
-      component: 'debate-store',
-      level: 'warn',
-      message: 'Lineage boost skipped',
-      data: {
-        reason: lineageFrame.length === 0 ? 'empty_frame' : 'data_not_loaded',
-        frame_count: lineageFrame.length,
-        lineage_data_loaded: isLineageDataLoaded(),
-      },
-    });
-  }
-  return relevanceOpts;
-}
-
 /**
  * Surface a user-visible debate warning when greatest-hits exclusion was requested but
  * not applied (t/1998 loud-degrade). Store-touching companion to the store-free
@@ -463,42 +282,18 @@ function surfaceGreatestHitsWarning(outcome: { requested: boolean; applied: bool
   }
 }
 
-/** Build the diagnostics injection manifest and log the lineage-boost promotion outcome. */
-function buildInjectionManifest(
-  scoredPov: ReturnType<typeof selectRelevantNodes>,
-  scoredCC: ReturnType<typeof selectRelevantSituationNodes>,
-  threshold: number,
-  allPovNodes: PovNode[],
-): Record<string, unknown> {
-  // Log lineage boost outcome — confirms how many nodes were actually promoted
-  const _lb = (scoredPov as unknown as { _lineageBoost?: { boostedNodeIds: string[]; promotedNodeIds: string[]; promotedCount: number } })._lineageBoost;
-  if (_lb) {
-    getGlobalRecorder()?.record({
-      type: 'lineage.boost-result',
-      component: 'debate-store',
-      level: _lb.promotedCount > 0 ? 'info' : 'debug',
-      message: _lb.promotedCount > 0
-        ? `Lineage boost promoted ${_lb.promotedCount} nodes`
-        : 'Lineage boost applied but promoted 0 nodes',
-      data: { boosted_count: _lb.boostedNodeIds.length, promoted_count: _lb.promotedCount, promoted_node_ids: _lb.promotedNodeIds?.slice(0, 10), total_selected: scoredPov.length, total_candidates: allPovNodes.length },
-    });
-  }
-
-  // Build injection manifest for diagnostics (mirrors debateEngine's _lastInjectionManifest)
-  const injectionManifest: Record<string, unknown> = {
-    povNodeIds: scoredPov.map(s => s.node.id),
-    povPrimaryIds: scoredPov.filter(s => s.score >= threshold + 0.1).map(s => s.node.id).slice(0, 5),
-    situationNodeIds: scoredCC.map(s => s.node.id),
-  };
-  if (_lb && _lb.boostedNodeIds.length > 0) {
-    injectionManifest.lineage_boost = {
-      boosted: _lb.boostedNodeIds.length,
-      promoted: _lb.promotedCount,
-      boostedNodeIds: _lb.boostedNodeIds.slice(0, 20),
-      promotedNodeIds: _lb.promotedNodeIds.slice(0, 20),
-    };
-  }
-  return injectionManifest;
+/** Log the lineage-boost promotion outcome from the lib fn's returned injectionManifest (the
+ *  manifest is built pure inside selectRelevantTaxonomy now; this is the client-side FR logging). */
+function logLineageBoostResult(injectionManifest: Record<string, unknown>, totalSelected: number, totalCandidates: number): void {
+  const lb = injectionManifest.lineage_boost as { boosted: number; promoted: number; promotedNodeIds: string[] } | undefined;
+  if (!lb) return;
+  getGlobalRecorder()?.record({
+    type: 'lineage.boost-result',
+    component: 'debate-store',
+    level: lb.promoted > 0 ? 'info' : 'debug',
+    message: lb.promoted > 0 ? `Lineage boost promoted ${lb.promoted} nodes` : 'Lineage boost applied but promoted 0 nodes',
+    data: { boosted_count: lb.boosted, promoted_count: lb.promoted, promoted_node_ids: lb.promotedNodeIds?.slice(0, 10), total_selected: totalSelected, total_candidates: totalCandidates },
+  });
 }
 
 /** Emit the situation interpretation-divergence summary — surfaces interpretation alignment at debate setup. */
@@ -566,44 +361,73 @@ export async function getRelevantTaxonomyContext(
   const allCCNodes: SituationNode[] = state.situations?.nodes ?? [];
 
   try {
-    const { nodeEmbeddings, allNodeIds } = await buildNodeEmbeddingMap(pov, allPovNodes, allCCNodes);
-
-    // Doctrinal anchoring: embed boundary strings once, then apply confidence floors to Beliefs
-    await applyDoctrinalAnchoring(pov, allPovNodes, nodeEmbeddings);
-
-    // Score nodes by relevance (AN-claim-based when embeddings exist, else topic-query fallback)
-    const { scores, nodeSourceMap } = await computeRelevanceScores(topic, recentTranscript, nodeEmbeddings, allNodeIds);
-
-    // Build relevance options with optional lineage boost
     const debate = useDebateStore.getState().activeDebate;
-    const relevanceOpts = buildRelevanceOptions(threshold, debate, allPovNodes);
 
-    // Greatest-hits exclusion (t/1998) — app mirror of the CLI engine (debateEngine/
-    // taxonomyContext.ts:266). Degrades LOUDLY, not by throwing (TL decision, PM p/19#120):
-    // when the flag is On but the exclusion list is unavailable, exclusion is skipped and
-    // surfaceGreatestHitsWarning raises a user-visible note so the overview can show
-    // "On — not applied".
-    const ghOutcome = await applyGreatestHitsExclusion(relevanceOpts, debate?.exclude_greatest_hits);
-    surfaceGreatestHitsWarning(ghOutcome);
+    // Corpus embeddings — renderer IO + per-debate memo — passed to the pure fn (server builds its own).
+    const { nodeEmbeddings } = await buildNodeEmbeddingMap(pov, allPovNodes, allCCNodes);
 
-    const scoredPov = selectRelevantNodes(allPovNodes, scores, relevanceOpts);
-    const scoredCC = selectRelevantSituationNodes(allCCNodes, scores, threshold, 3, 15);
+    // ── Assemble the pure-fn input (session state crosses the wire in the T2/T3 split) ──
+    const anClaimEmbeddings: ANClaimInput[] = (debate?.argument_network?.nodes ?? [])
+      .filter(n => n.embedding && n.embedding.length > 0)
+      .map(n => ({ id: n.id, vector: n.embedding!, strength: n.computed_strength, text: n.text }));
+    const lineageFrame = debate?.topic?.critique?.lineage_frame;
+    const excludeGreatestHits = !!debate?.exclude_greatest_hits;
+    const greatestHitsList = excludeGreatestHits ? await getGreatestHits() : undefined;
+    // Static/server-derivable: current POV's doctrinal boundaries (POVER_INFO) + the lineage L2 map.
+    const povInfo = Object.values(POVER_INFO).find(i => i.pov === pov);
+    const doctrinalBoundaries = (povInfo?.doctrinal_boundaries?.length ?? 0) > 0
+      ? { strings: povInfo!.doctrinal_boundaries ?? [] }
+      : undefined;
+    const lineageMapping = isLineageDataLoaded() ? getLineageMapping() : undefined;
+    // Boundary + topic-query embeddings use computeQueryEmbedding (matches the pre-extraction path).
+    const embed = async (texts: string[]): Promise<number[][]> =>
+      Promise.all(texts.map(async t => (await api.computeQueryEmbedding(t)).vector));
 
-    const injectionManifest = buildInjectionManifest(scoredPov, scoredCC, threshold, allPovNodes);
+    recordLineageBoostCheck(lineageFrame, debate?.source_type === 'topic');
 
-    // Unwrap ScoredPovNode → PovNode and build nodeScores map
-    const filteredPov = scoredPov.map(s => s.node);
-    const filteredCC = scoredCC.map(s => s.node);
+    const result = await selectRelevantTaxonomy({
+      povNodes: allPovNodes,
+      situationNodes: allCCNodes,
+      policyRegistry: (state.policyRegistry ?? []).map(p => ({ id: p.id, action: p.action, source_povs: p.source_povs })),
+      nodeEmbeddings,
+      lineageMapping,
+      doctrinalBoundaries,
+      session: { anClaimEmbeddings, lineageFrame, sourceType: debate?.source_type, excludeGreatestHits, greatestHitsList },
+      params: { pov, topic, recentTranscript, threshold },
+      embed,
+    });
+
+    // ── Re-apply the doctrinal-anchoring side-effect to the store's Belief nodes ──
+    // (mirrors the old in-place mutation EXACTLY: doctrinally_anchored always; confidence floor
+    // only when applied — that's why DoctrinalAdjustment carries floorApplied, t/3257#16 Δ1.)
+    const povById = new Map(allPovNodes.map(n => [n.id, n] as const));
+    for (const adj of result.anchoring) {
+      const node = povById.get(adj.nodeId);
+      if (!node) continue;
+      node.doctrinally_anchored = adj.doctrinallyAnchored || undefined;
+      if (adj.floorApplied) {
+        node.evidential_confidence = adj.evidentialConfidence;
+        node.confidence = adj.confidence;
+      }
+    }
+
+    // Greatest-hits loud-degrade warning (t/1998): requested but the list was unavailable.
+    surfaceGreatestHitsWarning({ requested: excludeGreatestHits, applied: !!(greatestHitsList && greatestHitsList.length > 0) });
+
+    // ── Map the lib result (ids + scores) back to full node objects + the consumer-facing maps ──
+    const ccById = new Map(allCCNodes.map(n => [n.id, n] as const));
+    const filteredPov = result.povNodes.map(r => povById.get(r.nodeId)).filter((n): n is PovNode => !!n);
+    const filteredCC = result.situationNodes.map(r => ccById.get(r.nodeId)).filter((n): n is SituationNode => !!n);
     const nodeScores = new Map<string, number>();
-    for (const s of scoredPov) nodeScores.set(s.node.id, s.score);
-    for (const s of scoredCC) nodeScores.set(s.node.id, s.score);
+    for (const r of result.povNodes) nodeScores.set(r.nodeId, r.score);
+    for (const r of result.situationNodes) nodeScores.set(r.nodeId, r.score);
+    const nodeSourceMap = new Map(Object.entries(result.nodeSourceMap));
 
     console.log(`[taxonomy] Relevance-filtered: ${filteredPov.length} POV nodes (from ${allPovNodes.length}), ${filteredCC.length} CC nodes (from ${allCCNodes.length})`);
-
+    logLineageBoostResult(result.injectionManifest, filteredPov.length, allPovNodes.length);
     recordSituationDivergence(filteredCC, allCCNodes);
 
-    const policyRegistry = (state.policyRegistry ?? []).map(p => ({ id: p.id, action: p.action, source_povs: p.source_povs }));
-    return { povNodes: filteredPov, situationNodes: filteredCC, policyRegistry, nodeScores, nodeSourceMap, injectionManifest };
+    return { povNodes: filteredPov, situationNodes: filteredCC, policyRegistry: result.policyRegistry, nodeScores, nodeSourceMap, injectionManifest: result.injectionManifest };
   } catch (err) {
     getGlobalRecorder()?.record({
       type: 'system.error',

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/types.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/types.ts
@@ -51,14 +51,10 @@ export interface ReflectionResult {
   new_item_proposals?: NewPovItemProposal[];
 }
 
-export interface NodeScoringSource {
-  source: 'an' | 'topic';
-  anScore: number;
-  topicScore: number;
-  bestClaimId?: string;
-  bestClaimText?: string;
-  bestClaimSim?: number;
-}
+// t/3257: source of truth relocated to lib/debate/relevanceSelection.ts (the pure relevance-
+// selection fn produces it; server + client type against the same definition). Re-exported here
+// so existing renderer imports (`from '../types'`) keep working.
+export type { NodeScoringSource } from '@lib/debate/relevanceSelection';
 
 export interface RelevanceSourceEntry {
   node_id: string;


### PR DESCRIPTION
**Draft — held for DebateTool co-review (their lib file) + TL parity GV.** The renderer half of the t/3257 relocation (T3) + the shared lib fn both callers use. Built on the TL-approved decomposition (t/3257#7/#8) + the signed-off interface (deltas t/3257#15/#17).

## Change (+399 / −263, 3 files)
- **NEW `lib/debate/relevanceSelection.ts`** (DebateTool scope; co-owned extraction) — pure `selectRelevantTaxonomy`. Composes the already-lib leaf fns; no store/singletons/logging; `povNodes` read-only (belief-clone → W2); order-preserving (W3); returns the full `RelevantTaxonomyResult` (W1). Exports `NodeScoringSource`/`NodeEmbeddingMap`/`ANClaimEmbedding` for the T2 caller.
- **`taxonomyContext.ts`** — now the thin CLIENT wrapper (build corpus embeddings + fetch greatest-hits + assemble session → call the pure fn → re-apply anchoring to the store, keyed on `floorApplied`, + emit diagnostics + map ids→nodes). Removed the 5 now-lib helpers; kept `buildLineageByNode`/`buildNameToCluster` (also used by the fallback-lineage path).
- **`types.ts`** — `NodeScoringSource` re-exported from lib.

## Co-review points (flagging honestly)
- **Anchoring re-apply** mirrors the old in-place mutation exactly (doctrinally_anchored always; confidence floor only when `floorApplied`).
- **embed adapter uses `computeQueryEmbedding`** per text (matches the pre-extraction path for boundaries + topic query — not `computeEmbeddings`).
- **Diagnostic consolidation:** dropped `checkThresholdAnomalies` console.warn (Δ3, approved) and folded lineage `boost-applied`/`boost-skipped` into `boost-check` + `boost-result`. Restore if you want them.
- Minor: doctrinal boundaries re-embed per speaker (no cross-POV cache) — 3× ~4 strings, trivial vs the corpus.

## Verify
- renderer-tsc **0 errors** in changed files (3 `../lib` errors are the known worktree artifact); lib-tsc clean.
- **useDebateStore 277/277** + the **t/3165 corpus-dedup** regression pass; eslint 0 errors (pre-existing no-console only).

Next: DebateTool co-review → un-draft → **TL parity GV** (the T2 fixture asserts server===client, order-preserving). ServerAPI builds T2 + fixture against the lib fn once this lands.

Commit: 5406aa81