### PR TITLE
feat(embeddings): K-slot off-thread embedding worker pool (t/3211)

### DIFF
--- a/lib/embeddings/offThreadEmbedding.test.ts
+++ b/lib/embeddings/offThreadEmbedding.test.ts
@@ -327,6 +327,39 @@ describe('offThreadEmbedding — pool: aggregate shed at MAX_QUEUE_DEPTH × K', 
   });
 });
 
+describe('offThreadEmbedding — pool: Condition B backpressure tightens with LIVE slots (dynamic)', () => {
+  it('K=2: crashing one slot tightens the cap 32→16 — a depth admitted at 32 now sheds with max:16', () => {
+    vi.useFakeTimers(); // crash schedules a respawn timer; fake timers keep the slot cleanly "down"
+    configureEmbeddingWorkerPool(2); // K=2 → cap = 16 × 2 = 32 while BOTH slots are live
+    const workers: FakeWorker[] = [];
+    __setEmbeddingWorkerFactory(() => { const w = new FakeWorker(); workers.push(w); return w; });
+
+    // 17 never-reply tasks: 2 in flight (slot0=worker0, slot1=worker1) + 15 queued → resident depth 17.
+    const pending: Promise<unknown>[] = [];
+    for (let i = 0; i < 17; i++) pending.push(computeEmbeddingsOffThread(['x'], { requester: `fill-${i}` }).catch(() => {}));
+    expect(workers).toHaveLength(2);
+    expect(__queueDepthForTests()).toBe(17);
+    // All 17 were admitted (none shed) at the full-capacity cap of 32 — the "admissible at 32" half of
+    // the discriminator. Under a STATIC single-slot cap of 16 the 17th would already have shed.
+    expect(warns().some(warn => /queue full/i.test(warn.message ?? ''))).toBe(false);
+
+    // Crash slot 0 → its in-flight task rejects (depth 17→16) and the slot enters respawn-backoff, so
+    // liveSlotCount drops 2→1 and the cap tightens 32→16. Slot 1 stays live (not an all-down shed).
+    workers[0].emit('error', new Error('boom'));
+    expect(__queueDepthForTests()).toBe(16); // 1 in-flight on slot1 + 15 queued
+
+    // Depth 16 was comfortably admissible at the old cap 32; against the tightened cap 16 it now sheds
+    // — and the WARN carries the SCALED-DOWN max (16, not the configured-K 32). This is the dynamic
+    // tightening that a static ×K cap would miss (TL GV required assertion, t/3211#8).
+    const rejected = expect(computeEmbeddingsOffThread(['x'], { requester: 'tightened' })).rejects.toThrow(/shed|queue full/i);
+    const shedWarn = warns().find(warn => /queue full/i.test(warn.message ?? '') && warn.data?.requester === 'tightened');
+    expect(shedWarn).toBeDefined();
+    expect(shedWarn!.data?.max).toBe(16);        // dynamic: cap followed live slots down from 32 to 16
+    expect(shedWarn!.data?.queueDepth).toBe(16);
+    return rejected.then(() => { void pending; });
+  });
+});
+
 describe('offThreadEmbedding — pool: per-slot fault isolation (t/3181 identity-guard, generalized)', () => {
   it('a crash + late-exit on slot 0 never disturbs slot 1; slot 0 respawns independently', async () => {
     vi.useFakeTimers();

--- a/lib/embeddings/offThreadEmbedding.test.ts
+++ b/lib/embeddings/offThreadEmbedding.test.ts
@@ -19,12 +19,25 @@ vi.mock('../flight-recorder/index.js', () => ({
   getGlobalRecorder: () => ({ record: (e: never) => { recorded.push(e); } }),
 }));
 
+// Control the core count the pool clamps against (t/3211) without depending on the CI machine's real
+// vCPUs — the module reads `availableParallelism()` from node:os. Default high so K=2/3/4 configs in
+// the pool tests are NOT clamped unless a test explicitly lowers `osMock.cores`. All other os exports
+// pass through untouched (spread the real module).
+const osMock = vi.hoisted(() => ({ cores: 8 }));
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  const patched = { ...actual, availableParallelism: () => osMock.cores };
+  return { ...patched, default: patched };
+});
+
 import {
   computeEmbeddingsOffThread,
+  configureEmbeddingWorkerPool,
   shutdownEmbeddingWorker,
   __setEmbeddingWorkerFactory,
   __resetEmbeddingWorkerForTests,
   __queueDepthForTests,
+  __poolSizeForTests,
   type EmbeddingWorkerLike,
 } from './offThreadEmbedding.js';
 import * as onnx from './onnxEmbedding.js';
@@ -68,6 +81,7 @@ const warns = () => recorded.filter(r => r.level === 'warn');
 
 beforeEach(() => {
   recorded.length = 0;
+  osMock.cores = 8; // ample headroom; pool-clamp tests lower this explicitly
   __resetEmbeddingWorkerForTests();
 });
 
@@ -250,6 +264,156 @@ describe('offThreadEmbedding — marshaling round-trip preserves vectors exactly
     expect(out[0]).toHaveLength(vectors[0].length);
     // The manager's request to the worker carries no transferList — only text strings marshal IN.
     expect(w.transfers.length).toBe(0);
+  });
+});
+
+// ══ t/3211 K-slot pool ═════════════════════════════════════════════════════════════════════════
+
+describe('offThreadEmbedding — pool: default (unconfigured) is K=1, byte-identical single-worker', () => {
+  it('without configure, pool size is 1 and one worker serves a round-trip', async () => {
+    // The EXISTING four-arm suite above runs entirely UNCONFIGURED — its green is the default-1 parity
+    // proof (TL non-negotiable). This case pins the invariant explicitly: no configure() → K=1.
+    expect(__poolSizeForTests()).toBe(1);
+
+    const workers: FakeWorker[] = [];
+    __setEmbeddingWorkerFactory(() => { const w = new FakeWorker(); workers.push(w); return w; });
+
+    const a = computeEmbeddingsOffThread(['a'], { requester: 'r1' });
+    workers[0].emit('message', resultFor(workers[0].lastId(), [[1, 0, 0, 0]]));
+    await expect(a).resolves.toHaveLength(1);
+    expect(workers).toHaveLength(1); // exactly one worker ever spawned at K=1
+  });
+});
+
+describe('offThreadEmbedding — pool: K tasks dispatch in parallel, K+1th queues', () => {
+  it('configures K=4 and dispatches up to K workers concurrently; the (K+1)th waits in the shared queue', () => {
+    configureEmbeddingWorkerPool(4); // cores=8 → cap 7 → K=4
+    expect(__poolSizeForTests()).toBe(4);
+
+    const workers: FakeWorker[] = [];
+    __setEmbeddingWorkerFactory(() => { const w = new FakeWorker(); workers.push(w); return w; });
+
+    // 4 tasks that never reply → each lands on its own idle slot, all in flight in parallel.
+    const pending: Promise<unknown>[] = [];
+    for (let i = 0; i < 4; i++) pending.push(computeEmbeddingsOffThread(['x'], { requester: `p-${i}` }).catch(() => {}));
+    expect(workers).toHaveLength(4);              // K workers spawned, one per slot
+    expect(__queueDepthForTests()).toBe(4);       // all 4 in flight, none waiting
+
+    // The 5th has no idle slot → it queues (does NOT spawn a 5th worker).
+    pending.push(computeEmbeddingsOffThread(['x'], { requester: 'p-5' }).catch(() => {}));
+    expect(workers).toHaveLength(4);              // still K — no oversubscription
+    expect(__queueDepthForTests()).toBe(5);       // 4 in flight + 1 queued
+    void pending;
+  });
+});
+
+describe('offThreadEmbedding — pool: aggregate shed at MAX_QUEUE_DEPTH × K', () => {
+  it('K=2 admits up to 32 resident tasks, sheds the 33rd with the scaled cap in the WARN', async () => {
+    configureEmbeddingWorkerPool(2); // cores=8 → K=2; cap = 16 × 2 = 32
+    const w = new FakeWorker(); // never replies → tasks stay resident
+    __setEmbeddingWorkerFactory(() => w);
+
+    const pending: Promise<unknown>[] = [];
+    for (let i = 0; i < 32; i++) pending.push(computeEmbeddingsOffThread(['x'], { requester: `fill-${i}` }).catch(() => {}));
+    expect(__queueDepthForTests()).toBe(32);
+
+    await expect(computeEmbeddingsOffThread(['x'], { requester: 'overflow' })).rejects.toThrow(/shed|queue full/i);
+    const shedWarn = warns().find(warn => /queue full/i.test(warn.message ?? ''));
+    expect(shedWarn).toBeDefined();
+    expect(shedWarn!.data?.requester).toBe('overflow');
+    expect(shedWarn!.data?.queueDepth).toBe(32);
+    expect(shedWarn!.data?.max).toBe(32); // scaled ×K, not the base 16
+    void pending;
+  });
+});
+
+describe('offThreadEmbedding — pool: per-slot fault isolation (t/3181 identity-guard, generalized)', () => {
+  it('a crash + late-exit on slot 0 never disturbs slot 1; slot 0 respawns independently', async () => {
+    vi.useFakeTimers();
+    configureEmbeddingWorkerPool(2); // K=2
+    const workers: FakeWorker[] = [];
+    __setEmbeddingWorkerFactory(() => { const w = new FakeWorker(); workers.push(w); return w; });
+
+    // Dispatch A→slot0(worker0), B→slot1(worker1); both in flight in parallel.
+    const pA = computeEmbeddingsOffThread(['a'], { requester: 'slot0-A' });
+    const pARejected = expect(pA).rejects.toThrow(/worker crash/i);
+    const pB = computeEmbeddingsOffThread(['b'], { requester: 'slot1-B' });
+    expect(workers).toHaveLength(2);
+    const worker0 = workers[0], worker1 = workers[1];
+    const staleId = worker0.lastId();
+    const bId = worker1.lastId();
+
+    // Slot 0's worker crashes → A rejects + slot 0 enters respawn-backoff. Slot 1 MUST be untouched.
+    worker0.emit('error', new Error('boom'));
+    await pARejected;
+    expect(worker0.terminated).toBe(true);
+    expect(worker1.terminated).toBe(false);   // sibling slot unaffected by slot 0's crash
+    const warnsAfterCrash = warns().length;
+
+    // Clear slot 0's backoff and dispatch C → slot 0 respawns a fresh worker2.
+    await vi.advanceTimersByTimeAsync(300);
+    const pC = computeEmbeddingsOffThread(['c'], { requester: 'slot0-C' });
+    expect(workers).toHaveLength(3);          // worker2 for slot 0; slot 1 never respawned
+    const worker2 = workers[2];
+    const cId = worker2.lastId();
+
+    // The OLD terminated worker0 fires late events — identity-guard (keyed on slot.worker) DROPS them:
+    // neither the fresh slot-0 worker nor the healthy slot-1 worker is torn down, no new crash WARN.
+    worker0.emit('exit', 137);
+    worker0.emit('message', resultFor(staleId, [[9, 9, 9, 9]]));
+    expect(worker1.terminated).toBe(false);
+    expect(worker2.terminated).toBe(false);
+    expect(warns().length).toBe(warnsAfterCrash); // stale events produced no WARN
+
+    // Both live tasks complete normally → resolve cleanly (pool survived the partial failure).
+    worker1.emit('message', resultFor(bId, [[1, 0, 0, 0]]));
+    worker2.emit('message', resultFor(cId, [[0, 1, 0, 0]]));
+    await expect(pB).resolves.toHaveLength(1);
+    await expect(pC).resolves.toHaveLength(1);
+  });
+});
+
+describe('offThreadEmbedding — pool: configure() clamps to cores and WARNs (fallback-logging)', () => {
+  it('POOL_SIZE=8 on a 4-core box lands K=3 with a clamp WARN carrying asked-vs-cores', () => {
+    osMock.cores = 4; // cap = 4 − 1 = 3
+    configureEmbeddingWorkerPool(8);
+    expect(__poolSizeForTests()).toBe(3); // min(8, 3)
+
+    const clampWarn = warns().find(warn => /clamped/i.test(warn.message ?? ''));
+    expect(clampWarn).toBeDefined();
+    expect(clampWarn!.data?.requestedSize).toBe(8);
+    expect(clampWarn!.data?.clampedSize).toBe(3);
+    expect(clampWarn!.data?.cores).toBe(4);
+  });
+
+  it('a size that fits the box is NOT clamped and produces no clamp WARN', () => {
+    osMock.cores = 8; // cap 7
+    configureEmbeddingWorkerPool(3);
+    expect(__poolSizeForTests()).toBe(3);
+    expect(warns().find(warn => /clamped/i.test(warn.message ?? ''))).toBeUndefined();
+  });
+});
+
+describe('offThreadEmbedding — pool: configure() ordering contract (t/3211 TL condition A)', () => {
+  it('(b) configure BEFORE any compute → the size is applied', () => {
+    configureEmbeddingWorkerPool(3);
+    expect(__poolSizeForTests()).toBe(3);
+  });
+
+  it('(a) configure AFTER the pool has materialized → no-op + WARN, size stays at the default', async () => {
+    // Compute first (no configure) → pool materializes at K=1.
+    const w = new FakeWorker();
+    w.onPost = (msg, self) => self.emit('message', resultFor(msg.id, [[1, 0, 0, 0]]));
+    __setEmbeddingWorkerFactory(() => w);
+    await expect(computeEmbeddingsOffThread(['x'], { requester: 'early' })).resolves.toHaveLength(1);
+    expect(__poolSizeForTests()).toBe(1);
+
+    // A late configure must NOT resize the live pool.
+    configureEmbeddingWorkerPool(4);
+    expect(__poolSizeForTests()).toBe(1);
+    const lateWarn = warns().find(warn => /already running/i.test(warn.message ?? ''));
+    expect(lateWarn).toBeDefined();
+    expect(lateWarn!.data?.requestedSize).toBe(4);
   });
 });
 

