### PR TITLE
infra(g8b): enable GROUNDING_SWEEP_ENABLED=1 in bicep baseEnv (t/3163, staged)

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -587,6 +587,7 @@ jobs:
               AZURE_STORAGE_ACCOUNT_URL          = '${{ steps.deploy.outputs.storageAccountBlobUrl }}'
               EMBEDDING_WORKER_OFFLOAD           = '1'  # t/3165 durable close — gate verifies the offload flag is deployed
               GROUNDING_RECONCILE_INLINE         = '1'  # t/3163 G8a — gate verifies the staged inline-reconcile flag is deployed
+              GROUNDING_SWEEP_ENABLED            = '1'  # t/3163 G8b — gate verifies the staged sweep-enable flag is deployed
             } `
             -CheckFirewall `
             -StorageAccountName '${{ steps.deploy.outputs.storageAccountName }}' `

--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -546,6 +546,13 @@ var baseEnv = [
   // baseEnv — never a CLI --set-env-vars (wiped by the next template apply). MUST stay in sync with
   // deploy-azure.yml ExpectedEnvVars (Gate Co-Location — the config-drift gate verifies it's deployed).
   { name: 'GROUNDING_RECONCILE_INLINE', value: '1' }
+  // t/3163 G8b (staged enable, TL GO t/3163#9): arm the scheduled grounding sweep (backstop to the
+  // G8a inline reconcile). Gate cleared — Option C measured grounding_lock held 0.00s + zero
+  // stale-break/contention (≤~2s bar), corroborating the code-level lock-safety GV (t/3163#5).
+  // MUST land + deploy TOGETHER WITH the git-ops-timeout fix (#1872, t/3267): the sweep does git
+  // ops, so it must run on the undici-timeout/degrade-and-proceed code, not the untimed-fetch code.
+  // baseEnv (never CLI --set-env-vars) + MUST stay in sync with deploy-azure.yml ExpectedEnvVars.
+  { name: 'GROUNDING_SWEEP_ENABLED', value: '1' }
 ]
 var envWithToken = githubTokenProvided
   ? concat(baseEnv, [ { name: 'GITHUB_TOKEN', secretRef: githubTokenSecretName } ])


### PR DESCRIPTION
**G8 staged enable — Step 2 (G8b).** TL GO at t/3163#9. Arms the scheduled grounding sweep (backstop to G8a''s inline reconcile).

## Gate cleared
G8b lock-hold gate CLEARED via Option C: `reconcile_grounding.py --nodes acc-desires-001 --apply` (controlled env) → **`grounding_lock held 0.00s`, zero stale-break/contention**, huge margin under the ≤~2s bar, corroborating the code-level lock-safety GV (t/3163#5).

## What
- `main.bicep` baseEnv: `GROUNDING_SWEEP_ENABLED = '1'`.
- `deploy-azure.yml` ExpectedEnvVars config-verify sync (Gate Co-Location).
- Bicep compiles clean; YAML valid.

## DRAFT — sequencing hold (deliberate)
Held draft until **#1872 (t/3267, the git-ops-timeout fix) merges**. The sweep does git ops, so it must run on the undici-timeout / degrade-and-proceed code, NOT the untimed-`branchExistsOnGitHub` fetch code that caused the ~90-120s hangs. Once #1872 is on main I un-draft + merge; the **next jsnover-authed deploy then carries both** (TL: bundle G8b into the #1872 deploy; no standalone G8b deploy). The deploy itself remains owner-authorized.

Enable + green → t/3163 Done → t/3156 closes. Post-enable, the first live sweep''s lock telemetry (via t/3265 obs fix) is the prod confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013iv1toUh9SurtepKUd8hpG