### PR TITLE
feat(server): wire EMBEDDING_WORKER_POOL_SIZE → configureEmbeddingWorkerPool at boot (t/3211)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/embeddingWorkerPoolSize.test.ts
+++ b/taxonomy-editor/src/server/__tests__/embeddingWorkerPoolSize.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment node
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3211 — getEmbeddingWorkerPoolSize: parse EMBEDDING_WORKER_POOL_SIZE, DEFAULT 1 (inert). The RAW
+// value is passed to Shared Lib's configureEmbeddingWorkerPool, which self-clamps — so this getter
+// only needs to yield a sane positive integer (>=1), defaulting to 1 on unset/invalid input.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { getEmbeddingWorkerPoolSize } from '../config.js';
+
+const prior = process.env.EMBEDDING_WORKER_POOL_SIZE;
+afterEach(() => {
+  if (prior === undefined) delete process.env.EMBEDDING_WORKER_POOL_SIZE;
+  else process.env.EMBEDDING_WORKER_POOL_SIZE = prior;
+});
+
+describe('getEmbeddingWorkerPoolSize (t/3211)', () => {
+  it('defaults to 1 when unset (inert — today\'s single-worker behavior)', () => {
+    delete process.env.EMBEDDING_WORKER_POOL_SIZE;
+    expect(getEmbeddingWorkerPoolSize()).toBe(1);
+  });
+
+  it('parses a valid positive integer verbatim (raw — the lib self-clamps)', () => {
+    process.env.EMBEDDING_WORKER_POOL_SIZE = '2';
+    expect(getEmbeddingWorkerPoolSize()).toBe(2);
+    process.env.EMBEDDING_WORKER_POOL_SIZE = '8'; // over-set is fine — configureEmbeddingWorkerPool clamps
+    expect(getEmbeddingWorkerPoolSize()).toBe(8);
+  });
+
+  it('falls back to 1 on invalid/non-positive input (never 0 or negative)', () => {
+    for (const v of ['0', '-3', 'abc', '', '  ', '1.5']) {
+      process.env.EMBEDDING_WORKER_POOL_SIZE = v;
+      const got = getEmbeddingWorkerPoolSize();
+      expect(got, `"${v}" → >=1`).toBeGreaterThanOrEqual(1);
+    }
+    process.env.EMBEDDING_WORKER_POOL_SIZE = '0';
+    expect(getEmbeddingWorkerPoolSize()).toBe(1);
+  });
+});

--- a/taxonomy-editor/src/server/config.ts
+++ b/taxonomy-editor/src/server/config.ts
@@ -413,6 +413,16 @@ export function isEmbeddingWorkerOffloadEnabled(): boolean {
   return v === '1' || v === 'true';
 }
 
+/** t/3211: desired embedding-worker POOL size (K). DEFAULT 1 → today's single-worker behavior exactly,
+ *  so this lands inert until EMBEDDING_WORKER_POOL_SIZE>1 AND a container with spare cores is deployed.
+ *  The RAW value is passed to configureEmbeddingWorkerPool, which SELF-CLAMPS to
+ *  min(size, availableParallelism()-1) + WARNs (Shared Lib owns the safety) so a mis-set value can never
+ *  oversubscribe the main event loop. A non-positive/NaN env → 1. */
+export function getEmbeddingWorkerPoolSize(): number {
+  const n = Number.parseInt(process.env.EMBEDDING_WORKER_POOL_SIZE ?? '', 10);
+  return Number.isFinite(n) && n >= 1 ? n : 1;
+}
+
 // t/3206 (t/3165 storm-replay canary): per-revision capability switch for the canary loop-lag
 // sampler + its two /internal/canary/loop-sampler routes. DEFAULT OFF — when off the routes 404 AND
 // the anon-exemption for /internal/canary/* does not exist (double-closed; zero prod exposure).

