### PR TITLE
chore(debate): gate co-location comment for watchlist t/3269 exemption (t/3273)

### DIFF
--- a/lib/debate/taxonomyContext.ts
+++ b/lib/debate/taxonomyContext.ts
@@ -314,6 +314,11 @@ export function formatTaxonomyContext(ctx: TaxonomyContext, pov: string, maxNode
   }
 
   // Reasoning watchlist — configurable confidence filter
+  // t/3273 gate co-location: NOT dropped by t/3269 blanket-drop because the opponent-dismissal
+  // ceiling-adoption mechanism is absent here — injection is self-directed (own povSlice only),
+  // tail-positioned (after all BDI grounding), and confidence-gated ('likely' filter). Worst case
+  // is mild self-hedging, a different/lower threat class than the 25% unfair-dismissal validated
+  // in t/3262. Residual chill risk from systematic bias deferred to future classification_source axis.
   const fallacyLines: string[] = [];
   const fallacyEnabled = cfg.fallacyEnabled ?? true;
   const fallacyFilter = cfg.fallacyConfidence ?? 'likely';


### PR DESCRIPTION
## Summary

- Adds a 5-line exemption comment at the `possible_fallacies` injection site in `lib/debate/taxonomyContext.ts` (lines 316–321)
- Documents *why* the reasoning watchlist is explicitly NOT dropped by the t/3269 blanket-drop: self-directed / tail-positioned / confidence-gated → opponent-dismissal ceiling-adoption mechanism is absent
- No logic change — comment only

## Test plan

- [ ] Comment-only change; no test gate required (self-cert under /trivial-change)
- [ ] TL GV approved at p/332#90

🤖 Generated with [Claude Code](https://claude.com/claude-code)