### PR TITLE
docs(ux): fix vocab spec index ticket ref (t/2895->t/3287)

### DIFF
--- a/docs/ux/README.md
+++ b/docs/ux/README.md
@@ -31,5 +31,5 @@ Active UX specs in `docs/ux/`. Design owns these; coding agents reference them d
 | `usage-hierarchy-navigation.md` | Presentation UX for the roll-up: breadcrumb drill-down + tree + user/session scope filtering across all tools (Taxonomy/Chat/Lineage/Situations); KIND registry, leaf cross-axis, endpoint additions. Builds on `usage-analytics-instrumentation.md`, supersedes `analytics-dashboard.md` §3 |
 | `oped-studio.md` | Op-Ed Studio — GUI for `New-OpEd`: My/Community library, multi-voice create (one topic → one op-ed per camp), tabbed multi-voice sets, clickable taxonomy grounding (t/2570) |
 | `debate-setup-details.md` | Debate Setup drill-in — modal surfacing full topic, source URL/document pointer, background, and setup config; retires the situations-only `Details`/`CrossCuttingDialog` (t/2731) |
-| `vocabulary-panel-readability.md` | Vocabulary panel (shared) readability fix — the panel ships with NO CSS (unstyled run-on rows); columns/spacing/tokens/a11y spec for Dictionary/Colloquial/Lint (t/2895) |
+| `vocabulary-panel-readability.md` | Vocabulary panel (shared) readability fix — the panel ships with NO CSS (unstyled run-on rows); columns/spacing/tokens/a11y spec for Dictionary/Colloquial/Lint (t/3287) |
 | `design-system.md` | Design system reference (living document) |


### PR DESCRIPTION
One-line README index fix: the vocabulary-panel spec row cited a guessed ticket number; real ticket is t/3287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)