### PR TITLE
obs(server): log os.availableParallelism() at boot for worker-pool SKU sizing (t/3211)

### DIFF
--- a/taxonomy-editor/src/server/server.ts
+++ b/taxonomy-editor/src/server/server.ts
@@ -1314,6 +1314,11 @@ server.listen(PORT, BIND_HOST, () => {
   // in ACA config but process.env evaluated false" regression (bicep value-form) is then visible
   // immediately, not inferred from a debate's compute path.
   log.server.info({ embeddingWorkerOffload: isEmbeddingWorkerOffloadEnabled() }, 'embedding offload flag at boot');
+  // t/3211: log the live cgroup-effective core count at boot so the embedding-worker-pool SKU sizing
+  // (K = min(EMBEDDING_WORKER_POOL_SIZE, availableParallelism()-1)) is confirmed EMPIRICALLY from LA on
+  // the next deploy, not asserted blind from the ACA vCPU config (cgroup quota can differ). DevOps reads
+  // this before any 4-vCPU bump + POOL_SIZE flip (p/526#75).
+  log.server.info({ availableParallelism: os.availableParallelism(), cpus: os.cpus().length }, 'host core count at boot');
   void warmupEmbeddings().catch((err: unknown) => {
     log.server.error({ err: String(err) }, 'ONNX embedding warmup failed at boot');
     getGlobalRecorder()?.record({ type: 'system.error', component: 'server', level: 'error', message: 'ONNX embedding warmup failed at boot', error: { name: (err as Error)?.name ?? 'Error', message: String(err), stack: (err as Error)?.stack } });


### PR DESCRIPTION
## What
One-line boot log (next to the existing offload-flag boot log in `server.ts`) of `os.availableParallelism()` + `os.cpus().length`.

## Why
The embedding-worker-pool sizing — `K = min(EMBEDDING_WORKER_POOL_SIZE, availableParallelism()-1)` (t/3211) — depends on the **live cgroup-effective** core count, which can differ from the ACA vCPU config. No boot log surfaced it, so DevOps couldn't confirm the value without asserting blind (p/526#75). This makes the real core count **greppable in Log Analytics on the next deploy**, de-risking the K=2 sizing decision before any 4-vCPU bump + `EMBEDDING_WORKER_POOL_SIZE` flip.

## Scope / risk
Log-only, no behavior change. `os` already imported. eslint clean, server.ts tsc-clean. **Self-cert /trivial-change.**

Part of the t/3211 worker-pool pre-build (Shared Lib owns the pool; DevOps owns the SKU; this is the ServerAPI observability piece — independent of the pool, lands now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)