### PR TITLE
test(storage): regression test — branchExistsOnGitHub timeout degrade-and-proceed (t/3267)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/githubApi.test.ts
+++ b/taxonomy-editor/src/server/__tests__/githubApi.test.ts
@@ -726,6 +726,31 @@ describe('SessionBranchManager — integration', () => {
 
     backend.shutdown();
   });
+
+  it('degrades-and-proceeds when branchExistsOnGitHub times out (t/3267)', async () => {
+    // Simulate the OS-TCP-timeout scenario: the branch existence fetch throws
+    // an AbortError (what the 10s AbortController fires). The fix must degrade
+    // to false (branch absent) so createBranch is called and the save succeeds.
+    apiHandlers.push((url, init) => {
+      if (url.includes('/git/refs/heads/api-session/') && (init.method ?? 'GET') === 'GET') {
+        throw Object.assign(new Error('The operation was aborted.'), { name: 'AbortError' });
+      }
+      return null!;
+    });
+
+    const { manager, backend: be } = await createSessionManager();
+
+    // Must NOT throw — degrade-and-proceed: AbortError → treat branch absent → createBranch
+    const branch = await manager.ensureBranch('alice@example.com');
+    expect(branch).toBe('api-session/alice-example.com');
+
+    // createBranch (POST /git/refs) must have been called — proves the degrade-and-proceed
+    // path completed: timeout → false → createBranch → 201 → session established
+    const createCall = fetchCalls.find(c => c.method === 'POST' && c.url.includes('/git/refs'));
+    expect(createCall).toBeDefined();
+
+    be.shutdown();
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- Adds regression test required by TL GV for t/3267.
- Follows up on #1872 (already merged) — that PR fixed the hang but didn't include the regression test.

**Test: `degrades-and-proceeds when branchExistsOnGitHub times out (t/3267)`**
- Injects an `AbortError` on the branch existence GET fetch (simulating the 10s `AbortController` timeout that the fix adds)
- Asserts `ensureBranch` does NOT throw — degrade-and-proceed is intact
- Asserts `createBranch` (POST /git/refs) was called — proves the full chain: timeout → treat-absent → createBranch → session established → save succeeds

## Test plan
- [ ] CI green on this single test-only commit
- [ ] Self-merge once green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011CdXhhZoESGNgqfGxJNNPf