### PR TITLE
feat(debate): MACHINE ANNOTATIONS block — structural separation for graph_attributes (t/3264 Phase B)

### DIFF
--- a/lib/debate/taxonomyContext.test.ts
+++ b/lib/debate/taxonomyContext.test.ts
@@ -316,3 +316,54 @@ describe('formatTaxonomyContext — RETRIEVED CONTEXT block (t/3264)', () => {
     expect(situationsIdx).toBeGreaterThan(retrievedIdx);
   });
 });
+
+function makeAnnotatedNode(id: string, label: string): PovNode {
+  return {
+    id, category: 'Beliefs', label, description: 'desc',
+    parent_id: null, children: [], situation_refs: [],
+    graph_attributes: { epistemic_type: 'empirical_claim', steelman_vulnerability: 'key vulnerability here' },
+  };
+}
+
+describe('formatTaxonomyContext — MACHINE ANNOTATIONS block (t/3264 Phase B)', () => {
+  it('flag OFF (default) keeps generateNodeGuidance inline — no MACHINE ANNOTATIONS block', () => {
+    const ctx = { povNodes: [makeAnnotatedNode('acc-bel-010', 'Annotated')], situationNodes: [] };
+    const output = formatTaxonomyContext(ctx, 'accelerationist');
+    expect(output).not.toContain('MACHINE ANNOTATIONS');
+    expect(output).toContain('ARGUE:');
+    expect(output).toContain('VULNERABLE:');
+  });
+
+  it('flag ON renders MACHINE ANNOTATIONS block and removes guidance from inline BDI section', () => {
+    const ctx = { povNodes: [makeAnnotatedNode('acc-bel-010', 'Annotated')], situationNodes: [] };
+    const output = formatTaxonomyContext(ctx, 'accelerationist', undefined, { machineAnnotationsEnabled: true });
+    expect(output).toContain('MACHINE ANNOTATIONS');
+    expect(output).toContain('advisory signals');
+    expect(output).toContain('acc-bel-010');
+    // Guidance appears in the block
+    expect(output).toContain('ARGUE:');
+    // The inline [heuristic] prefix is suppressed
+    expect(output).not.toContain('[heuristic] The following tactical annotations');
+  });
+
+  it('flag ON emits no MACHINE ANNOTATIONS block when nodes have no guidance fields', () => {
+    const ctx = {
+      povNodes: [makeNode('acc-bel-011', 'Plain', 'plain desc')],
+      situationNodes: [],
+    };
+    const output = formatTaxonomyContext(ctx, 'accelerationist', undefined, { machineAnnotationsEnabled: true });
+    expect(output).not.toContain('MACHINE ANNOTATIONS');
+  });
+
+  it('MACHINE ANNOTATIONS block appears after RETRIEVED CONTEXT and before SITUATIONS', () => {
+    const ctx = {
+      povNodes: [makeAnnotatedNode('acc-bel-010', 'Annotated')],
+      situationNodes: [makeSit('sit-001', 'A Situation')],
+    };
+    const output = formatTaxonomyContext(ctx, 'accelerationist', undefined, { machineAnnotationsEnabled: true });
+    const machineIdx = output.indexOf('MACHINE ANNOTATIONS');
+    const situationsIdx = output.indexOf('SITUATIONS');
+    expect(machineIdx).toBeGreaterThan(-1);
+    expect(situationsIdx).toBeGreaterThan(machineIdx);
+  });
+});

--- a/lib/debate/taxonomyContext.test.ts
+++ b/lib/debate/taxonomyContext.test.ts
@@ -325,45 +325,47 @@ function makeAnnotatedNode(id: string, label: string): PovNode {
   };
 }
 