--- a/lib/embeddings/offThreadEmbedding.ts
+++ b/lib/embeddings/offThreadEmbedding.ts
@@ -2,22 +2,31 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 /**
- * Main-thread manager for the off-thread embedding worker (t/3181, item A).
+ * Main-thread manager for the off-thread embedding worker pool (t/3181 item A; K-slot pool t/3211).
  *
- * Owns a SINGLE persistent worker (no pool), a bounded FIFO queue, an id↔promise map, a heartbeat
- * watchdog, and respawn-with-backoff. Exposes the shared contract B (ServerAPI) and C (ElectronMain)
- * build against:
+ * Owns a POOL of K persistent workers (default K=1 → the original single-worker behavior, byte-
+ * identical and inert), a bounded SHARED FIFO queue, an id↔promise map, a per-slot heartbeat
+ * watchdog, and per-slot respawn-with-backoff. Exposes the shared contract B (ServerAPI) and C
+ * (ElectronMain) build against:
  *
  *     computeEmbeddingsOffThread(texts, opts?: { requester?: string }): Promise<Float32Array[]>
  *
+ * Pool size is set ONCE at startup via {@link configureEmbeddingWorkerPool} (a startup-only mutator,
+ * NOT a ctor — keeping the free-function contract B/C already build against). Default 1 → today's
+ * exact behavior; ramp to K only behind the config knob + a multi-core SKU (t/3211).
+ *
  * Cache RESOLVE stays on the caller's main thread — only miss-texts marshal IN (structured-clone of
- * strings), vectors marshal OUT via a TRANSFERRED ArrayBuffer (zero-copy). The worker owns the ONNX
- * session exclusively; this module NEVER computes embeddings in-thread — not even on worker failure.
- * A worker crash/wedge/queue-overflow fails LOUD (ActionableError → the server's t/3078 block-mode
- * 503 load-shed); an in-thread fallback would reintroduce the exact t/3165 starvation it prevents.
+ * strings), vectors marshal OUT via a TRANSFERRED ArrayBuffer (zero-copy). Each worker owns its own
+ * ONNX session exclusively; this module NEVER computes embeddings in-thread — not even on worker
+ * failure. A worker crash/wedge/queue-overflow fails LOUD (ActionableError → the server's t/3078
+ * block-mode 503 load-shed); an in-thread fallback would reintroduce the exact t/3165 starvation it
+ * prevents. Under partial failure the pool keeps serving on live slots and sheds only when EVERY slot
+ * is down (t/3211 TL condition B); the queue-depth cap scales with LIVE slot count so a lone survivor
+ * cannot accept a K× backlog that tail-latencies past the route timeout.
  */
 
 import { Worker } from 'node:worker_threads';
