### PR TITLE
feat(auth): anon-gate POST /api/taxonomy/relevant-nodes via free-tier path (t/3284)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/anonAiRoutes.test.ts
+++ b/taxonomy-editor/src/server/__tests__/anonAiRoutes.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { isFreeTierAiPath, FREE_TIER_AI_POST_PATHS } from '../anonAiRoutes.js';
+import { isAnonAllowedRoute } from '../security/accessControl.js';
 
 describe('t/2489 — free-tier AI route allowlist (anon chat exemption)', () => {
   it('POST /api/ai/chat-stream is on the allowlist (the new anon-chat exemption)', () => {
@@ -19,6 +20,21 @@ describe('t/2489 — free-tier AI route allowlist (anon chat exemption)', () => 
     expect(isFreeTierAiPath('POST', '/api/ai/generate')).toBe(true);
     expect(isFreeTierAiPath('POST', '/api/embeddings/compute')).toBe(true);
     expect(isFreeTierAiPath('POST', '/api/embeddings/query')).toBe(true);
+  });
+
+  // ── t/3284 — /api/taxonomy/relevant-nodes anon-gate ──
+  it('t/3284: POST /api/taxonomy/relevant-nodes is free-tier exempt (predicate true)', () => {
+    expect(isFreeTierAiPath('POST', '/api/taxonomy/relevant-nodes')).toBe(true);
+    expect(FREE_TIER_AI_POST_PATHS).toContain('/api/taxonomy/relevant-nodes');
+  });
+
+  it('t/3284: GET /api/taxonomy/relevant-nodes is NOT exempt (method-scoped)', () => {
+    expect(isFreeTierAiPath('GET', '/api/taxonomy/relevant-nodes')).toBe(false);
+  });
+
+  it('t/3284 security negative: /api/taxonomy/relevant-nodes is NOT in the anon-safe allowlist (wrong bucket guard)', () => {
+    // Must be free-tier gated (rate-limited), NOT the blanket ANON_SAFE_POST_PATHS which bypasses rate limits.
+    expect(isAnonAllowedRoute('POST', '/api/taxonomy/relevant-nodes')).toBe(false);
   });
 
   // ── Negative arm (TL guardrail #1): other AI routes stay anon-blocked ──

--- a/taxonomy-editor/src/server/anonAiRoutes.ts
+++ b/taxonomy-editor/src/server/anonAiRoutes.ts
@@ -24,6 +24,7 @@ export const FREE_TIER_AI_POST_PATHS: readonly string[] = [
   '/api/embeddings/compute',
   '/api/embeddings/query',
   '/api/ai/chat-stream', // t/2489: anonymous users may use AI chat (free-tier Gemini)
+  '/api/taxonomy/relevant-nodes', // t/3284: anon debates reach server-side relevance (local ONNX, free-tier rate-limited)
 ];
 
 /**


### PR DESCRIPTION
## Summary

- Adds `/api/taxonomy/relevant-nodes` to `FREE_TIER_AI_POST_PATHS` in `anonAiRoutes.ts` so anonymous users can reach the server-side relevance endpoint under free-tier rate limits
- Mirrors the pattern of `/api/embeddings/compute` / `/api/embeddings/query` (local ONNX, not a generative backend)
- Correctly avoids `ANON_SAFE_POST_PATHS`, which bypasses rate limiting — preserves the t/3259 anon-cost gate

## Test plan

- [x] Predicate assertions: `isFreeTierAiPath('POST', path) === true`, GET false, non-member false
- [x] Security negative: `isAnonAllowedRoute('POST', path) === false` — confirms path is NOT in wrong bucket
- [x] 8/8 tests pass in `anonAiRoutes.test.ts`
- [x] `tsconfig.server.json` clean on main (worktree junction artifact — pre-existing lib/ errors unrelated to this change)

TL sign-off: p/602#2. Unblocks Rosetta T3 web-bridge wiring (t/3258).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013kAvxFH7W2DYghgN4gpULn