### PR TITLE
fix(server): enqueue grounding-reconcile before json(res) — ECONNRESET can't skip it (t/3267 Fix A)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/taxonomyGroundingWiring.test.ts
+++ b/taxonomy-editor/src/server/__tests__/taxonomyGroundingWiring.test.ts
@@ -97,4 +97,20 @@ describe('PUT /api/taxonomy/:pov → grounding reconcile wiring (t/3171)', () =>
     expect(getFlagSpy).toHaveBeenCalledWith('grounding_reconcile_inline'); // gate was consulted → returned false
     expect(enqueueSpy).not.toHaveBeenCalled();
   });
+
+  // t/3267 Fix A (t/3268): the enqueue must fire even when the response write races a client disconnect.
+  // Before the reorder, enqueue ran AFTER json(res); an ECONNRESET on the response write jumped to the
+  // catch and SKIPPED the reconcile. Enqueue-before-json guarantees it runs. This test fails on the old order.
+  it('flag ON + response write throws ECONNRESET → still enqueues (enqueue precedes json, t/3267 Fix A)', async () => {
+    getFlagSpy.mockReturnValue(true);
+    const res = fakeRes();
+    // Simulate the client socket already gone: the first response write (json → res.end) throws ECONNRESET.
+    (res.end as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      const e = new Error('write ECONNRESET') as Error & { code?: string }; e.code = 'ECONNRESET'; throw e;
+    });
+    await put(fakeReq(), res, { nodes: [{ id: 'n1', text: 'EDITED' }, { id: 'n2', text: 'stable' }] });
+    // The reconcile was enqueued BEFORE the failed response write → not skipped by the ECONNRESET.
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSpy.mock.calls[0][0]).toEqual(['n1']);
+  });
 });

--- a/taxonomy-editor/src/server/routes/taxonomy.ts
+++ b/taxonomy-editor/src/server/routes/taxonomy.ts
@@ -169,10 +169,15 @@ export function registerTaxonomyRoutes(r: Router, ctx: ServerCtx): void {
         );
       }
       await fileIO.writeTaxonomyFile(pov, body);
-      json(res, { ok: true });
-      // Fire-and-forget AFTER the 200 (never blocks/fails the write): debounced scoped grounding
-      // reconcile for the changed nodes. Gated OFF above until the tool-lock + PS lock (t/3203) land.
+      // t/3267 Fix A: enqueue the debounced scoped grounding reconcile BEFORE responding. It's
+      // synchronous + fire-and-forget/no-throw (Set.add + a debounce timer), so it can't delay or fail
+      // the response — but placing it AFTER json(res) meant a response-write throw (ECONNRESET when the
+      // client already timed out the ~100s git-sync write) jumped to the catch and SKIPPED the reconcile,
+      // silently leaving grounding stale on exactly the large-write PUTs that need it. Enqueue-first
+      // guarantees it runs; json still returns { ok: true } immediately after. Gated OFF above until the
+      // tool-lock + PS lock (t/3203) land.
       if (changedNodeIds.length > 0) enqueueGroundingReconcile(changedNodeIds);
+      json(res, { ok: true });
     } catch (err) { getGlobalRecorder()?.record({ type: 'system.error', component: 'server', level: 'error', message: 'Failed to write taxonomy file', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } }); error(res, String(err), 500, err); }
   });
 


### PR DESCRIPTION
## What (Bug 2 of t/3267, HIGH)
The PUT `/api/taxonomy/:pov` handler called `enqueueGroundingReconcile(changedNodeIds)` **after** `json(res, {ok:true})`. On a large-POV write the ~100s git-sync means the client has often already timed out → the response write throws **ECONNRESET** → execution jumps to the catch → **the reconcile enqueue is skipped**, silently leaving grounding stale on exactly the writes that changed nodes.

## Fix A (TL-approved t/3267#2, self-cert bugfix)
Move the enqueue **above** `json(res)`. `enqueueGroundingReconcile` is synchronous + fire-and-forget/no-throw (`Set.add` + a debounce timer), so it can't delay or fail the response; enqueue-first guarantees it runs, `json` still returns `{ok:true}` immediately after.

## Test (TL-required)
`taxonomyGroundingWiring.test.ts`: flag ON + `res.end` throws ECONNRESET on the response write → assert the enqueue **still fired**. Fails on the old order. 5/5 grounding-wiring + 4/4 routeTable pass; eslint clean.

## Scope
`routes/taxonomy.ts` + its test — ServerAPI. **Sibling** to Server Storage's Bug-1 fix (git-sync fetch timeout + fail-loud guard); independent, land order agnostic. ServerAPI sub-part tracked as t/3268 (child of t/3267).

Closes t/3268; contributes to t/3267 AC (reconcile fires even on disconnect race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)