+import { availableParallelism } from 'node:os';
 import { ActionableError } from '../debate/errors.js';
 import { getGlobalRecorder } from '../flight-recorder/index.js';
 
@@ -32,18 +41,30 @@ import { getGlobalRecorder } from '../flight-recorder/index.js';
 const HEARTBEAT_TIMEOUT_MS = 8000;
 
 /**
- * Max resident tasks (1 in-flight + 15 queued). Enqueue past this → load-shed 503 + WARN. Higher →
- * more memory + longer tail latency under burst; lower → sheds sooner under load. (t/3181 Q2.)
+ * Per-live-slot queue budget: each live slot admits 1 in-flight + (MAX_QUEUE_DEPTH − 1) queued. The
+ * aggregate resident cap is `MAX_QUEUE_DEPTH * liveSlotCount()` — DYNAMIC (t/3211 TL condition B):
+ * as slots go down the cap tightens, so a single survivor can never accept a K× backlog that drains
+ * at 1/K rate and tail-latencies past the ~50s route wall. Enqueue past the cap → load-shed 503 +
+ * WARN. Higher → more memory + longer tail latency under burst; lower → sheds sooner. (t/3181 Q2.)
  */
 const MAX_QUEUE_DEPTH = 16;
 
 /**
  * Respawn backoff after a worker crash/wedge: doubles per consecutive failure up to the cap, resets
  * on a clean task. Too short → tight crash→respawn spin burning CPU; too long → extended shed gap
- * where every request is rejected. New tasks arriving during the gap are shed. (t/3181 Q2.)
+ * where that slot's requests are rejected. New tasks arriving while ALL slots are down are shed.
+ * (t/3181 Q2.)
  */
 const BACKOFF_BASE_MS = 250;
 const BACKOFF_CAP_MS = 5000;
