### PR TITLE
obs(storage): loadDictionary WARN on missing/empty dict dir (t/3289)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/dictionaryWarn.test.ts
+++ b/taxonomy-editor/src/server/__tests__/dictionaryWarn.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment node
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3289 — loadDictionary() Fallback-Path Logging: WARN on missing/unreadable dict dir.
+// Verifies:
+//   (1) Missing standardized dir → WARN with cause='dir-missing'
+//   (2) Dir present but 0 .json files → WARN with cause='empty-listing'
+//   (3) Happy path → no WARN, returns terms
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ── Mocks (hoisted before imports) ──
+
+let recordedEvents: Array<{ level?: string; message?: string; data?: Record<string, unknown> }> = [];
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({
+  getGlobalRecorder: () => ({ record: (ev: unknown) => { recordedEvents.push(ev as never); } }),
+  redactRecord: (r: unknown) => r,
+}));
+
+import { loadDictionary, setBackend } from '../storage/fileIO.js';
+import type { StorageBackend } from '../storage/storageBackend.js';
+import { FilesystemBackend } from '../storage/filesystemBackend.js';
+
+// ── Helpers ──
+
+function makeBackend(
+  listFn: (dir: string) => Promise<string[]>,
+  readFn: (p: string) => Promise<string | null> = async () => null,
+): StorageBackend {
+  return {
+    listDirectory: listFn,
+    readFile: readFn,
+  } as unknown as StorageBackend;
+}
+
+// ── Tests ──
+
+describe('loadDictionary — Fallback-Path Logging (t/3289)', () => {
+  beforeEach(() => {
+    recordedEvents = [];
+  });
+
+  afterEach(() => {
+    setBackend(new FilesystemBackend());
+  });
+
+  it('emits WARN with cause=dir-missing when standardized dir listing throws ENOENT', async () => {
+    const enoent = Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' });
+    setBackend(makeBackend(async (dir) => {
+      if (dir.includes('standardized')) throw enoent;
+      return [];
+    }));
+
+    const result = await loadDictionary();
+
+    expect(result.standardized).toEqual([]);
+    const stdWarn = recordedEvents.find(e =>
+      e.message?.includes('standardized') && e.message?.includes('dir-missing'),
+    );
+    expect(stdWarn).toBeDefined();
+    expect(stdWarn?.level).toBe('warn');
+    expect(stdWarn?.data?.cause).toBe('dir-missing');
+  });
+
+  it('emits WARN with cause=empty-listing when standardized dir has zero .json files', async () => {
+    setBackend(makeBackend(async () => []));
+
+    const result = await loadDictionary();
+
+    expect(result.standardized).toEqual([]);
+    const stdWarn = recordedEvents.find(e =>
+      e.message?.includes('standardized') && e.message?.includes('empty-listing'),
+    );
+    expect(stdWarn).toBeDefined();
+    expect(stdWarn?.level).toBe('warn');
+    expect(stdWarn?.data?.cause).toBe('empty-listing');
+  });
+
+  it('does not emit WARN when terms load successfully', async () => {
+    setBackend(makeBackend(
+      async () => ['term1.json'],
+      async () => JSON.stringify({ id: 'term1', label: 'Test' }),
+    ));
+
+    const result = await loadDictionary();
+
+    expect(result.standardized).toHaveLength(1);
+    expect(recordedEvents.filter(e => e.level === 'warn')).toHaveLength(0);
+  });
+});

--- a/taxonomy-editor/src/server/__tests__/dictionaryWarn.test.ts
+++ b/taxonomy-editor/src/server/__tests__/dictionaryWarn.test.ts
@@ -28,10 +28,7 @@ function makeBackend(
   listFn: (dir: string) => Promise<string[]>,
   readFn: (p: string) => Promise<string | null> = async () => null,
 ): StorageBackend {
-  return {
-    listDirectory: listFn,
-    readFile: readFn,
-  } as unknown as StorageBackend;
+  return { listDirectory: listFn, readFile: readFn } as unknown as StorageBackend;
 }
 
 // ── Tests ──

--- a/taxonomy-editor/src/server/storage/fileIO.ts
+++ b/taxonomy-editor/src/server/storage/fileIO.ts
@@ -1371,24 +1371,54 @@ export async function loadDictionary(): Promise<{ standardized: unknown[]; collo
   const standardized: unknown[] = [];
   try {
     const stdFiles = await backend.listDirectory(stdDir);
-    for (const f of stdFiles.filter(f => f.endsWith('.json'))) {
+    const stdJson = stdFiles.filter(f => f.endsWith('.json'));
+    if (stdJson.length === 0) {
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'file-io', level: 'warn',
+        message: 'loadDictionary: standardized dir present but zero .json files — returning empty (t/3289)',
+        data: { dir: stdDir, cause: 'empty-listing', fileCount: stdFiles.length },
+      });
+    }
+    for (const f of stdJson) {
       try {
         const raw = await backend.readFile(path.join(stdDir, f));
         if (raw) standardized.push(JSON.parse(raw));
-      } catch { /* telemetry — silent by design;  skip malformed */ }
+      } catch { /* telemetry — silent by design; skip malformed */ }
     }
