### PR TITLE
infra(devops): deploy-drift gate — merged≠deployed detection (t/3278 Arm-2)

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -270,7 +270,13 @@ jobs:
           load: ${{ steps.push_mode.outputs.load }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: BUILD_SHA=${{ github.sha }}
+          # BUILD_SHA MUST match the checkout ref (inputs.sha || github.sha), NOT bare
+          # github.sha — on a workflow_dispatch build with an explicit `sha`, github.sha is
+          # the dispatch ref HEAD while the checkout builds inputs.sha. Baking the dispatch
+          # HEAD would make the image report a commit it does NOT contain, and the t/3278
+          # deploy-drift gate would then compare a WRONG running SHA vs main (t/3110 sink:
+          # a misleading marker is worse than none). Keep this expression identical to `ref:`.
+          build-args: BUILD_SHA=${{ inputs.sha || github.sha }}
           cache-from: type=gha,scope=shared-docker
           cache-to: type=gha,scope=shared-docker,mode=min
 

--- a/.github/workflows/deploy-drift-check.yml
+++ b/.github/workflows/deploy-drift-check.yml
@@ -1,0 +1,145 @@
+# Deploy-drift gate (t/3278) — detect "merged-to-main ≠ deployed-to-prod" silent drift.
+#
+# Root incident: container.yml builds :latest only on tag-push / manual dispatch (NOT
+# per-merge), so a full day of merges — including a prod-incident fix (#1872) and a
+# security fix (#1877) — sat un-deployed while main was green and tickets read Done.
+# "Merged + CI-green + Done" silently did NOT mean "live in prod".
+#
+# This gate makes that drift VISIBLE (it deliberately does NOT auto-deploy — a code-bearing
+# prod deploy stays owner-authorized; we kill the SILENCE, not the human gate). It reads the
+# running image's BUILD_SHA from prod /health (baked by container.yml --build-arg → Dockerfile
+# ARG/ENV → surfaced in the non-admin /health branch), measures how long shippable work has
+# sat un-deployed, and — past a TIME threshold — opens/updates a GitHub issue so a human is
+# notified (a red job in an unwatched run list is silent-by-another-name; TL GV cond. 3).
+#
+# Verdict logic is the pure predicate operations/devops/Get-DeployDriftVerdict.ps1, unit-proven
+# in tests/Get-DeployDriftVerdict.Tests.ps1 (both arms, 4 cases — Guard Testability t/2971).
+
+name: deploy-drift-check
+
+on:
+  schedule:
+    - cron: '17 */3 * * *'   # every 3h at :17 (offset off the hour to dodge cron congestion)
+  workflow_dispatch:
+    inputs:
+      prod_url:
+        description: 'Prod base URL to probe (default: canonical prod — see deployment-facts.md)'
+        required: false
+        type: string
+      threshold_hours:
+        description: 'N — fire only when un-deployed work is older than this many hours'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  # Canonical prod URL (public, non-secret) — see deploy/azure/runbooks/deployment-facts.md.
+  DEFAULT_PROD_URL: 'https://taxonomy-editor.yellowbush-aeda037d.eastus.azurecontainerapps.io'
+  DEFAULT_THRESHOLD_HOURS: '24'
+  DRIFT_LABEL: 'deploy-drift'
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
+        with:
+          fetch-depth: 0   # full history — rev-list <runningSha>..origin/main needs the range
+
+      - name: Compute drift inputs (running buildSha + un-deployed age)
+        id: inputs
+        env:
+          PROD_URL: ${{ github.event.inputs.prod_url || env.DEFAULT_PROD_URL }}
+        run: |
+          set -uo pipefail
+
+          # --- running build SHA from prod /health (non-admin branch exposes buildSha) ---
+          HEALTH_JSON=$(curl -fsS --max-time 30 "${PROD_URL}/health" 2>/dev/null || echo '')
+          if [ -z "$HEALTH_JSON" ]; then
+            echo "::warning::/health probe failed or timed out — treating as unreachable (NOT drift)."
+            RUNNING_SHA=''
+          else
+            RUNNING_SHA=$(echo "$HEALTH_JSON" | jq -r '.buildSha // empty' 2>/dev/null || echo '')
+          fi
+          echo "running_sha=${RUNNING_SHA}" >> "$GITHUB_OUTPUT"
+
+          git fetch origin main --quiet
+          MAIN_SHA=$(git rev-parse origin/main)
+          echo "main_sha=${MAIN_SHA}" >> "$GITHUB_OUTPUT"
+
+          # --- un-deployed age: hours since the OLDEST commit after RUNNING_SHA on main ---
+          AGE_HOURS='0'
+          if [ -n "$RUNNING_SHA" ] && [ "$RUNNING_SHA" != 'unknown' ]; then
+            if [ "$RUNNING_SHA" = "$MAIN_SHA" ]; then
+              AGE_HOURS='0'   # prod == main HEAD → nothing un-deployed
+            elif git merge-base --is-ancestor "$RUNNING_SHA" "$MAIN_SHA" 2>/dev/null; then
+              OLDEST=$(git rev-list --reverse "${RUNNING_SHA}..${MAIN_SHA}" | head -1)
+              if [ -n "$OLDEST" ]; then
+                CDATE=$(git show -s --format=%ct "$OLDEST")
+                NOW=$(date -u +%s)
+                AGE_HOURS=$(awk "BEGIN { printf \"%.2f\", ($NOW - $CDATE) / 3600 }")
+              fi
+            else
+              # RUNNING_SHA is not an ancestor of main (unknown/force-push/detached) — we
+              # cannot measure lag → treat as unreachable, never fire on ambiguity.
+              echo "::warning::running buildSha ${RUNNING_SHA} is not an ancestor of origin/main — treating as unreachable."
+              RUNNING_SHA=''
+              echo "running_sha=" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+          echo "age_hours=${AGE_HOURS}" >> "$GITHUB_OUTPUT"
+          echo "Running SHA=${RUNNING_SHA:-<unreachable>}  main=${MAIN_SHA}  undeployed-age-h=${AGE_HOURS}"
+
+      - name: Evaluate drift verdict (pure predicate)
+        id: verdict
+        shell: pwsh
+        env:
+          RUNNING_SHA: ${{ steps.inputs.outputs.running_sha }}
+          AGE_HOURS: ${{ steps.inputs.outputs.age_hours }}
+          THRESHOLD_HOURS: ${{ github.event.inputs.threshold_hours || env.DEFAULT_THRESHOLD_HOURS }}
+        run: |
+          . "$env:GITHUB_WORKSPACE/operations/devops/Get-DeployDriftVerdict.ps1"
+          $v = Get-DeployDriftVerdict `
+                 -RunningBuildSha $env:RUNNING_SHA `
+                 -UndeployedAgeHours ([double]$env:AGE_HOURS) `
+                 -ThresholdHours ([double]$env:THRESHOLD_HOURS)
+          "fire=$($v.Fire.ToString().ToLower())" >> $env:GITHUB_OUTPUT
+          "reason=$($v.Reason)"                  >> $env:GITHUB_OUTPUT
+          Write-Host "verdict: Fire=$($v.Fire) Reason=$($v.Reason)"
+
+      - name: Open / update / resolve drift issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FIRE: ${{ steps.verdict.outputs.fire }}
+          REASON: ${{ steps.verdict.outputs.reason }}
+          RUNNING_SHA: ${{ steps.inputs.outputs.running_sha }}
+          MAIN_SHA: ${{ steps.inputs.outputs.main_sha }}
+          AGE_HOURS: ${{ steps.inputs.outputs.age_hours }}
+        run: |
+          set -uo pipefail
+          TITLE='⚠️ Prod deploy drift: running image is behind main'
+          EXISTING=$(gh issue list --label "$DRIFT_LABEL" --state open --json number --jq '.[0].number // empty')
+
+          if [ "$FIRE" = 'true' ]; then
+            BODY=$(printf '**Prod is running a stale image (t/3278 deploy-drift gate).**\n\n- Running buildSha: `%s`\n- main HEAD: `%s`\n- Un-deployed age: **%s h** (reason: `%s`)\n\nShippable work — possibly including incident/security fixes — has sat un-deployed past the threshold. **Ship it:** owner-authorized `container.yml` build of HEAD + `deploy-azure.yml` (see production-release.md). This gate does not auto-deploy by design; it only makes the drift visible.\n\n_Auto-managed by deploy-drift-check.yml — auto-closes when prod catches up._' "${RUNNING_SHA:-<unreachable>}" "$MAIN_SHA" "$AGE_HOURS" "$REASON")
+            if [ -n "$EXISTING" ]; then
+              gh issue comment "$EXISTING" --body "$BODY"
+              echo "Updated existing drift issue #$EXISTING"
+            else
+              gh issue create --title "$TITLE" --label "$DRIFT_LABEL" --body "$BODY"
+              echo "Opened new drift issue"
+            fi
+            echo "::error::Deploy drift: prod behind main by ${AGE_HOURS}h (${REASON}). See the deploy-drift issue."
+            exit 1
+          else
+            # Not drift — auto-resolve any open drift issue so the signal is self-clearing.
+            if [ -n "$EXISTING" ]; then
+              gh issue comment "$EXISTING" --body "Resolved: prod caught up (verdict reason: \`$REASON\`, running \`${RUNNING_SHA:-<unreachable>}\`). Auto-closing."
+              gh issue close "$EXISTING"
+              echo "Closed drift issue #$EXISTING (no longer drifting)"
+            fi
+            echo "No drift (reason: ${REASON})."
+          fi

--- a/operations/devops/Get-DeployDriftVerdict.ps1
+++ b/operations/devops/Get-DeployDriftVerdict.ps1
@@ -1,0 +1,79 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    Pure predicate for the deploy-drift gate (t/3278): is prod running a stale image?
+
+.DESCRIPTION
+    Decides whether to FIRE a "prod is behind main" alert, given the running image's
+    build SHA reachability and how long shippable work has sat un-deployed. Kept as a
+    pure function — no I/O — so the same logic the deploy-drift workflow runs is proven
+    directly by Pester (Guard Testability, t/2971), the way Test-BootFlagEffective.ps1
+    (t/3247) is shared between deploy-azure.yml and its test.
+
+    Design constraints baked in per TL GV (t/3278#4):
+      1. TIME-based, not commits-behind — a bare commit count false-fires on every normal
+         deploy window. The trigger is: shippable work has sat un-deployed > N hours.
+      2. "buildSha unreachable" is NOT drift — a failed /health probe (or an image that
+         predates the BUILD_SHA marker) must never fire the stale-image alert; a broken
+         probe is a distinct condition from a stale image (avoids the t/3110 vacuous-gate
+         trap where the gate can't tell "healthy+current" from "can't tell").
+
+.PARAMETER RunningBuildSha
+    The build SHA the deployed image reports at /health (buildSha). Empty string, $null,
+    or the sentinel 'unknown' all mean UNREACHABLE / unpopulated → never drift.
+
+.PARAMETER UndeployedAgeHours
+    Hours since the OLDEST un-deployed commit landed on main (now - commitDate of the first
+    commit after RunningBuildSha on origin/main). <= 0 means prod == main HEAD (nothing
+    un-deployed). The caller (workflow) computes this from git; the predicate only applies
+    the threshold so both arms are unit-testable without a repo.
+
+.PARAMETER ThresholdHours
+    N — fire only when UndeployedAgeHours >= this. Default 24h. MUST exceed a normal
+    build+deploy turnaround with margin so routine windows stay silent.
+
+.OUTPUTS
+    [pscustomobject] @{ Fire = [bool]; Reason = [string] }
+      Fire=$true  reason 'stale:<age>h>=<N>h'
+      Fire=$false reason 'unreachable' | 'current' | 'within-threshold'
+#>
+function Get-DeployDriftVerdict {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [AllowNull()]
+        [string] $RunningBuildSha,
+
+        [Parameter(Mandatory)]
+        [double] $UndeployedAgeHours,
+
+        [double] $ThresholdHours = 24
+    )
+
+    # Arm 1 (TL cond. 2): unreachable / unpopulated buildSha is NOT drift. A failed probe
+    # or a pre-marker image can't testify to staleness — treat as "can't tell", never fire.
+    $sha = if ($null -eq $RunningBuildSha) { '' } else { $RunningBuildSha.Trim() }
+    if ($sha -eq '' -or $sha -eq 'unknown') {
+        return [pscustomobject]@{ Fire = $false; Reason = 'unreachable' }
+    }
+
+    # Prod is current — nothing has landed on main past the deployed commit.
+    if ($UndeployedAgeHours -le 0) {
+        return [pscustomobject]@{ Fire = $false; Reason = 'current' }
+    }
+
+    # Un-deployed work exists but is younger than the threshold — a normal deploy window,
+    # stay silent (TL cond. 1: time-based, don't false-fire on routine lag).
+    if ($UndeployedAgeHours -lt $ThresholdHours) {
+        return [pscustomobject]@{ Fire = $false; Reason = 'within-threshold' }
+    }
+
+    # Shippable work has sat un-deployed past the threshold → the silent-drift the gate exists
+    # to surface (the #1872/#1877 stranding). FIRE.
+    $age = [math]::Round($UndeployedAgeHours, 1)
+    return [pscustomobject]@{ Fire = $true; Reason = "stale:${age}h>=${ThresholdHours}h" }
+}

--- a/tests/Get-DeployDriftVerdict.Tests.ps1
+++ b/tests/Get-DeployDriftVerdict.Tests.ps1
@@ -1,0 +1,68 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+# Guard Testability (t/2971) for the deploy-drift gate (t/3278): both arms of the pure
+# predicate proven directly — the alert FIRES when prod is stale past the threshold and
+# stays SILENT for each not-drift condition — without needing a live stale deployment.
+# 4 cases per TL GV (t/3278#4): fire; current; within-threshold; unreachable.
+
+BeforeAll {
+    . "$PSScriptRoot/../operations/devops/Get-DeployDriftVerdict.ps1"
+}
+
+Describe 'Get-DeployDriftVerdict' {
+
+    Context 'FIRE arm — shippable work stranded past the threshold' {
+        It 'fires when un-deployed work is older than N hours' {
+            $v = Get-DeployDriftVerdict -RunningBuildSha 'abc123' -UndeployedAgeHours 30 -ThresholdHours 24
+            $v.Fire | Should -BeTrue
+            $v.Reason | Should -BeLike 'stale:*'
+        }
+
+        It 'fires exactly AT the threshold boundary (>= is inclusive)' {
+            $v = Get-DeployDriftVerdict -RunningBuildSha 'abc123' -UndeployedAgeHours 24 -ThresholdHours 24
+            $v.Fire | Should -BeTrue
+        }
+    }
+
+    Context 'SILENT arm — not drift' {
+        It 'is silent when prod == main HEAD (nothing un-deployed): reason current' {
+            $v = Get-DeployDriftVerdict -RunningBuildSha 'abc123' -UndeployedAgeHours 0 -ThresholdHours 24
+            $v.Fire | Should -BeFalse
+            $v.Reason | Should -Be 'current'
+        }
+
+        It 'is silent for a normal deploy window under the threshold: reason within-threshold' {
+            $v = Get-DeployDriftVerdict -RunningBuildSha 'abc123' -UndeployedAgeHours 5 -ThresholdHours 24
+            $v.Fire | Should -BeFalse
+            $v.Reason | Should -Be 'within-threshold'
+        }
+
+        It 'treats an unreachable/empty buildSha as NOT drift (TL cond. 2): reason unreachable' {
+            $v = Get-DeployDriftVerdict -RunningBuildSha '' -UndeployedAgeHours 999 -ThresholdHours 24
+            $v.Fire | Should -BeFalse
+            $v.Reason | Should -Be 'unreachable'
+        }
+
+        It "treats the 'unknown' BUILD_SHA sentinel as NOT drift even with huge age" {
+            $v = Get-DeployDriftVerdict -RunningBuildSha 'unknown' -UndeployedAgeHours 999 -ThresholdHours 24
+            $v.Fire | Should -BeFalse
+            $v.Reason | Should -Be 'unreachable'
+        }
+
+        It 'treats $null buildSha as NOT drift (probe returned no field)' {
+            $v = Get-DeployDriftVerdict -RunningBuildSha $null -UndeployedAgeHours 999 -ThresholdHours 24
+            $v.Fire | Should -BeFalse
+            $v.Reason | Should -Be 'unreachable'
+        }
+    }
+
+    Context 'Precedence — unreachable dominates staleness' {
+        It 'reports unreachable (not stale) when buildSha is empty AND age exceeds threshold' {
+            # A broken probe must never masquerade as a stale-image fire (t/3110 sink lesson).
+            $v = Get-DeployDriftVerdict -RunningBuildSha '   ' -UndeployedAgeHours 100 -ThresholdHours 24
+            $v.Fire | Should -BeFalse
+            $v.Reason | Should -Be 'unreachable'
+        }
+    }
+}


### PR DESCRIPTION
Closes the DevOps arm of **t/3278** (prevention for the merged-but-not-deployed strand that left #1872 write-hang + #1877 security fixes off-prod for a day). Design + TL GV approval: t/3278#1-#4.

## What
- **`operations/devops/Get-DeployDriftVerdict.ps1`** — pure predicate. TIME-based (not commits-behind); `buildSha` unreachable/`unknown`/null ⇒ NOT drift (never fire on a broken probe — t/3110 sink). Returns `{Fire, Reason}`.
- **`tests/Get-DeployDriftVerdict.Tests.ps1`** — 8 cases, both arms (fire; current; within-threshold; unreachable×3; boundary; precedence). Guard Testability (t/2971). Green locally.
- **`.github/workflows/deploy-drift-check.yml`** — scheduled every 3h + dispatch. Reads prod `/health.buildSha`, computes un-deployed age (`git rev-list <runningSha>..origin/main` oldest-commit date), calls the predicate, and **past threshold opens/updates a GitHub issue** so a human is notified (TL cond. 3 — not a silent red job). Self-closes the issue when prod catches up. Does **not** auto-deploy (owner-auth prod gate preserved; only the silence dies).
- **`.github/workflows/container.yml`** — fixes `build-args: BUILD_SHA` from bare `github.sha` (dispatch HEAD) to `inputs.sha || github.sha` (the built commit), matching the checkout `ref:`. Without this, a dispatch-with-sha build bakes a wrong SHA and the gate compares the wrong running commit.

## Chain coherence (GV item — real-env-first)
`buildSha` is non-null only once the full chain is in the deployed image: Rosetta's Dockerfile ARG/ENV (#1897) + ServerAPI's `/health` field (#1898) + this PR's `--build-arg`. Until then the gate correctly reports `unreachable` (no false fire). **Remaining GV step:** after the chain deploys, confirm `/health.buildSha != null` on real prod and validate a live drift verdict before trusting the gate.

## Not doing
Auto-deploy-on-merge (option 2) — rejected in design: it would remove the owner-authorized prod-deploy gate. Detectable drift preserves the human gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)