### PR TITLE
feat(debate): relocate corpus assembly to lib assembleNodeEmbeddings — T2 parity (t/3257#21)

### DIFF
--- a/lib/debate/relevanceSelection.ts
+++ b/lib/debate/relevanceSelection.ts
@@ -37,6 +37,51 @@ import { computeDoctrinalAnchoring } from './doctrinalAnchoring.js';
 /** Corpus embedding map (single vector + optional synthetic multi-vectors), keyed by node id. */
 export type NodeEmbeddingMap = Record<string, { pov: string; vector: number[]; vectors?: number[][] }>;
 
+/** Merge synthetic multi-vector embeddings into the base corpus map (pure). Moved from the renderer
+ *  so server + client merge identically; the renderer re-exports it for its other consumers. */
+export function mergeSyntheticVectors(
+  base: Record<string, { pov: string; vector: number[] }>,
+  syntheticVectors: Record<string, number[][]>,
+): NodeEmbeddingMap {
+  const merged: NodeEmbeddingMap = {};
+  for (const [nodeId, entry] of Object.entries(base)) {
+    const sv = syntheticVectors[nodeId];
+    merged[nodeId] = sv ? { ...entry, vectors: sv } : entry;
+  }
+  return merged;
+}
+
+/**
+ * Assemble the corpus embedding map both callers feed to `selectRelevantTaxonomy` — the SAME
+ * implementation server-side (T2) and client-side (T3), so the corpus can't drift between them
+ * (parity by construction; ServerAPI t/3257#21). Pure: builds `"label: description"` texts + ids
+ * for every POV + situation node, embeds them via the injected `embed` cb, tags each with `pov`,
+ * then merges synthetic multi-vectors when present. The CLIENT keeps its per-debate embed memo +
+ * synthetic-vector fetch in a thin wrapper (a client optimization / bridge IO — out of lib); the
+ * server passes its own embed + cached synthetic vectors.
+ */
+export async function assembleNodeEmbeddings(
+  pov: string,
+  povNodes: PovNode[],
+  ccNodes: SituationNode[],
+  embed: (texts: string[], ids?: string[]) => Promise<number[][]>,
+  syntheticVectors?: Record<string, number[][]> | null,
+): Promise<{ nodeEmbeddings: NodeEmbeddingMap; allNodeIds: string[] }> {
+  const allNodeTexts = [
+    ...povNodes.map(n => `${n.label}: ${n.description}`),
+    ...ccNodes.map(n => `${n.label}: ${n.description}`),
+  ];
+  const allNodeIds = [
+    ...povNodes.map(n => n.id),
+    ...ccNodes.map(n => n.id),
+  ];
+  const vectors = await embed(allNodeTexts, allNodeIds);
+  const base: Record<string, { pov: string; vector: number[] }> = {};
+  for (let i = 0; i < allNodeIds.length; i++) base[allNodeIds[i]] = { pov, vector: vectors[i] };
+  const nodeEmbeddings = syntheticVectors ? mergeSyntheticVectors(base, syntheticVectors) : base;
+  return { nodeEmbeddings, allNodeIds };
+}
+
 /**
  * Per-node scoring provenance: whether the node was surfaced by AN-claim similarity or the topic
  * query, plus the best-matching AN claim. Relocated from the renderer debate-store types so BOTH

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/taxonomyContext.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/taxonomyContext.ts
@@ -14,8 +14,11 @@ import { computeLineageDistribution, formatLineageContext } from '@lib/debate/to
 // t/3257: the relevance-selection pipeline moved to lib-pure; this file is now the thin CLIENT
 // wrapper (build corpus embeddings + fetch greatest-hits + assemble session state → call the pure
 // fn → re-apply anchoring + emit diagnostics + map the result). The server calls the SAME fn (T2).
-import { selectRelevantTaxonomy } from '@lib/debate/relevanceSelection';
+import { selectRelevantTaxonomy, assembleNodeEmbeddings } from '@lib/debate/relevanceSelection';
 import type { ANClaimInput } from '@lib/debate/relevanceSelection';
+// t/3257#21: corpus assembly + synthetic merge relocated to lib so the server (T2) + client build
+// the corpus map identically (parity by construction). Re-exported here for argumentNetwork.ts.
+export { mergeSyntheticVectors } from '@lib/debate/relevanceSelection';
 import type { TaxonomyContext } from '../../../utils/taxonomyContext';
 import { getGreatestHits } from './getGreatestHits';
 import { getLineageMapping, getL2Categories, isLineageDataLoaded } from '../../../data/lineageCategories';
@@ -53,18 +56,6 @@ export async function loadSyntheticVectors(): Promise<Record<string, number[][]>
   }
   _syntheticVectorsLoaded = true;
   return _syntheticVectorsCache;
-}
-
-export function mergeSyntheticVectors(
-  nodeEmbeddings: Record<string, { pov: string; vector: number[] }>,
-  syntheticVectors: Record<string, number[][]>,
-): Record<string, { pov: string; vector: number[]; vectors?: number[][] }> {
-  const merged: Record<string, { pov: string; vector: number[]; vectors?: number[][] }> = {};
-  for (const [nodeId, entry] of Object.entries(nodeEmbeddings)) {
-    const sv = syntheticVectors[nodeId];
-    merged[nodeId] = sv ? { ...entry, vectors: sv } : entry;
-  }
-  return merged;
 }
 
 export function enrichPolicyRefs(
@@ -185,44 +176,28 @@ let corpusEmbedMemoDebateId: string | null = null;
  * Exported for the t/3165 corpus-dedup regression test.
  */
 export async function buildNodeEmbeddingMap(pov: string, allPovNodes: PovNode[], allCCNodes: SituationNode[]): Promise<{ nodeEmbeddings: NodeEmbeddingMap; allNodeIds: string[] }> {
-  const allNodeTexts = [
-    ...allPovNodes.map(n => `${n.label}: ${n.description}`),
-    ...allCCNodes.map(n => `${n.label}: ${n.description}`),
-  ];
-  const allNodeIds = [
-    ...allPovNodes.map(n => n.id),
-    ...allCCNodes.map(n => n.id),
-  ];
-
-  // Reset the memo when the active debate changes, then embed ONLY the ids not yet seen this
-  // debate (the shared situations are embedded on the first speaker, resolved for the rest).
+  // Reset the per-debate memo when the active debate changes.
   const debateId = useDebateStore.getState().activeDebate?.id ?? null;
   if (debateId !== corpusEmbedMemoDebateId) {
     corpusEmbedMemo.clear();
     corpusEmbedMemoDebateId = debateId;
   }
-  const missIdx: number[] = [];
-  for (let i = 0; i < allNodeIds.length; i++) {
-    if (!corpusEmbedMemo.has(allNodeIds[i])) missIdx.push(i);
-  }
-  if (missIdx.length > 0) {
-    const missTexts = missIdx.map(i => allNodeTexts[i]);
-    const missIds = missIdx.map(i => allNodeIds[i]);
-    const { vectors } = await api.computeEmbeddings(missTexts, missIds);
-    for (let k = 0; k < missIds.length; k++) corpusEmbedMemo.set(missIds[k], vectors[k]);
-  }
-
-  const baseNodeEmbeddings: Record<string, { pov: string; vector: number[] }> = {};
-  for (const id of allNodeIds) {
-    baseNodeEmbeddings[id] = { pov, vector: corpusEmbedMemo.get(id) as number[] };
-  }
-
-  // Merge synthetic multi-vector embeddings when available
+  // Memoizing corpus-embed adapter: embed ONLY the ids not yet seen this debate (the shared
+  // situations are embedded on the first speaker, resolved from the memo for the rest — t/3165),
+  // returning every id's vector in order. This client optimization stays out of the pure lib fn.
+  const corpusEmbed = async (texts: string[], ids?: string[]): Promise<number[][]> => {
+    const idList = ids ?? [];
+    const missIdx: number[] = [];
+    for (let i = 0; i < idList.length; i++) if (!corpusEmbedMemo.has(idList[i])) missIdx.push(i);
+    if (missIdx.length > 0) {
+      const { vectors } = await api.computeEmbeddings(missIdx.map(i => texts[i]), missIdx.map(i => idList[i]));
+      for (let k = 0; k < missIdx.length; k++) corpusEmbedMemo.set(idList[missIdx[k]], vectors[k]);
+    }
+    return idList.map(id => corpusEmbedMemo.get(id) as number[]);
+  };
   const synVecs = await loadSyntheticVectors();
-  const nodeEmbeddings = synVecs
-    ? mergeSyntheticVectors(baseNodeEmbeddings, synVecs)
-    : baseNodeEmbeddings;
-  return { nodeEmbeddings, allNodeIds };
+  // Shared lib assembly → the server (T2) and client build the corpus map identically (t/3257#21).
+  return assembleNodeEmbeddings(pov, allPovNodes, allCCNodes, corpusEmbed, synVecs);
 }
 
 /** Build the lineage→node map (intellectual_lineage graph attribute) for the given nodes. */


### PR DESCRIPTION
**Draft — held for DebateTool co-review (their lib file).** Closes the last T2 parity gap ServerAPI flagged (p/528#38): `buildNodeEmbeddingMap` + `mergeSyntheticVectors` were still renderer-scoped, so the server would hand-reproduce the corpus merge → drift risk.

## Change (+65 / −45, 2 files)
- **`lib/debate/relevanceSelection.ts`** — new pure `assembleNodeEmbeddings(pov, povNodes, ccNodes, embed, syntheticVectors?)`; `mergeSyntheticVectors` moved here (pure). Both callers use them → corpus parity by construction.
- **`taxonomyContext.ts`** — `buildNodeEmbeddingMap` is now a thin wrapper: the per-debate corpus-embed MEMO (t/3165 dedup) becomes a memoizing `embed` adapter passed to the lib fn; `loadSyntheticVectors` (bridge IO) stays client-side. Re-exports `mergeSyntheticVectors` for `argumentNetwork.ts` (3rd consumer).
- **lineageMapping needs NO move** — `getLineageMapping` is a verbatim passthrough of `lineage_categories.json`'s `mapping`; server loads the same JSON + passes the same param (zero drift). It was never code.

## Verify
- **useDebateStore 280/280**, incl. the **t/3165 corpus-dedup** regression (memo preserved) + the relocation-parity test.
- renderer-tsc 0 errors in changed files; eslint 0 errors.

On DebateTool co-review → un-draft → self-merge → ServerAPI wires T2 against `assembleNodeEmbeddings`.

Commit: 0fbc5237