-  } catch { /* telemetry — silent by design;  directory may not exist */ }
+  } catch (err: unknown) {
+    const cause = (err as NodeJS.ErrnoException).code === 'ENOENT' ? 'dir-missing' : 'read-error';
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'file-io', level: 'warn',
+      message: `loadDictionary: standardized dir unreadable — returning empty (${cause}) (t/3289)`,
+      data: { dir: stdDir, cause, error: String(err) },
+    });
+  }
 
   const colloquial: unknown[] = [];
   try {
     const colFiles = await backend.listDirectory(colDir);
-    for (const f of colFiles.filter(f => f.endsWith('.json'))) {
+    const colJson = colFiles.filter(f => f.endsWith('.json'));
+    if (colJson.length === 0) {
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'file-io', level: 'warn',
+        message: 'loadDictionary: colloquial dir present but zero .json files — returning empty (t/3289)',
+        data: { dir: colDir, cause: 'empty-listing', fileCount: colFiles.length },
+      });
+    }
+    for (const f of colJson) {
       try {
         const raw = await backend.readFile(path.join(colDir, f));
         if (raw) colloquial.push(JSON.parse(raw));
-      } catch { /* telemetry — silent by design;  skip malformed */ }
+      } catch { /* telemetry — silent by design; skip malformed */ }
     }
-  } catch { /* telemetry — silent by design;  directory may not exist */ }
+  } catch (err: unknown) {
+    const cause = (err as NodeJS.ErrnoException).code === 'ENOENT' ? 'dir-missing' : 'read-error';
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'file-io', level: 'warn',
+      message: `loadDictionary: colloquial dir unreadable — returning empty (${cause}) (t/3289)`,
+      data: { dir: colDir, cause, error: String(err) },
+    });
+  }
 
   return { standardized, colloquial, lintViolations: [] };
 }

--- a/taxonomy-editor/src/server/storage/fileIO.ts
+++ b/taxonomy-editor/src/server/storage/fileIO.ts
@@ -1375,7 +1375,7 @@ export async function loadDictionary(): Promise<{ standardized: unknown[]; collo
     if (stdJson.length === 0) {
       getGlobalRecorder()?.record({
         type: 'system.error', component: 'file-io', level: 'warn',
-        message: 'loadDictionary: standardized dir present but zero .json files — returning empty (t/3289)',
+        message: 'loadDictionary: standardized dir present but zero .json files (empty-listing) — returning empty (t/3289)',
         data: { dir: stdDir, cause: 'empty-listing', fileCount: stdFiles.length },
       });
     }
@@ -1401,7 +1401,7 @@ export async function loadDictionary(): Promise<{ standardized: unknown[]; collo
     if (colJson.length === 0) {
       getGlobalRecorder()?.record({
         type: 'system.error', component: 'file-io', level: 'warn',
-        message: 'loadDictionary: colloquial dir present but zero .json files — returning empty (t/3289)',
+        message: 'loadDictionary: colloquial dir present but zero .json files (empty-listing) — returning empty (t/3289)',
         data: { dir: colDir, cause: 'empty-listing', fileCount: colFiles.length },
       });
     }


### PR DESCRIPTION
## Summary

- `loadDictionary()` in `fileIO.ts` had bare silent catches — dir-missing, empty-listing, and read-error all returned empty with no observable signal (Fallback-Path Logging violation)
- Now emits `getGlobalRecorder` WARN on each degraded return, with `cause` field distinguishing `dir-missing` / `read-error` / `empty-listing` and the resolved sub-path (`standardized` vs `colloquial`)
- Happy path unchanged (54 terms still load normally)
- Adds `dictionaryWarn.test.ts`: three arms — dir-missing WARN, empty-listing WARN, happy-path no-WARN — using `setBackend` injection

## Test plan

- [ ] CI green on `test-server-prod-config` and `test-electron (taxonomy-editor)`
- [ ] `dictionaryWarn.test.ts` all 3 tests pass
- [ ] Pre-self-merge verify: base=main, head OID, CI on exact OID

Fixes t/3289

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011CdXhhZoESGNgqfGxJNNPf