### PR TITLE
feat(embeddings): queued-task age-out at dispatch (t/3275)

### DIFF
--- a/lib/embeddings/offThreadEmbedding.test.ts
+++ b/lib/embeddings/offThreadEmbedding.test.ts
@@ -450,6 +450,107 @@ describe('offThreadEmbedding — pool: configure() ordering contract (t/3211 TL 
   });
 });
 
+// ══ t/3275 queued-task age-out (dispatch-time reject) ════════════════════════════════════════════
+// QUEUE_AGE_OUT_MS is 40_000 in the module (not exported — same convention as HEARTBEAT_TIMEOUT_MS).
+// Tests advance past it and pin the value via the WARN's budgetMs. A slot is kept alive across the
+// long wait by heartbeating its in-flight task (each heartbeat resets the 8s watchdog) — that's the
+// real shape: slots busy on slow work while a backlog ages behind them.
+
+/** Advance `totalMs` in <8s steps, heartbeating `worker`'s in-flight `id` so its watchdog never fires. */
+async function ageWhileServing(worker: FakeWorker, id: number, totalMs: number): Promise<void> {
+  for (let elapsed = 0; elapsed < totalMs; elapsed += 5_000) {
+    worker.emit('message', { type: 'heartbeat', id, chunk: elapsed / 5_000 });
+    await vi.advanceTimersByTimeAsync(5_000);
+  }
+}
+
+describe('offThreadEmbedding — age-out: reject a task queued past the budget, still serve a fresh one', () => {
+  it('drains the stale head-of-queue on dispatch (WARN carries waitedMs≥budgetMs) and dispatches a fresh task', async () => {
+    vi.useFakeTimers();
+    const workers: FakeWorker[] = [];
+    __setEmbeddingWorkerFactory(() => { const w = new FakeWorker(); workers.push(w); return w; });
+
+    // A holds the single slot (in flight, heartbeating); B queues behind it and will age out.
+    const pA = computeEmbeddingsOffThread(['A'], { requester: 'A-inflight' });
+    const worker = workers[0];
+    const aId = worker.lastId();
+    const pB = computeEmbeddingsOffThread(['B'], { requester: 'B-stale' });
+    const pBRejected = expect(pB).rejects.toThrow(/age-out|queued past/i);
+    expect(__queueDepthForTests()).toBe(2); // A in flight + B queued
+
+    // Time passes past the 40s budget while A keeps its slot alive.
+    await ageWhileServing(worker, aId, 45_000);
+
+    // A fresh task D is enqueued now (well within budget), then A completes → the freed slot drains B
+    // (stale → age-out reject) and dispatches D (fresh → served).
+    const pD = computeEmbeddingsOffThread(['D'], { requester: 'D-fresh' }).catch(() => {});
+    worker.emit('message', resultFor(aId, [[1, 0, 0, 0]]));
+    await pBRejected;
+    await expect(pA).resolves.toHaveLength(1);
+
+    const ageWarn = warns().find(warn => /age-out budget/i.test(warn.message ?? ''));
+    expect(ageWarn).toBeDefined();
+    expect(ageWarn!.data?.requester).toBe('B-stale');
+    expect(ageWarn!.data?.budgetMs).toBe(40_000);
+    expect(ageWarn!.data?.waitedMs as number).toBeGreaterThanOrEqual(40_000); // payload, not just the message
+
+    // D (fresh) was dispatched onto the freed slot — proof age-out drops only the stale head, not the queue.
+    expect(worker.posted[worker.posted.length - 1].texts).toEqual(['D']);
+    void pD;
+  });
+
+  it('does NOT age-out a task still within budget — it dispatches normally', async () => {
+    vi.useFakeTimers();
+    const workers: FakeWorker[] = [];
+    __setEmbeddingWorkerFactory(() => { const w = new FakeWorker(); workers.push(w); return w; });
+
+    const pA = computeEmbeddingsOffThread(['A'], { requester: 'A' });
+    const worker = workers[0];
+    const aId = worker.lastId();
+    const pB = computeEmbeddingsOffThread(['B'], { requester: 'B-young' });
+
+    await ageWhileServing(worker, aId, 10_000); // only 10s < 40s budget
+    worker.emit('message', resultFor(aId, [[1, 0, 0, 0]])); // A done → B dispatched (young, not shed)
+    await expect(pA).resolves.toHaveLength(1);
+
+    expect(worker.posted[worker.posted.length - 1].texts).toEqual(['B']); // B was served, not aged out
+    const bId = worker.lastId();
+    worker.emit('message', resultFor(bId, [[2, 0, 0, 0]]));
+    await expect(pB).resolves.toHaveLength(1);
+    expect(warns().some(warn => /age-out budget/i.test(warn.message ?? ''))).toBe(false);
+  });
+
+  it('drains an ALL-stale queue and leaves the slot idle — nothing dispatched (TL 4th case)', async () => {
+    vi.useFakeTimers();
+    const workers: FakeWorker[] = [];
+    __setEmbeddingWorkerFactory(() => { const w = new FakeWorker(); workers.push(w); return w; });
+
+    // A in flight; B and C both queue behind and both age past the budget.
+    const pA = computeEmbeddingsOffThread(['A'], { requester: 'A' });
+    const worker = workers[0];
+    const aId = worker.lastId();
+    const pB = computeEmbeddingsOffThread(['B'], { requester: 'B' });
+    const pC = computeEmbeddingsOffThread(['C'], { requester: 'C' });
+    const pBRejected = expect(pB).rejects.toThrow(/age-out|queued past/i);
+    const pCRejected = expect(pC).rejects.toThrow(/age-out|queued past/i);
+    expect(__queueDepthForTests()).toBe(3);
+
+    await ageWhileServing(worker, aId, 45_000);
+    const postedBeforeFree = worker.posted.length;
+
+    // A completes → the freed slot pumps: B and C are both stale → both age-out reject, and since no
+    // servable task remains the slot stays idle (no dispatch).
+    worker.emit('message', resultFor(aId, [[1, 0, 0, 0]]));
+    await pBRejected;
+    await pCRejected;
+    await expect(pA).resolves.toHaveLength(1);
+
+    expect(__queueDepthForTests()).toBe(0);                 // queue fully drained, nothing in flight
+    expect(worker.posted.length).toBe(postedBeforeFree);    // slot idle — no new postMessage after A
+    expect(warns().filter(warn => /age-out budget/i.test(warn.message ?? '')).length).toBe(2);
+  });
+});
+
 // ── Equivalence (condition 3): real-ONNX worker intra-op=1 vs in-thread default — skip-guarded ──
 
 function realOnnxAvailable(): boolean {

--- a/lib/embeddings/offThreadEmbedding.ts
+++ b/lib/embeddings/offThreadEmbedding.ts
@@ -66,12 +66,25 @@ const BACKOFF_CAP_MS = 5000;
  */
 const POOL_CORE_HEADROOM = 1;
 
+/**
+ * Queue age-out budget (t/3275). A task that has waited longer than this in the SHARED queue is
+ * rejected fail-loud at the moment a slot would dispatch it, instead of being computed for a caller
+ * the route has already abandoned. Sized against the ~50s server route wall: must be `< 50s` with
+ * headroom for one dispatch + a first-compute start (~10s, incl. a cold model-load spike) so a task
+ * admitted at the budget still returns before the route times out. Too low → sheds tasks that could
+ * still finish in budget; too high → burns a worker slot on doomed work behind the backlog. The
+ * in-flight watchdog (HEARTBEAT_TIMEOUT_MS) guards tasks already dispatched; this guards the queue
+ * wait the watchdog never sees. (t/3275; ~50s route wall / 512-batch storm.)
+ */
+const QUEUE_AGE_OUT_MS = 40_000;
+
 // ── Types ─────────────────────────────────────────────
 
 interface Task {
   id: number;
   texts: string[];
   requester: string;
+  queuedAt: number; // Date.now() at enqueue — drives the QUEUE_AGE_OUT_MS dispatch-time age-out (t/3275)
   resolve: (vectors: Float32Array[]) => void;
   reject: (err: unknown) => void;
 }
@@ -237,7 +250,7 @@ export function computeEmbeddingsOffThread(
   }
 
   return new Promise<Float32Array[]>((resolve, reject) => {
-    _queue.push({ id: _nextId++, texts, requester, resolve, reject });
+    _queue.push({ id: _nextId++, texts, requester, queuedAt: Date.now(), resolve, reject });
     pump();
   });
 }