+
+/**
+ * Cores kept for the main thread (event loop + cache resolve + request handling) when clamping the
+ * configured pool size. K is capped at `availableParallelism() - POOL_CORE_HEADROOM` because the
+ * bottleneck is op-thread compute: K worker op-threads beyond the available cores oversubscribe the
+ * box and buy nothing (throughput stays flat — the finding this ticket is built on). (t/3211.)
+ */
+const POOL_CORE_HEADROOM = 1;
 
 // ── Types ─────────────────────────────────────────────
 
@@ -53,6 +74,22 @@ interface Task {
   requester: string;
   resolve: (vectors: Float32Array[]) => void;
   reject: (err: unknown) => void;
+}
+
+/**
+ * One pool slot: a persistent worker plus the per-slot state the single-worker manager used to hold
+ * at module scope. Watchdog, respawn/backoff, consecutive-failure count and the down-flag are ALL
+ * per-slot so a crash/wedge on one slot rejects+respawns only its own worker — a healthy sibling's
+ * concurrent in-flight task is untouched (the t/3181 identity-guard, now keyed on `slot.worker`).
+ */
+interface Slot {
+  worker: EmbeddingWorkerLike | null;
+  inFlight: Task | null;
+  watchdog: ReturnType<typeof setTimeout> | null;
+  lastChunkSeen: number;
+  consecutiveFailures: number;
+  down: boolean; // true during this slot's respawn-backoff gap
+  respawnTimer: ReturnType<typeof setTimeout> | null;
 }
 
 /**
@@ -74,18 +111,13 @@ type WorkerMessage =
 
 type DownCause = 'crash' | 'exit' | 'wedge';
 
-// ── State (module-level singleton — one worker, serial dispatch) ──
+// ── State (module-level — a shared queue feeding K slots) ──
 
 let _workerFactory: EmbeddingWorkerFactory = defaultWorkerFactory;
-let _worker: EmbeddingWorkerLike | null = null;
+let _slots: Slot[] = [];               // materialized lazily on first pump() (see ensureSlots)
+let _desiredSize: number | null = null; // set by configureEmbeddingWorkerPool; null → unconfigured (K=1)
 const _queue: Task[] = [];
-let _inFlight: Task | null = null;
-let _watchdog: ReturnType<typeof setTimeout> | null = null;
-let _lastChunkSeen = -1;
 let _nextId = 1;
-let _consecutiveFailures = 0;
-let _respawnTimer: ReturnType<typeof setTimeout> | null = null;
-let _down = false; // true during the respawn-backoff gap → new tasks are shed
 
 function defaultWorkerFactory(): EmbeddingWorkerLike {
   // Node/dev-Electron resolution. Packaged-Electron asar worker-entry resolution is C's exit
@@ -93,12 +125,38 @@ function defaultWorkerFactory(): EmbeddingWorkerLike {
   return new Worker(new URL('./embeddingWorker.js', import.meta.url)) as unknown as EmbeddingWorkerLike;
 }
 
+/** Effective pool size: the clamped configured value, or 1 when compute precedes configure. */
+function poolSize(): number {
+  return _desiredSize ?? 1;
+}
+
+/** Materialize the slot array on first use (compute-before-configure lands here → K=1). */
+function ensureSlots(): void {
+  if (_slots.length > 0) return;
+  _slots = Array.from({ length: poolSize() }, () => ({
+    worker: null, inFlight: null, watchdog: null,
+    lastChunkSeen: -1, consecutiveFailures: 0, down: false, respawnTimer: null,
+  }));
+}
+
+/** Live slots = those able to serve (not in a respawn-backoff gap). Nominal size before materialize. */
+function liveSlotCount(): number {
+  if (_slots.length === 0) return poolSize();
+  return _slots.reduce((n, s) => n + (s.down ? 0 : 1), 0);
+}
+
+/** True only when the pool has slots AND every one of them is down (respawning) → hard shed. */
+function allSlotsDown(): boolean {
+  return _slots.length > 0 && _slots.every(s => s.down);
+}
+
+/** Current resident tasks: everything queued plus everything in flight across all slots. */
 function queueLen(): number {
-  return _queue.length + (_inFlight ? 1 : 0);
+  return _queue.length + _slots.reduce((n, s) => n + (s.inFlight ? 1 : 0), 0);
 }
 
 function warn(message: string, data: Record<string, unknown>): void {
-  // Fallback-Path Logging: every shed / crash / wedge records WHAT degraded + WHY + WHO (requester).
+  // Fallback-Path Logging: every shed / crash / wedge / clamp records WHAT degraded + WHY + WHO.
   getGlobalRecorder()?.record({ type: 'system.error', component: 'offThreadEmbedding', level: 'warn', message, data });
 }
 
