### PR TITLE
refactor(validation): import canonical entity/conceptLinkRefSchema from lib (t/3253)

### DIFF
--- a/taxonomy-editor/src/renderer/utils/validation.ts
+++ b/taxonomy-editor/src/renderer/utils/validation.ts
@@ -4,27 +4,11 @@
 import { z } from 'zod';
 import { POV_KEYS } from '@lib/debate/types';
 import { logicalFormSchema } from '@lib/entities/logicalForm';
+import { entityLinkRefSchema, conceptLinkRefSchema } from '@lib/entities/linkRefs';
 
 const categoryEnum = z.enum(['Desires', 'Beliefs', 'Intentions']);
 
-// t/3157 forward-grounding link refs — Zod mirror of lib/entities EntityLinkRef/ConceptLinkRef so a
-// reflection/node write validates + KEEPS them. The node schema already .passthrough()es unknowns,
-// but making these explicit is what G1 gates the forward write on. Inner .passthrough() = fwd-compat.
-const entityLinkRefSchema = z.object({
-  ref: z.string(),
-  surface: z.string(),
-  method: z.enum(['exact', 'alias', 'embedding']),
-  link_confidence: z.number(),
-  match_level: z.enum(['exact', 'instance_of', 'subclass', 'superclass', 'related']),
-  status: z.enum(['linked', 'proposed']),
-}).passthrough();
-const conceptLinkRefSchema = z.object({
-  ref: z.string(),
-  surface: z.string(),
-  method: z.enum(['surface', 'embedding']),
-  link_confidence: z.number(),
-  status: z.enum(['linked', 'proposed']),
-}).passthrough();
+// t/3157 forward-grounding link refs — canonical Zod in @lib/entities/linkRefs (t/3253), imported not re-declared. Inner .passthrough() = fwd-compat.
 
 const povNodeSchema = z.object({
   id: z.string().regex(/^(acc|saf|skp)-(desires|beliefs|intentions)-\d{3}$/, 'ID must match {pov}-{category}-{NNN}'),


### PR DESCRIPTION
The last hand-mirrored-Zod migration from the t/3250 drift family (TL's separate follow-up). Replaces validation.ts's local `entityLinkRefSchema`/`conceptLinkRefSchema` with an import of the canonical `@lib/entities/linkRefs` (#1867) — byte-equivalent, with bidirectional `Equals` guards vs `types.ts` on the lib side.

## Change (−18 / +2)
- Import `entityLinkRefSchema`, `conceptLinkRefSchema` from `@lib/entities/linkRefs`; drop the two local decls; update the comment. `povNodeSchema.entity_refs/concept_refs` keep the same names → **behavior-identical**.

## Self-cert (Shared Lib exact diff, t/3253#2)
- `validation.test.ts` **30/30 unchanged** (incl. the entity_ref invalid-status case).
- renderer-tsc: **0 errors** in validation.ts (import resolves); the 3 `../lib` errors are the known worktree artifact.

Self-merging on green. Closes the Rosetta half of t/3253.

Commit: bc635f29