### PR TITLE
feat(config): add current-gen Gemini text models to the registry (t/3276)

### DIFF
--- a/ai-models.json
+++ b/ai-models.json
@@ -105,6 +105,48 @@
       "backend": "gemini"
     },
     {
+      "id": "gemini-3.8-flash",
+      "apiModelId": "gemini-3.8-flash",
+      "label": "Gemini 3.8 Flash",
+      "backend": "gemini"
+    },
+    {
+      "id": "gemini-3.6-flash",
+      "apiModelId": "gemini-3.6-flash",
+      "label": "Gemini 3.6 Flash",
+      "backend": "gemini"
+    },
+    {
+      "id": "gemini-3.5-flash",
+      "apiModelId": "gemini-3.5-flash",
+      "label": "Gemini 3.5 Flash",
+      "backend": "gemini"
+    },
+    {
+      "id": "gemini-3.1-flash-lite",
+      "apiModelId": "gemini-3.1-flash-lite",
+      "label": "Gemini 3.1 Flash Lite",
+      "backend": "gemini"
+    },
+    {
+      "id": "gemini-2.5-pro",
+      "apiModelId": "gemini-2.5-pro",
+      "label": "Gemini 2.5 Pro",
+      "backend": "gemini"
+    },
+    {
+      "id": "gemini-2.5-flash",
+      "apiModelId": "gemini-2.5-flash",
+      "label": "Gemini 2.5 Flash",
+      "backend": "gemini"
+    },
+    {
+      "id": "gemini-2.5-flash-lite",
+      "apiModelId": "gemini-2.5-flash-lite",
+      "label": "Gemini 2.5 Flash-Lite",
+      "backend": "gemini"
+    },
+    {
       "id": "claude-opus-5",
       "apiModelId": "claude-opus-5",
       "label": "Claude Opus 5",


### PR DESCRIPTION
Closes t/3276. Adds current-generation Gemini text chat/debate models to `ai-models.json` `models[]` (SSOT for PS + Electron). PM-requested, TL-scoped (t/3276#1/#3), self-cert `/add-ai-backend`.

## Models added (7)
Discovered via the **live ListModels API**, not a curated list (per TL AC t/3276#3):

| id / apiModelId | label |
|---|---|
| `gemini-3.8-flash` | Gemini 3.8 Flash |
| `gemini-3.6-flash` | Gemini 3.6 Flash |
| `gemini-3.5-flash` | Gemini 3.5 Flash |
| `gemini-3.1-flash-lite` | Gemini 3.1 Flash Lite |
| `gemini-2.5-pro` | Gemini 2.5 Pro |
| `gemini-2.5-flash` | Gemini 2.5 Flash |
| `gemini-2.5-flash-lite` | Gemini 2.5 Flash-Lite |

(Existing gemini entries unchanged: 3.7-flash, 3.1-pro-preview, 3.5-flash-lite → 10 total.)

## ⚠️ `gemini-4.8-flash` does NOT exist
The intake named `gemini-4.8-flash`, but the live API's newest flash is `gemini-3.8-flash`. Registering it would 404 at runtime, so per the "don't register a phantom" AC it is **not** added. Flagged to TL/PM.

## Filter (TL AC)
INCLUDE only `generateContent`-capable text flash+pro. EXCLUDE: embedding-only; image/vision (Nano Banana `*-image`); TTS/native-audio; transcribe/live/omni/robotics/computer-use; `-preview`/`-exp`/`-customtools` experimental-or-tuned where a stable exists; floating `-latest` aliases (registry convention is concrete versions). **Scope note:** I read "discover the lineup, don't curate" literally and included stable 2.5-gen text models too (they pass the type filter) — trivial to prune in review if only 3.x is wanted.

## Verification
- **`npm run verify:config` → all 7 registry gates green** (Test-AIModelsConfig, ModelLiteralLint, keysValidation, resolveApiModelId, configInvariant, modelDiscovery). No TS-enum / PS-ValidateSet / settings-option coupling site flagged → SSOT auto-propagates (model-level add under existing backend).
- **Real `generateContent` spot-check:** `gemini-3.8-flash`, `gemini-3.6-flash`, `gemini-2.5-pro`, `gemini-2.5-flash-lite` → all HTTP 200 (no tier/403 gap).
- `apiModelId` == exact ListModels name minus `models/`. JSON round-trips byte-identical.

Deletion-only? No — pure additions (+42/-0), config-only.