@@ -261,15 +274,39 @@ export function shutdownEmbeddingWorker(): void {
 function pump(): void {
   ensureSlots();
   for (const slot of _slots) {
-    if (_queue.length === 0) break;
     if (slot.inFlight || slot.down) continue;         // busy or respawning → skip
+    const task = takeNextServableTask();              // skips + rejects tasks aged past the budget
+    if (!task) break;                                 // queue empty (or fully drained of stale tasks)
     if (!slot.worker) slot.worker = spawnWorker(slot); // lazily (re)spawn on demand
-    const task = _queue.shift()!;
     slot.inFlight = task;
     slot.lastChunkSeen = -1;
     armWatchdog(slot); // ARM ON DISPATCH (TL Q1) — catches a hang before the first heartbeat too
     slot.worker.postMessage({ id: task.id, texts: task.texts });
   }
+}
+
+/**
+ * Pop the next task that is still worth serving, age-out-rejecting any that waited past
+ * `QUEUE_AGE_OUT_MS` (t/3275). The check runs at the DISPATCH decision — exactly when a slot would
+ * take the task — so a doomed task never seizes a worker; the reject just fires at the moment
+ * dispatch would have. Returns `null` when the queue is empty or every remaining task is stale (the
+ * slot then stays idle). Each age-out is a fail-loud shed (ActionableError → 503) + a WARN naming the
+ * requester and wait time (fallback-logging); there is NO in-thread fallback.
+ */
+function takeNextServableTask(): Task | null {
+  while (_queue.length > 0) {
+    const task = _queue.shift()!;
+    const waitedMs = Date.now() - task.queuedAt;
+    if (waitedMs > QUEUE_AGE_OUT_MS) {
+      warn('embedding request shed — queued past age-out budget before dispatch', {
+        requester: task.requester, waitedMs, budgetMs: QUEUE_AGE_OUT_MS, queueDepth: queueLen(),
+      });
+      task.reject(ageOutError(task.requester, waitedMs));
+      continue; // drop this stale task, try the next one — do not consume the slot on it
+    }
+    return task;
+  }
+  return null;
 }
 
 function spawnWorker(slot: Slot): EmbeddingWorkerLike {
@@ -384,6 +421,20 @@ function shedError(requester: string, reason: string): ActionableError {
     nextSteps: [
       'Retry after backpressure clears — this maps to the existing t/3078 block-mode 503 load-shed',
       'Intentional load-shedding, not a fault: the worker queue is bounded to protect request handling',
+    ],
+  });
+}
+
+function ageOutError(requester: string, waitedMs: number): ActionableError {
+  return new ActionableError({
+    goal: 'Compute embeddings off the main thread within the request budget',
+    problem: `Embedding request from "${requester}" was shed: waited ${waitedMs}ms in the queue, past `
+      + `the ${QUEUE_AGE_OUT_MS}ms age-out budget, before a worker was free to serve it`,
+    location: 'lib/embeddings/offThreadEmbedding.ts:takeNextServableTask',
+    nextSteps: [
+      'Retry after backpressure clears — this maps to the existing t/3078 block-mode 503 load-shed',
+      'Intentional load-shedding, not a fault: a task queued past the budget would exceed the route '
+        + 'timeout anyway, so it is rejected rather than dispatched to compute a now-abandoned result',
     ],
   });
 }


