### PR TITLE
obs(server): forward reconciler grounding_lock held Xs to log.server.…

### DIFF
--- a/taxonomy-editor/src/server/__tests__/groundingReconcileHook.test.ts
+++ b/taxonomy-editor/src/server/__tests__/groundingReconcileHook.test.ts
@@ -34,11 +34,13 @@ import {
   __resetGroundingHookForTest,
   __stateForTest,
   parseStats,
+  parseLockTelemetry,
   sanitizeNodeIds,
   DEBOUNCE_QUIET_MS,
   DEBOUNCE_MAX_WAIT_MS,
   type ReconcilerStats,
 } from '../groundingReconcileHook.js';
+import { log } from '../logger.js'; // mocked above → log.server.info/warn are vi.fns we assert on
 
 const okStats = (n = 1): ReconcilerStats => ({ changed: n, skipped: 0, removed: 0 });
 const warnRecords = () => recordSpy.mock.calls.map(c => c[0] as { level?: string; message?: string; data?: Record<string, unknown> })
@@ -170,5 +172,36 @@ describe('groundingReconcileHook (t/3171 G8a)', () => {
     const stdout = '{\n  "changed": 3,\n  "skipped": 1,\n  "removed": 0\n}\nscoped nodes: 4  touched POVs: [\'accelerationist\']\nAPPLIED (scoped): 1 POV file(s), 2 dict file(s)';
     expect(parseStats(stdout)).toEqual({ changed: 3, skipped: 1, removed: 0 });
     expect(parseStats('no json here')).toEqual({ changed: null, skipped: null, removed: null });
+  });
+
+  it('t/3265: SUCCESS path forwards the reconciler `grounding_lock held Xs` (stderr) to log.server.info', async () => {
+    __setReconcilerRunnerForTest(null); // REAL defaultRunner → exercises the stderr parse + the flush forward
+    mockExecFile.mockClear();
+    vi.mocked(log.server.info).mockClear();
+    // reconciler SUCCESS: stats on stdout, lock-hold telemetry on stderr (reconcile_grounding.py:593).
+    mockExecFile.mockImplementationOnce((_f: string, _a: string[], _o: unknown, cb: (e: Error | null, o: string, s: string) => void) =>
+      cb(null, '{"changed":1,"skipped":0,"removed":0}', 'grounding_lock held 0.42s (node:* merge; PS-shared critical section)\n'));
+
+    enqueueGroundingReconcile(['acc-beliefs-003']);
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_QUIET_MS + 10);
+
+    // Previously the lock-held line was echoed only on FAILURE; now a healthy run surfaces it to LA.
+    expect(log.server.info).toHaveBeenCalledWith(
+      expect.objectContaining({ component: 'grounding-reconcile', lock_held_s: 0.42, node_ids: ['acc-beliefs-003'] }),
+      expect.stringContaining('grounding_lock held 0.42s'),
+    );
+  });
+
+  it('parseLockTelemetry extracts lock-held + stale-break from stderr; nulls on a miss (never throws)', () => {
+    expect(parseLockTelemetry('grounding_lock held 0.42s (node:* merge; PS-shared critical section)\n'))
+      .toEqual({ lockHeldS: 0.42, staleBreak: null });
+    const stale = 'WARN grounding_lock: breaking stale lock (mtime age 130s > 120s) at /x/lock; prior holder presumed dead\n';
+    expect(parseLockTelemetry(stale).staleBreak).toContain('breaking stale lock');
+    expect(parseLockTelemetry(stale).lockHeldS).toBeNull();
+    const both = stale + 'grounding_lock held 1.10s (node:* merge)\n';
+    expect(parseLockTelemetry(both).lockHeldS).toBe(1.1);
+    expect(parseLockTelemetry(both).staleBreak).toContain('breaking stale lock');
+    expect(parseLockTelemetry('APPLIED (scoped): 1 POV file(s)')).toEqual({ lockHeldS: null, staleBreak: null });
+    expect(parseLockTelemetry('')).toEqual({ lockHeldS: null, staleBreak: null });
   });
 });

--- a/taxonomy-editor/src/server/groundingReconcileHook.ts
+++ b/taxonomy-editor/src/server/groundingReconcileHook.ts
@@ -44,7 +44,16 @@ const RECONCILE_TIMEOUT_MS = 120_000;
 const RECONCILE_MAX_BUFFER = 10 * 1024 * 1024;
 
 // ── Injectable runner (testability — tests drive flush/coalesce/failure without spawning python) ──
-export interface ReconcilerStats { changed: number | null; skipped: number | null; removed: number | null }
+export interface ReconcilerStats {
+  changed: number | null;
+  skipped: number | null;
+  removed: number | null;
+  /** t/3265: the reconciler's `grounding_lock held Xs` (stderr) — surfaced on the SUCCESS path so the
+   *  lock-hold trend is greppable in LA, not only on failure. null when the line is absent (parse miss). */
+  lockHeldS?: number | null;
+  /** t/3265: the reconciler's stale-lock-break WARN line (stderr), forwarded when present. */
+  staleBreak?: string | null;
+}
 export type ReconcilerRunner = (nodeIds: string[]) => Promise<ReconcilerStats>;
 
 // Node-id charset: `{pov}-{cat}-{NNN}`, `pol-*`, `term:*`, `sei:*`, `summary:*` — word chars, ':',
