### PR TITLE
infra(container): bake BUILD_SHA into the runtime image env (t/3278)

### DIFF
--- a/taxonomy-editor/Dockerfile
+++ b/taxonomy-editor/Dockerfile
@@ -147,6 +147,13 @@ LABEL org.opencontainers.image.source="https://github.com/jpsnover/ai-triad-rese
 LABEL org.opencontainers.image.description="AI Triad Taxonomy Editor"
 LABEL org.opencontainers.image.licenses="MIT"
 
+# Build commit SHA baked into the RUNTIME image env (t/3278 drift-prevention). container.yml passes
+# --build-arg BUILD_SHA=<sha>; default 'unknown' keeps local/plain builds working. Makes "which
+# commit is running in prod?" answerable from the running image env instead of digest forensics.
+# ARG is re-declared here because ARGs do not cross stages (the builder stage's BUILD_SHA is for Vite).
+ARG BUILD_SHA=unknown
+ENV BUILD_SHA=${BUILD_SHA}
+
 # Cache dir created at runtime by the app (GitHubAPIBackend).
 # TAXONOMY_CACHE_DIR MUST match AI_TRIAD_DATA_ROOT (t/2061): config.ts's cacheDir
 # defaults to ~/.cache/taxonomy (=/root/.cache/taxonomy in-container) when unset,


### PR DESCRIPTION
DevOps drift-prevention primitive (t/3278, TL-approved; requested p/519#32). The RUNTIME stage now carries the build commit SHA in its env, so "which commit is running in prod?" is answerable from the running image — instead of the digest forensics that let a security fix sit silently un-shipped (the t/3278 incident).

## Change (+7, 1 file)
Runtime stage (`taxonomy-editor/Dockerfile`): `ARG BUILD_SHA=unknown` + `ENV BUILD_SHA=${BUILD_SHA}`.
- ARG **re-declared** in the runtime stage — ARGs don't cross stages (the builder stage's `BUILD_SHA` is Vite-only).
- Default `unknown` keeps local/plain builds working; `container.yml` passes `--build-arg BUILD_SHA=<sha>` (DevOps's half).

Self-cert **/trivial-change** (2 stanzas, my Dockerfile scope). Verified via CI `test-container` (the image builds). DevOps's `container.yml` `--build-arg` + drift-detection are their arms of t/3278.

Self-merging on green.

Commit: 7bbd538f