### PR TITLE
obs(server): emit paid-fallback success marker to stdout so overflow-cost alert can fire (t/3110)

### DIFF
--- a/taxonomy-editor/src/server/routes/ai.ts
+++ b/taxonomy-editor/src/server/routes/ai.ts
@@ -187,6 +187,10 @@ export async function generateWithPaidFallback(
         message: `Paid fallback succeeded for ${backend}/${requestModel}`,
         data: { model: requestModel, backend, fallback: 'paid', delayMs: 3000, responseLength: result.text?.length ?? 0 },
       });
+      // t/3110 (t/3274): the record() above is FR-ring only — never reaches stdout/Log Analytics, so
+      // DevOps's overflow-cost alert (#1733) that keys on "Paid fallback succeeded" could never fire.
+      // Emit the same marker to Pino/stdout too (record() kept for forensics). Pattern: log.api.warn @659.
+      log.api.info({ component: 'ai-generate', model: requestModel, backend, fallback: 'paid' }, `Paid fallback succeeded for ${backend}/${requestModel}`);
       return result;
     } catch (fallbackErr) {
       getGlobalRecorder()?.record({
@@ -238,6 +242,12 @@ export async function generateWithSearch(
         : `generate+search success ${backend}/${requestModel}`,
       data: { model: requestModel, backend, responseLength: result.text?.length ?? 0, search: true, ...(fallback ? { fallback } : {}) },
     });
+    // t/3110 (t/3274): the record() above is FR-ring only. On the PAID branch (billed overflow), also emit
+    // the "Paid fallback succeeded" marker to Pino/stdout so DevOps's overflow-cost alert (#1733) can fire —
+    // it can't see the FR ring. Paid branch only (never the non-fallback success), matching the record().
+    if (fallback === 'paid') {
+      log.api.info({ component: 'ai-generate', model: requestModel, backend, fallback: 'paid', search: true }, `Paid fallback succeeded (search) ${backend}/${requestModel}`);
+    }
   };
   try {
     const result = await ai.generateTextWithSearchByUsage('server.search', { prompt }, overrides, explicitKey);


### PR DESCRIPTION
## What
The paid-fallback SUCCESS markers at `routes/ai.ts:187` (non-search) and `:237` (search) used `getGlobalRecorder().record()` **only** — FR-ring, never stdout → Log Analytics. So DevOps's overflow-cost alert (#1733), which keys on the `"Paid fallback succeeded"` token, could never fire (TL diag t/3110#12, DevOps 2 p/555#30).

## Fix
Add `log.api.info(..., 'Paid fallback succeeded ...')` alongside the existing `record()` at both sites (`record()` kept for forensics), same pattern as `log.api.warn` @ ai.ts:659. The **search** path emits only on the `fallback === 'paid'` branch (billed overflow), matching the record()'s success-only semantics — never the non-fallback success.

## Scope / risk
Log-only, no behavior change; `log` already imported. No key material in the log fields (model/backend/fallback only). eslint clean, ai.ts tsc-clean. **Self-cert /trivial-change.**

Tracked as t/3274 (child of t/3110). DevOps 2 re-runs the fire-arm check + re-requests TL GV once landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)