### PR TITLE
feat(settings): add 4 new Gemini 3.x models to renderer picker (t/3277)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/settingsSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/settingsSlice.ts
@@ -26,6 +26,10 @@ export type GeminiModel =
   | typeof DEFAULT_MODEL
   | 'gemini-3-flash-preview'
   | 'gemini-3.1-pro-preview'
+  | 'gemini-3.8-flash'      // t/3277
+  | 'gemini-3.6-flash'      // t/3277
+  | 'gemini-3.5-flash'      // t/3277
+  | 'gemini-3.1-flash-lite' // t/3277
   | 'gemini-2.5-flash'
   | 'gemini-2.5-flash-lite'
   | 'gemini-2.5-pro';
@@ -94,6 +98,10 @@ export const MODELS_BY_BACKEND: Record<AIBackend, AIModelEntry[]> = {
     { value: DEFAULT_MODEL, label: '3.1 Flash Lite Preview (default)' },
     { value: 'gemini-3-flash-preview', label: '3 Flash Preview' },
     { value: 'gemini-3.1-pro-preview', label: '3.1 Pro Preview (best quality)' },
+    { value: 'gemini-3.8-flash', label: '3.8 Flash' },
+    { value: 'gemini-3.6-flash', label: '3.6 Flash' },
+    { value: 'gemini-3.5-flash', label: '3.5 Flash' },
+    { value: 'gemini-3.1-flash-lite', label: '3.1 Flash Lite' },
     { value: 'gemini-2.5-flash', label: '2.5 Flash' },
     { value: 'gemini-2.5-flash-lite', label: '2.5 Flash Lite (fastest)' },
     { value: 'gemini-2.5-pro', label: '2.5 Pro' },


### PR DESCRIPTION
Coupling site missed by the config-only PR #1892 (t/3276): `settingsSlice.ts` hardcodes the `GeminiModel` type union + `MODELS_BY_BACKEND.gemini` static fallback. Adds the 4 genuinely-new IDs (2.5-gen already present), **verified against origin/main `ai-models.json` (2b7be7fc)**: `gemini-3.8-flash` / `3.6-flash` / `3.5-flash` / `3.1-flash-lite`.

## Change (+8, 1 file)
- `GeminiModel` union: +4 IDs (compile-time type).
- `MODELS_BY_BACKEND.gemini`: +4 `{value,label}` entries (pre-`initAIModels` fallback).

## Self-cert /trivial-change (Quality-specced, t/3277)
- No `promptCatalog.ts` change: it has no hardcoded gemini model *list*, only a `gemini-3.1-pro-preview` default in one description string (ticket point 4 satisfied).
- **DEVIATION (flagged):** used the file's existing **short-label** convention (`'3.8 Flash'`) rather than the ticket's `'Gemini 3.8 Flash'` labels — the static block uniformly strips the `Gemini` prefix, and `initAIModels()` overwrites these with `ai-models.json`'s full labels at runtime anyway (the picker shows the authoritative full labels regardless; static labels are fallback-only).

## Verify
- renderer-tsc **0 errors** in settingsSlice (3 `../lib` errors are the known worktree artifact).
- settings-slice tests **11/11**. `ALL_MODEL_IDS` derives from `MODELS_BY_BACKEND` so it picks up the new IDs.

Self-merging on green. t/3276 → Done once this lands.

Commit: c37845bb