@@ -73,7 +82,9 @@ function defaultRunner(nodeIds: string[]): Promise<ReconcilerStats> {
       { timeout: RECONCILE_TIMEOUT_MS, maxBuffer: RECONCILE_MAX_BUFFER },
       (err, stdout, stderr) => {
         if (err) { reject(new Error(`reconcile_grounding.py exited non-zero/timeout: ${err.message}\n${stderr}`)); return; }
-        resolve(parseStats(stdout));
+        // t/3265: on SUCCESS, also carry the reconciler's stderr lock-hold telemetry (previously discarded
+        // here — only the FAILURE reject echoed stderr), so a healthy sweep still reports `grounding_lock held Xs`.
+        resolve({ ...parseStats(stdout), ...parseLockTelemetry(stderr) });
       },
     );
   });
@@ -90,6 +101,22 @@ export function parseStats(stdout: string): ReconcilerStats {
     }
   } catch { /* telemetry — silent by design: a stdout parse miss yields null stats, never throws (observability field only) */ }
   return { changed: null, skipped: null, removed: null };
+}
+
+/** t/3265: extract the reconciler's lock-hold telemetry from STDERR — `grounding_lock held Xs`
+ *  (reconcile_grounding.py:593) and the stale-lock-break WARN (…:150). Observability only; a parse
+ *  miss yields nulls, never throws. Couples to those two stderr strings — noted here so the coupling
+ *  is greppable if CL changes them. Exported for unit test. */
+export function parseLockTelemetry(stderr: string): { lockHeldS: number | null; staleBreak: string | null } {
+  let lockHeldS: number | null = null;
+  let staleBreak: string | null = null;
+  try {
+    const held = stderr.match(/grounding_lock held ([\d.]+)s/);
+    if (held) { const n = Number.parseFloat(held[1]); if (Number.isFinite(n)) lockHeldS = n; }
+    const stale = stderr.match(/WARN grounding_lock: breaking stale lock[^\n]*/);
+    if (stale) staleBreak = stale[0];
+  } catch { /* telemetry — silent by design: a stderr parse miss yields null, never throws */ }
+  return { lockHeldS, staleBreak };
 }
 
 let _runner: ReconcilerRunner = defaultRunner;
@@ -133,6 +160,22 @@ async function flush(): Promise<void> {
       message: `grounding_reconcile_inline: reconciled ${ids.length} node(s) — ${stats.changed ?? '?'} changed`,
       data: { node_ids: ids, changed: stats.changed, skipped: stats.skipped, removed: stats.removed, duration_ms: Date.now() - startedMs },
     });
+    // t/3265: forward the reconciler's `grounding_lock held Xs` (stderr) to log.server.info on the SUCCESS
+    // path so the lock-hold trend is continuously greppable in Log Analytics — previously it echoed stderr
+    // only on FAILURE, so a healthy sweep emitted NO lock telemetry (the t/3165 present-but-unobservable
+    // class; the exact metric the G8 lock-hold gate wants). Fire-and-forget: a parse miss → no line.
+    if (stats.lockHeldS != null) {
+      log.server.info(
+        { component: 'grounding-reconcile', node_ids: ids, lock_held_s: stats.lockHeldS, reconcile_ms: Date.now() - startedMs },
+        `grounding_lock held ${stats.lockHeldS}s (inline reconcile)`,
+      );
+    }
+    if (stats.staleBreak) {
+      log.server.warn(
+        { component: 'grounding-reconcile', node_ids: ids, stale_break: stats.staleBreak },
+        'grounding_lock: stale lock broken during inline reconcile',
+      );
+    }
   } catch (err) {
     // Fallback-Path Logging: a failed/skipped reconcile must be visible (silently-stale grounding is
     // invisible degradation) — WARN it — but NEVER propagate: the taxonomy write already succeeded,


### PR DESCRIPTION
## What
`reconcile_grounding.py` writes `grounding_lock held Xs` (:593) + the stale-lock-break WARN (:150) to **stderr**. The inline hook discarded stderr on the **SUCCESS** path (FR `duration_ms` only) and echoed it **only on FAILURE** — so a healthy G8 sweep emitted no lock telemetry (the exact metric the lock-hold gate wants, visible only on failure — the t/3165 present-but-unobservable class).

## Fix
- `parseLockTelemetry(stderr)` → `{ lockHeldS, staleBreak }` (exported); `defaultRunner` carries them on success (`ReconcilerStats` gains `lockHeldS`/`staleBreak`); `flush()` forwards on success — `log.server.info` for the lock-hold, `log.server.warn` for a stale-break. Fire-and-forget/never-throw preserved (parse miss → null → no line).

## Coupling
Depends on two `reconcile_grounding.py` stderr strings (:593, :150) — commented + pinned by the tests.

## Tests (11/11, eslint clean)
`parseLockTelemetry` (held/stale/both/miss) + a SUCCESS-path integration test (default runner + mocked execFile stderr → asserts the lock-held reaches `log.server.info`).

## AC status
AC 1–3 satisfied by code + tests. **AC 4 (canary shows the line in LA)** is post-deploy, gated on `grounding_reconcile_inline` ON (G8b enable, t/3203) — this PR makes it observable; the LA canary lands at the enable. Chore, self-cert. Relates t/3163, t/3165.