### PR DESCRIPTION
## Summary
Follow-up to t/3211 (TL GV note). The in-flight watchdog never sees a task **still in the shared queue** — under a long backlog or partial pool failure (a lone survivor draining at 1/K) a queued task can blow the ~50s route wall before it's ever dispatched. This rejects such tasks **fail-loud at the dispatch decision**, so a doomed task never seizes a worker.

Design + **Quality (Tech Lead) approval**: t/3275#1, p/430#10.

## Changes (`lib/embeddings/offThreadEmbedding.ts`)
- **`QUEUE_AGE_OUT_MS` = 40s** — co-located constant with the margin rationale (must be `< ~50s` route wall, headroom for one dispatch + a first-compute start).
- **`Task.queuedAt`** stamped at enqueue; `pump()` now pulls via **`takeNextServableTask()`**, which drains stale head-of-queue entries (age-out reject + WARN carrying `requester`/`waitedMs`/`budgetMs`, fallback-logging) before dispatching the first fresh task.
- **`ageOutError`** (ActionableError → 503). Fail-loud contract unchanged, **no in-thread fallback**.
- No periodic sweep (deliberate) — the dispatch-time check covers exactly the case that matters (a doomed task seizing a slot).

## Tests
Three new cases: age-out-at-dispatch (stale head dropped, **fresh task still served**, WARN `waitedMs≥budgetMs` asserted on the payload), within-budget dispatches normally, and the **all-stale-queue drains to idle** case (Quality-TL requested 4th test).

- `vitest` → **19 passed / 1 skipped** (real-ONNX env-gated); default-1 parity intact (existing suite unchanged).
- `tsc` + `eslint` → clean for changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)