@@ -112,13 +170,46 @@ function safeTerminate(w: EmbeddingWorkerLike | null): void {
   } catch { /* already dead */ }
 }
 
+// ── Startup configuration ─────────────────────────────
+
+/**
+ * Set the worker-pool size. **Startup-only** — call once before the first embedding request; ServerAPI
+ * threads `EMBEDDING_WORKER_POOL_SIZE` (raw, default 1) here from config (t/3211). The RAW size is
+ * self-clamped to `min(size, availableParallelism() − 1)` so a mis-set value can never oversubscribe
+ * the box regardless of SKU (e.g. POOL_SIZE=8 on a 4-core box → K=3), and to a floor of 1.
+ *
+ * Ordering contract (t/3211 TL condition A):
+ *  - Called AFTER the pool has materialized (any request already dispatched) → **no-op + WARN**; a
+ *    live pool is never resized mid-flight.
+ *  - {@link computeEmbeddingsOffThread} called BEFORE this → pool defaults to K=1 (never throws).
+ */
+export function configureEmbeddingWorkerPool(size: number): void {
+  if (_slots.length > 0) {
+    warn('configureEmbeddingWorkerPool ignored — pool already running (startup-only, cannot resize live)', {
+      requestedSize: size, activeSize: _slots.length,
+    });
+    return;
+  }
+  const cores = availableParallelism();
+  const cap = Math.max(1, cores - POOL_CORE_HEADROOM);
+  const requested = Math.max(1, Math.floor(Number.isFinite(size) ? size : 1));
+  const clamped = Math.min(requested, cap);
+  if (clamped < requested) {
+    warn('embedding pool size clamped to available cores', {
+      requestedSize: requested, clampedSize: clamped, cores, headroom: POOL_CORE_HEADROOM,
+    });
+  }
+  _desiredSize = clamped;
+}
+
 // ── Public contract ───────────────────────────────────
 
 /**
  * Compute embeddings off the main thread. Resolves to one 384-dim `Float32Array` per input text
  * (views over a single transferred buffer — do not assume they are independently backed). Rejects
- * with an `ActionableError` when the request is shed (queue full or worker respawning) or the worker
- * crashes/wedges — the server maps that to a 503 load-shed. NEVER falls back to in-thread compute.
+ * with an `ActionableError` when the request is shed (queue full, or every slot respawning) or the
+ * serving worker crashes/wedges — the server maps that to a 503 load-shed. NEVER falls back to
+ * in-thread compute.
  *
  * @param opts.requester short label for the caller (surfaced in the queue-full/shed WARN so a shed
  *   event names who was dropped — fallback-logging rule). Threaded from B/C.
@@ -131,16 +222,18 @@ export function computeEmbeddingsOffThread(
 
   if (texts.length === 0) return Promise.resolve([]); // trivial — no worker round-trip
 
-  // Shed while the worker is down during a respawn-backoff gap (fail loud, no in-thread fallback).
-  if (_down) {
-    warn('embedding request shed — worker respawning (backoff gap)', { requester, queueDepth: queueLen() });
-    return Promise.reject(shedError(requester, 'worker is respawning after a crash/wedge'));
+  // Shed while EVERY slot is down during a respawn-backoff gap (fail loud, no in-thread fallback).
+  if (allSlotsDown()) {
+    warn('embedding request shed — all workers respawning (backoff gap)', { requester, queueDepth: queueLen() });
+    return Promise.reject(shedError(requester, 'all workers are respawning after a crash/wedge'));
   }
 
-  // Bounded queue: 1 in-flight + (MAX_QUEUE_DEPTH − 1) waiting. Overflow → load-shed 503 + WARN.
-  if (queueLen() >= MAX_QUEUE_DEPTH) {
-    warn('embedding request shed — queue full', { requester, queueDepth: queueLen(), max: MAX_QUEUE_DEPTH });
-    return Promise.reject(shedError(requester, `queue full (max ${MAX_QUEUE_DEPTH})`));
+  // Bounded queue, cap scaled by LIVE slots (t/3211): K in-flight + (MAX_QUEUE_DEPTH−1)×live queued.
+  // Overflow → load-shed 503 + WARN.
+  const cap = MAX_QUEUE_DEPTH * liveSlotCount();
+  if (queueLen() >= cap) {
+    warn('embedding request shed — queue full', { requester, queueDepth: queueLen(), max: cap });
+    return Promise.reject(shedError(requester, `queue full (max ${cap})`));
   }
 
   return new Promise<Float32Array[]>((resolve, reject) => {
@@ -149,63 +242,72 @@ export function computeEmbeddingsOffThread(
   });
 }
 
-/** Terminate the worker and drop pending work. Call on app shutdown. */
+/** Terminate all workers and drop pending work. Call on app shutdown. */
 export function shutdownEmbeddingWorker(): void {
-  clearWatchdog();
-  if (_respawnTimer) { clearTimeout(_respawnTimer); _respawnTimer = null; }
-  safeTerminate(_worker);
-  _worker = null;
-  _inFlight = null;
+  for (const slot of _slots) {
+    clearWatchdog(slot);
+    if (slot.respawnTimer) { clearTimeout(slot.respawnTimer); slot.respawnTimer = null; }
+    safeTerminate(slot.worker);
+    slot.worker = null;
+    slot.inFlight = null;
+    slot.down = false;
+  }
   _queue.length = 0;
-  _down = false;
 }
 
 // ── Scheduling ────────────────────────────────────────
 
