### PR TITLE
obs(server): expose BUILD_SHA at boot + /health (non-admin) for drift detection (t/3278 Arm-1)

### DIFF
--- a/taxonomy-editor/src/server/routes/meta.ts
+++ b/taxonomy-editor/src/server/routes/meta.ts
@@ -106,7 +106,11 @@ export function registerMetaRoutes(r: Router, ctx: ServerCtx): void {
     // AI key status is always included so deployment gates can verify readiness.
     const geminiReady = await hasApiKey('gemini');
     const freeKeyPoolSize = proxyTiers.parseFreeTierKeys(process.env.FREE_TIER_GEMINI_KEY).length;
-    if (!community.isAdmin()) { json(res, { status: 'ok', ai: { geminiKeyConfigured: geminiReady, freeTierKeyPoolSize: freeKeyPoolSize } }); return; }
+    // t/3278 Arm-1: buildSha in the UNAUTH branch — the drift checker (Arm-2) hits /health anonymously
+    // to compare the running image's SHA against origin/main HEAD. Public repo → the commit SHA is not
+    // secret. `?? null` so a build that didn't bake BUILD_SHA is a visible null (a vacuous compare the
+    // checker treats as sha-unavailable), never a crash.
+    if (!community.isAdmin()) { json(res, { status: 'ok', buildSha: process.env.BUILD_SHA ?? null, ai: { geminiKeyConfigured: geminiReady, freeTierKeyPoolSize: freeKeyPoolSize } }); return; }
     const base: Record<string, unknown> = {
       status: 'ok',
       version: ctx.serverVersion,

--- a/taxonomy-editor/src/server/server.ts
+++ b/taxonomy-editor/src/server/server.ts
@@ -1315,6 +1315,10 @@ server.listen(PORT, BIND_HOST, () => {
   // in ACA config but process.env evaluated false" regression (bicep value-form) is then visible
   // immediately, not inferred from a debate's compute path.
   log.server.info({ embeddingWorkerOffload: isEmbeddingWorkerOffloadEnabled() }, 'embedding offload flag at boot');
+  // t/3278 Arm-1: log the baked BUILD_SHA at boot so "what SHA is running?" is answerable from LA on
+  // every deploy (the durable primitive vs the incidental t/3211 marker). 'unknown' if the build didn't
+  // pass --build-arg BUILD_SHA → a visible gap, not a silent one (drift-check reads /health.buildSha).
+  log.server.info({ buildSha: process.env.BUILD_SHA ?? 'unknown' }, 'build sha at boot');
   // t/3211: log the live cgroup-effective core count at boot so the embedding-worker-pool SKU sizing
   // (K = min(EMBEDDING_WORKER_POOL_SIZE, availableParallelism()-1)) is confirmed EMPIRICALLY from LA on
   // the next deploy, not asserted blind from the ACA vCPU config (cgroup quota can differ). DevOps reads


### PR DESCRIPTION
## What
ServerAPI slice of the TL-GV'd deploy-drift prevention (t/3278#3/#4, DevOps p/526#80). Reads `process.env.BUILD_SHA` (baked by the Dockerfile ARG→ENV + container.yml `--build-arg`):
- **server.ts** boot log `'build sha at boot'` — makes "what SHA is running?" answerable from Log Analytics on every deploy (the durable primitive, vs the incidental t/3211 marker).
- **routes/meta.ts** `/health` — `buildSha` added to the **NON-ADMIN (unauth)** minimal response, because the Arm-2 drift checker hits `/health` **anonymously** to compare running SHA vs `origin/main` HEAD. Public repo → the commit SHA is not secret (DevOps + TL confirmed).

## Safety / edge
`?? null` (/health) / `?? 'unknown'` (boot) → a build that didn't bake `BUILD_SHA` is a **visible gap** the checker treats as sha-unavailable (not-drift, TL condition t/3278#4), never a crash or a vacuous non-null compare. Log/field-only, no behavior change.

## Verify
- eslint + tsc clean; no test asserts the exact non-admin /health shape (adding a field is safe)
- **Self-cert /trivial-change** (log-only, follows the existing boot-log + /health pattern)

**TL condition carried:** the build-arg→Dockerfile→/health chain must actually populate buildSha (null = vacuous compare, the t/3110 sink lesson) — my code reads the env; the **end-to-end non-null verification is on the deployed image** (DevOps's Arm-2 GV). Tracked t/3285; relates t/3278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)