--- a/taxonomy-editor/src/server/server.ts
+++ b/taxonomy-editor/src/server/server.ts
@@ -34,8 +34,9 @@ import {
   getStoredApiKeys, addApiKey, removeApiKey, resolveDataPath,
   getPaidGeminiFallbackKey, setPaidGeminiFallbackKey, deletePaidGeminiFallbackKey,
   BROKER_SCRIPT, SCRIPTS_DIR, getProjectRoot, type AIBackend,
-  STORAGE_MODE, CACHE_DIR, isEmbeddingWorkerOffloadEnabled,
+  STORAGE_MODE, CACHE_DIR, isEmbeddingWorkerOffloadEnabled, getEmbeddingWorkerPoolSize,
 } from './config.js';
+import { configureEmbeddingWorkerPool } from '../../../lib/embeddings/offThreadEmbedding.js';
 import { GitHubAPIBackend } from './storage/githubAPIBackend.js';
 import { SessionBranchManager } from './storage/sessionBranchManager.js';
 import { runWithUser, getCurrentUserId, getSessionBranchName, setSessionBranchName, deriveStorageUserId, type UserContext } from './security/userContext.js';
@@ -1319,6 +1320,13 @@ server.listen(PORT, BIND_HOST, () => {
   // the next deploy, not asserted blind from the ACA vCPU config (cgroup quota can differ). DevOps reads
   // this before any 4-vCPU bump + POOL_SIZE flip (p/526#75).
   log.server.info({ availableParallelism: os.availableParallelism(), cpus: os.cpus().length }, 'host core count at boot');
+  // t/3211: configure the embedding-worker POOL once at startup with the RAW EMBEDDING_WORKER_POOL_SIZE
+  // (default 1 → single worker, today's exact behavior). Shared Lib's configureEmbeddingWorkerPool
+  // SELF-CLAMPS to min(size, availableParallelism()-1) + WARNs, so a mis-set value can't oversubscribe
+  // the main loop. Inert until POOL_SIZE>1 on a container with spare cores (needs the 4-vCPU SKU + flip).
+  const poolSize = getEmbeddingWorkerPoolSize();
+  configureEmbeddingWorkerPool(poolSize);
+  log.server.info({ requestedPoolSize: poolSize }, 'embedding worker pool configured at boot');
   void warmupEmbeddings().catch((err: unknown) => {
     log.server.error({ err: String(err) }, 'ONNX embedding warmup failed at boot');
     getGlobalRecorder()?.record({ type: 'system.error', component: 'server', level: 'error', message: 'ONNX embedding warmup failed at boot', error: { name: (err as Error)?.name ?? 'Error', message: String(err), stack: (err as Error)?.stack } });


### PR DESCRIPTION
## What
The ServerAPI half of the embedding-worker-pool pre-build. `getEmbeddingWorkerPoolSize()` parses `EMBEDDING_WORKER_POOL_SIZE` (default 1); server startup calls Shared Lib's `configureEmbeddingWorkerPool(rawSize)` once (next to the offload-flag + core-count boot logs), passing the **raw** value — the lib **self-clamps** to `min(size, availableParallelism()−1)` + WARNs, so a mis-set value can't oversubscribe the main event loop (safety owned there, p/575#15).

## Lands INERT
default-1 = single worker = **zero behavior change**. Activation = DevOps's 4-vCPU/8Gi SKU bump + `EMBEDDING_WORKER_POOL_SIZE=2` (K=2, 1 core headroom — chosen over K=3 to avoid re-starving main, the t/3165 lesson). Pool impl in #1888 (ee6ed0cd); core-count boot-log in #1886.

## Verify
- getter test: defaults to 1 on unset/invalid, parses valid positives verbatim → **3/3**
- eslint + tsc clean; `computeEmbeddingsOffThread` unchanged

Self-cert (ServerAPI-side config wiring of the TL-GV'd pool). Relates t/3165, t/3211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)