+/** Drain the shared queue onto any idle, up-and-serving slots (≤ liveSlotCount in flight at once). */
 function pump(): void {
-  if (_inFlight || _queue.length === 0 || _down) return;
-  if (!_worker) _worker = spawnWorker();
-  const task = _queue.shift()!;
-  _inFlight = task;
-  _lastChunkSeen = -1;
-  armWatchdog(); // ARM ON DISPATCH (TL Q1) — catches a hang before the first heartbeat too
-  _worker.postMessage({ id: task.id, texts: task.texts });
+  ensureSlots();
+  for (const slot of _slots) {
+    if (_queue.length === 0) break;
+    if (slot.inFlight || slot.down) continue;         // busy or respawning → skip
+    if (!slot.worker) slot.worker = spawnWorker(slot); // lazily (re)spawn on demand
+    const task = _queue.shift()!;
+    slot.inFlight = task;
+    slot.lastChunkSeen = -1;
+    armWatchdog(slot); // ARM ON DISPATCH (TL Q1) — catches a hang before the first heartbeat too
+    slot.worker.postMessage({ id: task.id, texts: task.texts });
+  }
 }
 
-function spawnWorker(): EmbeddingWorkerLike {
+function spawnWorker(slot: Slot): EmbeddingWorkerLike {
   const w = _workerFactory();
-  // IDENTITY-GUARD every handler on the specific worker instance `w`: after a respawn the OLD
-  // (terminated) worker can still emit a late 'exit'/'error'/'message'. Without this guard that
-  // stale event would act on the CURRENT module state — e.g. an old worker's late 'exit' would
-  // call onWorkerDown and tear down the HEALTHY new worker (reject its task, terminate, re-respawn).
-  // `w !== _worker` means the event came from a superseded worker → drop it. (TL GV required fix.)
-  w.on('message', ((msg: WorkerMessage) => { if (w === _worker) onWorkerMessage(msg); }) as (arg: never) => void);
+  // IDENTITY-GUARD every handler on the specific worker instance `w` AND its owning `slot`: after a
+  // respawn the OLD (terminated) worker can still emit a late 'exit'/'error'/'message'. Without this
+  // guard that stale event would act on the CURRENT slot state — e.g. an old worker's late 'exit'
+  // would call onWorkerDown and tear down the HEALTHY new worker (reject its task, terminate, re-
+  // respawn). `w !== slot.worker` means the event came from a superseded worker → drop it. Keying on
+  // the slot (not a module singleton) is what isolates a fault to its own slot and leaves siblings
+  // serving. (t/3181 GV required fix, generalized to the pool in t/3211.)
+  w.on('message', ((msg: WorkerMessage) => { if (w === slot.worker) onWorkerMessage(slot, msg); }) as (arg: never) => void);
   w.on('error', ((err: Error) => {
-    if (w === _worker) onWorkerDown('crash', err instanceof Error ? err.message : String(err));
+    if (w === slot.worker) onWorkerDown(slot, 'crash', err instanceof Error ? err.message : String(err));
   }) as (arg: never) => void);
   w.on('exit', ((code: number) => {
-    if (w === _worker && code !== 0) onWorkerDown('exit', `worker exited with code ${code}`);
+    if (w === slot.worker && code !== 0) onWorkerDown(slot, 'exit', `worker exited with code ${code}`);
   }) as (arg: never) => void);
   return w;
 }
 
-function onWorkerMessage(msg: WorkerMessage): void {
+function onWorkerMessage(slot: Slot, msg: WorkerMessage): void {
   if (msg.type === 'heartbeat') {
-    if (_inFlight && msg.id === _inFlight.id) {
-      _lastChunkSeen = msg.chunk;
-      armWatchdog(); // forward progress → reset the wedge window
+    if (slot.inFlight && msg.id === slot.inFlight.id) {
+      slot.lastChunkSeen = msg.chunk;
+      armWatchdog(slot); // forward progress → reset the wedge window
     }
     return;
   }
 
-  // result — ignore stale messages from a terminated/superseded worker.
-  if (!_inFlight || msg.id !== _inFlight.id) return;
-  clearWatchdog();
-  const task = _inFlight;
-  _inFlight = null;
+  // result — ignore stale messages from a terminated/superseded worker or a mismatched task.
+  if (!slot.inFlight || msg.id !== slot.inFlight.id) return;
+  clearWatchdog(slot);
+  const task = slot.inFlight;
+  slot.inFlight = null;
 
   if (msg.ok) {
-    _consecutiveFailures = 0; // a clean task resets the respawn backoff
+    slot.consecutiveFailures = 0; // a clean task resets THIS slot's respawn backoff
     task.resolve(unpack(msg.buffer, msg.count, msg.dim));
   } else {
     // Worker is alive but the compute threw (e.g. model load) — reject this task, keep the worker.
@@ -215,49 +317,51 @@ function onWorkerMessage(msg: WorkerMessage): void {
   pump();
 }
 
-function armWatchdog(): void {
-  clearWatchdog();
-  _watchdog = setTimeout(onWedge, HEARTBEAT_TIMEOUT_MS);
+function armWatchdog(slot: Slot): void {
+  clearWatchdog(slot);
+  slot.watchdog = setTimeout(() => onWedge(slot), HEARTBEAT_TIMEOUT_MS);
 }
 
-function clearWatchdog(): void {
-  if (_watchdog) { clearTimeout(_watchdog); _watchdog = null; }
+function clearWatchdog(slot: Slot): void {
+  if (slot.watchdog) { clearTimeout(slot.watchdog); slot.watchdog = null; }
 }
 
-function onWedge(): void {
-  if (!_inFlight) return; // result already handled — spurious fire
-  onWorkerDown('wedge', `no heartbeat within ${HEARTBEAT_TIMEOUT_MS}ms (last chunk seen: ${_lastChunkSeen})`);
+function onWedge(slot: Slot): void {
+  if (!slot.inFlight) return; // result already handled — spurious fire
+  onWorkerDown(slot, 'wedge', `no heartbeat within ${HEARTBEAT_TIMEOUT_MS}ms (last chunk seen: ${slot.lastChunkSeen})`);
 }
 
 /**
- * Unified crash / exit / wedge handler: terminate the faulted worker, reject the in-flight task
- * (never recompute in-thread), and respawn with backoff. New tasks during the gap are shed.
+ * Unified per-slot crash / exit / wedge handler: terminate the faulted worker, reject the in-flight
+ * task (never recompute in-thread), and respawn THIS slot with backoff. Sibling slots are untouched.
+ * New tasks arriving while every slot is down are shed.
  */
-function onWorkerDown(cause: DownCause, detail: string): void {
-  if (_down) return; // already handling this outage (e.g. terminate() → 'exit' re-entry)
-  _down = true;
-  clearWatchdog();
+function onWorkerDown(slot: Slot, cause: DownCause, detail: string): void {
+  if (slot.down) return; // already handling this slot's outage (e.g. terminate() → 'exit' re-entry)
+  slot.down = true;
+  clearWatchdog(slot);
 
-  safeTerminate(_worker);
-  _worker = null;
+  safeTerminate(slot.worker);
+  slot.worker = null;
 
-  if (_inFlight) {
-    const task = _inFlight;
-    _inFlight = null;
+  if (slot.inFlight) {
+    const task = slot.inFlight;
+    slot.inFlight = null;
     warn(`embedding worker ${cause} — terminating + respawning`, {
-      requester: task.requester, taskId: task.id, cause, detail, lastChunkSeen: _lastChunkSeen,
+      requester: task.requester, taskId: task.id, cause, detail, lastChunkSeen: slot.lastChunkSeen,
     });
     task.reject(workerDownError(task.requester, cause, detail));
   } else {
     warn(`embedding worker ${cause} — terminating + respawning (no task in flight)`, { cause, detail });
   }
 
-  // Respawn after backoff; the worker is lazily re-spawned by the next pump() once the gap clears.
-  _consecutiveFailures++;
-  const delay = Math.min(BACKOFF_BASE_MS * 2 ** (_consecutiveFailures - 1), BACKOFF_CAP_MS);
-  _respawnTimer = setTimeout(() => {
-    _respawnTimer = null;
-    _down = false;
+  // Respawn this slot after backoff; the worker is lazily re-spawned by the next pump() once its gap
+  // clears. Backoff is per-slot so one slot's crash storm doesn't stall the others.
+  slot.consecutiveFailures++;
+  const delay = Math.min(BACKOFF_BASE_MS * 2 ** (slot.consecutiveFailures - 1), BACKOFF_CAP_MS);
+  slot.respawnTimer = setTimeout(() => {
+    slot.respawnTimer = null;
+    slot.down = false;
     pump(); // resume any tasks still queued from before the outage
   }, delay);
 }
@@ -316,21 +420,25 @@ export function __setEmbeddingWorkerFactory(factory: EmbeddingWorkerFactory | nu
   _workerFactory = factory ?? defaultWorkerFactory;
 }
 
-/** Reset all manager state between tests (timers, queue, worker, counters). */
+/** Reset all manager state between tests (timers, queue, slots, counters, configured size). */
 export function __resetEmbeddingWorkerForTests(): void {
-  clearWatchdog();
-  if (_respawnTimer) { clearTimeout(_respawnTimer); _respawnTimer = null; }
-  safeTerminate(_worker);
-  _worker = null;
-  _inFlight = null;
+  for (const slot of _slots) {
+    clearWatchdog(slot);
+    if (slot.respawnTimer) { clearTimeout(slot.respawnTimer); slot.respawnTimer = null; }
+    safeTerminate(slot.worker);
+  }
+  _slots = [];
+  _desiredSize = null;
   _queue.length = 0;
   _nextId = 1;
-  _consecutiveFailures = 0;
-  _lastChunkSeen = -1;
-  _down = false;
 }
 
-/** Introspection for tests: current queue depth (in-flight + waiting). */
+/** Introspection for tests: current queue depth (queued + in-flight across all slots). */
 export function __queueDepthForTests(): number {
   return queueLen();
+}
+
+/** Introspection for tests: the effective (clamped) pool size. */
+export function __poolSizeForTests(): number {
+  return poolSize();
 }


### PR DESCRIPTION
## Summary
Generalizes the single-worker off-thread embedding manager (t/3181) to a **K-slot pool**. Default **K=1 → byte-identical, inert** single-worker behavior; ramps only when ServerAPI sets `EMBEDDING_WORKER_POOL_SIZE>1` **and** DevOps sizes a multi-core SKU.

Design + TL approval: t/3211#5 / t/3211#6. Novel hot-path concurrency → **returns to Main (TL) for Gate Verification** (draft until GV clears).

## What changed (`lib/embeddings/offThreadEmbedding.ts`)
- **`configureEmbeddingWorkerPool(size)`** — startup-only mutator (NOT a ctor; preserves the free-function `computeEmbeddingsOffThread` contract B/C build against). Self-clamps to `min(size, availableParallelism()−1)` with a fallback-logging WARN on clamp. **[TL condition A]** called-after-spawn → no-op + WARN; compute-before-configure → K=1, never throws.
- **`pump()`** dispatches each queued task to any idle, up-and-serving slot (≤ liveSlotCount in flight). Per-slot watchdog / respawn-backoff / consecutive-failures / down-flag.
- **Identity-guard generalized to the slot ref** — a superseded worker's late exit/error tears down only its own slot; healthy siblings keep serving (the load-bearing t/3181 GV invariant).
- **[TL condition B]** shed only when **all** slots are down; queue-depth cap = `MAX_QUEUE_DEPTH × liveSlotCount` (dynamic) so a lone survivor can't accept a K× backlog that tail-latencies past the ~50s route wall.
- **Fail-loud contract preserved** — no in-thread fallback anywhere.

## Tests
Extend the injectable-factory suite: **default-1 parity** (existing 4-arm suite passes byte-identical), K-parallel dispatch, aggregate shed at ×K, **per-slot fault isolation reproducing the t/3181 late-exit regression**, clamp + WARN, configure ordering (both edges).

- `npx vitest run` → **15 passed / 1 skipped** (real-ONNX, env-gated)
- `tsc --noEmit` → clean for changed files (5 pre-existing `electron-shared` react/electron errors are a local-install quirk, identical on `main`)
- `eslint` → clean

## Safety
Lands **inert**: nothing changes until the config knob is raised on a multi-core SKU.

## Follow-up (separate ticket, non-blocking, per TL)
Queued-task age-out: a task can sit in the shared queue while slots are down and blow the route timeout before dispatch. Filing against Shared Lib.

Ownership: `lib/embeddings/` = Shared Lib. ServerAPI owns `EMBEDDING_WORKER_POOL_SIZE` config + dispatch threading + the `availableParallelism()` boot log; DevOps owns the SKU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)