-describe('formatTaxonomyContext — MACHINE ANNOTATIONS block (t/3264 Phase B)', () => {
-  it('flag OFF (default) keeps generateNodeGuidance inline — no MACHINE ANNOTATIONS block', () => {
+describe('formatTaxonomyContext — EXTERNAL ANALYTICAL SIGNALS block (t/3264 Phase B v3)', () => {
+  it('flag OFF (default) keeps generateNodeGuidance inline — no EXTERNAL ANALYTICAL SIGNALS block', () => {
     const ctx = { povNodes: [makeAnnotatedNode('acc-bel-010', 'Annotated')], situationNodes: [] };
     const output = formatTaxonomyContext(ctx, 'accelerationist');
-    expect(output).not.toContain('MACHINE ANNOTATIONS');
+    expect(output).not.toContain('EXTERNAL ANALYTICAL SIGNALS');
     expect(output).toContain('ARGUE:');
     expect(output).toContain('VULNERABLE:');
   });
 
-  it('flag ON renders MACHINE ANNOTATIONS block and removes guidance from inline BDI section', () => {
+  it('flag ON renders EXTERNAL ANALYTICAL SIGNALS block with third-party voice, removes inline guidance', () => {
     const ctx = { povNodes: [makeAnnotatedNode('acc-bel-010', 'Annotated')], situationNodes: [] };
     const output = formatTaxonomyContext(ctx, 'accelerationist', undefined, { machineAnnotationsEnabled: true });
-    expect(output).toContain('MACHINE ANNOTATIONS');
-    expect(output).toContain('NOT established facts about your position');
-    expect(output).toContain('acc-bel-010');
-    // Guidance appears in the block
-    expect(output).toContain('ARGUE:');
+    expect(output).toContain('EXTERNAL ANALYTICAL SIGNALS');
+    expect(output).toContain('not your beliefs or position assessments');
+    // [id] as pointer in third-party voice
+    expect(output).toContain('External analysis of argument [acc-bel-010]');
+    // Annotation content present (epistemic_type + steelman from makeAnnotatedNode fixture)
+    expect(output).toContain('epistemic_type: empirical_claim');
+    expect(output).toContain('steelman_vulnerability');
     // The inline [heuristic] prefix is suppressed
     expect(output).not.toContain('[heuristic] The following tactical annotations');
   });
 
-  it('flag ON emits no MACHINE ANNOTATIONS block when nodes have no guidance fields', () => {
+  it('flag ON emits no EXTERNAL ANALYTICAL SIGNALS block when nodes have no annotation fields', () => {
     const ctx = {
       povNodes: [makeNode('acc-bel-011', 'Plain', 'plain desc')],
       situationNodes: [],
     };
     const output = formatTaxonomyContext(ctx, 'accelerationist', undefined, { machineAnnotationsEnabled: true });
-    expect(output).not.toContain('MACHINE ANNOTATIONS');
+    expect(output).not.toContain('EXTERNAL ANALYTICAL SIGNALS');
   });
 
-  it('MACHINE ANNOTATIONS block appears after RETRIEVED CONTEXT and before SITUATIONS', () => {
+  it('EXTERNAL ANALYTICAL SIGNALS block appears after RETRIEVED CONTEXT and before SITUATIONS', () => {
     const ctx = {
       povNodes: [makeAnnotatedNode('acc-bel-010', 'Annotated')],
       situationNodes: [makeSit('sit-001', 'A Situation')],
     };
     const output = formatTaxonomyContext(ctx, 'accelerationist', undefined, { machineAnnotationsEnabled: true });
-    const machineIdx = output.indexOf('MACHINE ANNOTATIONS');
+    const externalIdx = output.indexOf('EXTERNAL ANALYTICAL SIGNALS');
     const situationsIdx = output.indexOf('SITUATIONS');
-    expect(machineIdx).toBeGreaterThan(-1);
-    expect(situationsIdx).toBeGreaterThan(machineIdx);
+    expect(externalIdx).toBeGreaterThan(-1);
+    expect(situationsIdx).toBeGreaterThan(externalIdx);
   });
 });

--- a/lib/debate/taxonomyContext.test.ts
+++ b/lib/debate/taxonomyContext.test.ts
@@ -338,7 +338,7 @@ describe('formatTaxonomyContext — MACHINE ANNOTATIONS block (t/3264 Phase B)',
     const ctx = { povNodes: [makeAnnotatedNode('acc-bel-010', 'Annotated')], situationNodes: [] };
     const output = formatTaxonomyContext(ctx, 'accelerationist', undefined, { machineAnnotationsEnabled: true });
     expect(output).toContain('MACHINE ANNOTATIONS');
-    expect(output).toContain('advisory signals');
+    expect(output).toContain('NOT established facts about your position');
     expect(output).toContain('acc-bel-010');
     // Guidance appears in the block
     expect(output).toContain('ARGUE:');

--- a/lib/debate/taxonomyContext.ts
+++ b/lib/debate/taxonomyContext.ts
@@ -367,8 +367,8 @@ export function formatTaxonomyContext(ctx: TaxonomyContext, pov: string, maxNode
   if (cfg.machineAnnotationsEnabled) {
     const annotatedNodes = povSlice.filter(n => generateNodeGuidance(n, n.category || 'Beliefs').length > 0);
     if (annotatedNodes.length > 0) {
-      lines.push('=== MACHINE ANNOTATIONS (advisory signals — use as tactical guidance, not grounding) ===');
-      lines.push('These are machine-generated signals about your nodes. They are advisory — useful prompts for argument construction, not authoritative facts about your position.');
+      lines.push('=== MACHINE ANNOTATIONS (unverified signals — NOT established facts about your position) ===');
+      lines.push('These machine-generated signals are external to your verified beliefs. A claim here you cannot independently confirm is a candidate to evaluate — not yours to assert.');
       lines.push('');
       for (const n of annotatedNodes) {
         const guidance = generateNodeGuidance(n, n.category || 'Beliefs');

--- a/lib/debate/taxonomyContext.ts
+++ b/lib/debate/taxonomyContext.ts
@@ -119,6 +119,15 @@ export interface FormatContextConfig {
    * No-op today (no nodes have verification_status set); safe to land inert.
    */
   retrievedContextEnabled?: boolean;
+  /**
+   * Enable the MACHINE ANNOTATIONS block — moves generateNodeGuidance output (epistemic_type,
+   * falsifiability, assumes, steelman_vulnerability, doctrinal anchor) out of the inline BDI node
+   * rendering into a structurally-separate advisory block (t/3264 Phase B, Arm 2 mitigation).
+   * DEFAULT: false (behavior-preserving). Graph_attributes annotations are written live today, so
+   * flipping changes live prompt behavior. Land flag-OFF → CL A_anno_structural validates → TL GV
+   * → then flip on. Set true only after probe clears.
+   */
+  machineAnnotationsEnabled?: boolean;
 }
 
 /** Generate per-node inline guidance lines from metadata.
@@ -295,8 +304,8 @@ export function formatTaxonomyContext(ctx: TaxonomyContext, pov: string, maxNode
       sorted = sorted.slice(0, maxDesires);
     }
 
-    // t/3146: machine-origin signal — emitted once per category section, before any node guidance
-    if (sorted.length > 0) {
+    // t/3146: machine-origin signal (inline mode — suppressed when machineAnnotationsEnabled moves guidance to its own block)
+    if (!cfg.machineAnnotationsEnabled && sorted.length > 0) {
       lines.push('  [heuristic] The following tactical annotations are machine-estimated heuristics, not established facts — use them as suggestions.');
     }
     for (let i = 0; i < sorted.length; i++) {
@@ -308,8 +317,11 @@ export function formatTaxonomyContext(ctx: TaxonomyContext, pov: string, maxNode
         const weightLabel = nodeWeightLabel(n, cat);
         lines.push(`${prefix}[${n.id}]${weightLabel}`);
         lines.push(`  "${n.label}" — ${stripExcludes(n.description)}`);
-        const guidance = generateNodeGuidance(n, cat);
-        lines.push(...guidance);
+        // t/3264 Phase B: guidance moves to MACHINE ANNOTATIONS block when flag is on; inline otherwise
+        if (!cfg.machineAnnotationsEnabled) {
+          const guidance = generateNodeGuidance(n, cat);
+          lines.push(...guidance);
+        }
       } else {
         lines.push(`${prefix}[${n.id}] "${n.label}"`);
       }
@@ -349,6 +361,22 @@ export function formatTaxonomyContext(ctx: TaxonomyContext, pov: string, maxNode
       lines.push(`  "${n.label}" — ${stripExcludes(n.description)}`);
     }
     lines.push('');
+  }
+
+  // t/3264 Phase B: MACHINE ANNOTATIONS block — structurally separate advisory signals (flag-gated, default off)
+  if (cfg.machineAnnotationsEnabled) {
+    const annotatedNodes = povSlice.filter(n => generateNodeGuidance(n, n.category || 'Beliefs').length > 0);
+    if (annotatedNodes.length > 0) {
+      lines.push('=== MACHINE ANNOTATIONS (advisory signals — use as tactical guidance, not grounding) ===');
+      lines.push('These are machine-generated signals about your nodes. They are advisory — useful prompts for argument construction, not authoritative facts about your position.');
+      lines.push('');
+      for (const n of annotatedNodes) {
+        const guidance = generateNodeGuidance(n, n.category || 'Beliefs');
+        lines.push(`  [${n.id}] "${n.label}":`);
+        lines.push(...guidance);
+      }
+      lines.push('');
+    }
   }
 
   // Situations section — hierarchy-grouped with Lost-in-the-Middle ordering

--- a/lib/debate/taxonomyContext.ts
+++ b/lib/debate/taxonomyContext.ts
@@ -120,12 +120,12 @@ export interface FormatContextConfig {
    */
   retrievedContextEnabled?: boolean;
   /**
-   * Enable the MACHINE ANNOTATIONS block — moves generateNodeGuidance output (epistemic_type,
-   * falsifiability, assumes, steelman_vulnerability, doctrinal anchor) out of the inline BDI node
-   * rendering into a structurally-separate advisory block (t/3264 Phase B, Arm 2 mitigation).
-   * DEFAULT: false (behavior-preserving). Graph_attributes annotations are written live today, so
-   * flipping changes live prompt behavior. Land flag-OFF → CL A_anno_structural validates → TL GV
-   * → then flip on. Set true only after probe clears.
+   * Enable the EXTERNAL ANALYTICAL SIGNALS block — moves graph_attributes annotations out of the
+   * inline BDI node rendering into a structurally-separate, fully-external-voice block (t/3264
+   * Phase B v3, Option A). Third-party observational voice severs ownership association:
+   * "External analysis of argument [id]..." rather than "[id]: VULNERABLE: ..." (t/3264#19).
+   * DEFAULT: false (behavior-preserving). Annotations are live today, so flipping changes prompt
+   * behavior. Land flag-OFF → CL A_anno_struct_v3 validates → TL GV → then flip on.
    */
   machineAnnotationsEnabled?: boolean;
 }
@@ -176,6 +176,59 @@ export function generateNodeGuidance(node: PovNode, category: string): string[] 
   }
 
   return lines;
+}
+
+/** Generate fully-external-voice annotation lines for a node (t/3264 Phase B v3, Option A).
+ *  Third-party observational voice: "External analysis of argument [id]..." with [id] as pointer only.
+ *  Severs ownership by NOT using assertive-ownership syntax ("[id]: VULNERABLE: ..."). */
+export function generateExternalAnnotationLines(node: PovNode): string[] {
+  const ga = node.graph_attributes;
+  if (!ga) return [];
+
+  const contentLines: string[] = [];
+
+  if (ga.epistemic_type) {
+    const guidance: Record<string, string> = {
+      empirical_claim: 'opponents may demand primary sources and peer-reviewed evidence',
+      normative_prescription: 'opponents may challenge coherence with stated principles or tradeoffs',
+      strategic_recommendation: 'opponents may challenge feasibility, implementation, or cost-benefit',
+      interpretive_lens: 'opponents may challenge explanatory power or offer counter-interpretations',
+    };
+    const hint = guidance[ga.epistemic_type] ?? '';
+    contentLines.push(`    epistemic_type: ${ga.epistemic_type}${hint ? ` — ${hint}` : ''}`);
+  }
+
+  if (ga.falsifiability) {
+    const guidance: Record<string, string> = {
+      high: 'opponents may use counter-evidence, methodological critique, or replication failure',
+      medium: 'opponents may exploit scope limits, competing frameworks, or edge cases',
+      low: 'opponents may use coherence challenges, analogical breakdown, or generalization failure',
+    };
+    const hint = guidance[ga.falsifiability] ?? '';
+    contentLines.push(`    falsifiability: ${ga.falsifiability}${hint ? ` — ${hint}` : ''}`);
+  }
+
+  if (ga.assumes?.length) {
+    const top2 = ga.assumes.slice(0, 2).map(a => `"${a}"`).join(', ');
+    contentLines.push(`    assumes: ${top2} — these premises may be challenged`);
+  }
+
+  if (ga.steelman_vulnerability) {
+    const sv = ga.steelman_vulnerability;
+    const svText = typeof sv === 'string' ? sv : Object.values(sv).filter(Boolean).join(' | ');
+    if (svText) contentLines.push(`    steelman_vulnerability: "${svText}" [external assessment — verify independently]`);
+  }
+
+  if (node.doctrinally_anchored) {
+    contentLines.push(`    doctrinally_anchored: true — high concession cost flagged`);
+  }
+
+  if (contentLines.length === 0) return [];
+
+  return [
+    `  External analysis of argument [${node.id}] ("${node.label}"):`,
+    ...contentLines,
+  ];
 }
 
 /** Compute weighted sort score: Beliefs use relevance×confidence, Desires use relevance×(priority/5), Intentions use relevance×(operationality/5). */
@@ -363,17 +416,17 @@ export function formatTaxonomyContext(ctx: TaxonomyContext, pov: string, maxNode
     lines.push('');
   }
 
-  // t/3264 Phase B: MACHINE ANNOTATIONS block — structurally separate advisory signals (flag-gated, default off)
+  // t/3264 Phase B v3: EXTERNAL ANALYTICAL SIGNALS block — fully-external-voice, Option A (flag-gated, default off)
   if (cfg.machineAnnotationsEnabled) {
-    const annotatedNodes = povSlice.filter(n => generateNodeGuidance(n, n.category || 'Beliefs').length > 0);
-    if (annotatedNodes.length > 0) {
-      lines.push('=== MACHINE ANNOTATIONS (unverified signals — NOT established facts about your position) ===');
-      lines.push('These machine-generated signals are external to your verified beliefs. A claim here you cannot independently confirm is a candidate to evaluate — not yours to assert.');
+    const annotationEntries = povSlice
+      .map(n => generateExternalAnnotationLines(n))
+      .filter(entry => entry.length > 0);
+    if (annotationEntries.length > 0) {
+      lines.push('=== EXTERNAL ANALYTICAL SIGNALS (unverified — not your beliefs or position assessments) ===');
+      lines.push('Third-party analytical classifications of arguments in this debate domain. Machine-generated and unverified — treat as external observations, not your own position assessments.');
       lines.push('');
-      for (const n of annotatedNodes) {
-        const guidance = generateNodeGuidance(n, n.category || 'Beliefs');
-        lines.push(`  [${n.id}] "${n.label}":`);
-        lines.push(...guidance);
+      for (const entry of annotationEntries) {
+        lines.push(...entry);
       }
       lines.push('');
     }


### PR DESCRIPTION
## Summary

- **Finding**: Arm 2 probe showed graph_attributes inline annotations adopt at ceiling (0.92) even with the t/3146 heuristic-prefix — Δ−0.04, same ceiling as the grounding block (0.96). Framing alone is insufficient (consistent with Arm 1 / t/3262).
- **Fix**: `machineAnnotationsEnabled` flag (default **false**, behavior-preserving) that moves `generateNodeGuidance` output out of the inline BDI node rendering into a structurally-separate `=== MACHINE ANNOTATIONS (advisory signals) ===` block.
- **Default OFF**: graph_attributes annotations are written live today — flipping changes live prompt behavior. Land inert → CL A_anno_structural validates → TL GV → flip on.

## Changes

- `FormatContextConfig`: `machineAnnotationsEnabled?: boolean` (default false, documented with probe-gate rationale)
- BDI rendering: heuristic prefix + `generateNodeGuidance` suppressed inline when flag on; `generateNodeGuidance` kept (relocated to block)
- New block: `=== MACHINE ANNOTATIONS ===` rendered after RETRIEVED CONTEXT, before SITUATIONS; node-referencing self-contained
- 4 new tests (18/18 green): flag-off keeps inline, flag-on renders block, no-guidance → no-block, block ordering

## Test plan

- [x] `npx vitest run taxonomyContext.test.ts` — 18/18 green
- [ ] CL A_anno_structural arm on same two-sided bar — required before merge
- [ ] TL GV — required before flip-on

Closes t/3264 (Phase B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mDXUBnNuJ1wBED66RPewk