### PR TITLE
feat(cmdlet): Add Get-Concept — standardized dictionary reader + concept↔node map (t/3291)

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -18,6 +18,7 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | `Get-Tax` | Load full taxonomy (nodes, edges, metadata) |
 | `Get-GraphNode` | Look up a specific node by ID |
 | `Get-Edge` | Fetch edges (filter by source/target/type) |
+| `Get-Concept` | Read the standardized dictionary (concepts, `term:*`) as objects; filter by `-Slug`/`-Camp`/`-Status`, reverse concept↔node map via `-UsedByNode <id>`, `-IncludeColloquial` adds colloquial terms (t/3291) |
 | `Get-Situation` | List/filter situations (by id/label/text/linked-node/camp); reports per-POV supporting-evidence counts derived from `linked_nodes` |
 | `Get-Policy` | Look up policy actions from the registry |
 | `Get-TaxonomyHealth` | Check node/edge counts, orphans, structural issues |

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -53,6 +53,7 @@
         'Find-GraphPath'
         'Approve-Edge'
         'Approve-TaxonomyProposal'
+        'Get-Concept'   # t/3291 — standardized dictionary reader + concept<->node reverse map
         'Get-Edge'
         'Get-Situation'
         'Set-Edge'

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -815,6 +815,7 @@ Export-ModuleMember -Function @(
     'Find-GraphPath'
     'Approve-Edge'
     'Approve-TaxonomyProposal'
+    'Get-Concept'   # t/3291 — standardized dictionary reader + concept<->node reverse map
     'Get-Edge'
     'Get-Situation'
     'Set-Edge'

--- a/scripts/AITriad/Public/Get-Concept.ps1
+++ b/scripts/AITriad/Public/Get-Concept.ps1
@@ -1,0 +1,206 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Get-Concept {
+    <#
+    .SYNOPSIS
+        Read the standardized dictionary (concepts, `term:*`) and query the concept↔node grounding map.
+    .DESCRIPTION
+        The PowerShell reader for the standardized dictionary (t/3291). Concepts are TS-first
+        (`lib/dictionary/DictionaryLoader`); this cmdlet gives PS/CLI callers object access to the
+        same on-disk data under `<dataRoot>/dictionary/standardized/*.json` (and, with
+        -IncludeColloquial, `<dataRoot>/dictionary/colloquial/*.json`).
+
+        Emits one object per matching term (never text). Filters compose (AND): -Slug, -Camp,
+        -Status, -UsedByNode. -UsedByNode is the reverse concept↔BDI query — it returns the concepts
+        that ground a given node, read from each term's `used_by_nodes[]` (single-source; no taxonomy
+        load required).
+    .PARAMETER Slug
+        A concept canonical form — `"risk_existential"` or the prefixed `"term:risk_existential"`
+        (the `term:` prefix is stripped). Omit to return all concepts. Case-insensitive exact match.
+    .PARAMETER Camp
+        Filter by originating camp. Accepts the short codes `acc` / `saf` / `skp` (mapped to the
+        stored `primary_camp_origin` = accelerationist / safetyist / skeptic).
+    .PARAMETER Status
+        Filter by coinage status: accepted / provisional / contested / deprecated.
+    .PARAMETER UsedByNode
+        Return only concepts whose `used_by_nodes[]` contains this BDI node id (e.g. `skp-beliefs-001`).
+        The direct reverse concept↔node query.
+    .PARAMETER IncludeColloquial
+        Also emit the colloquial terms (`Kind = 'colloquial'`). Colloquial entries have a different
+        source schema — only the fields that map are populated (see .OUTPUTS); `ResolvesTo` carries
+        their standardized targets.
+    .PARAMETER DictionaryRoot
+        Override the dictionary directory (fixtures/tests). Default: `<dataRoot>/dictionary`, with
+        `<dataRoot>` resolved by the standard priority (env `AI_TRIAD_DATA_ROOT` > `.aitriad.json` >
+        monorepo fallback) via Get-DataRoot. Never hardcoded.
+    .OUTPUTS
+        [pscustomobject] per term: CanonicalForm, DisplayForm, Definition, Camp, Status,
+        UsedByNodes[], CharacteristicPhrases[], SeeAlso[], CoinedAt, CoinedBy, Kind
+        ('standardized' | 'colloquial'), ResolvesTo[] (colloquial only; else empty).
+    .EXAMPLE
+        Get-Concept
+        All 54 standardized concepts as objects.
+    .EXAMPLE
+        Get-Concept -Slug term:risk_existential
+        The single concept `risk_existential` (prefix tolerated).
+    .EXAMPLE
+        Get-Concept -UsedByNode skp-beliefs-001
+        The concepts that ground BDI node skp-beliefs-001 (reverse map).
+    .EXAMPLE
+        Get-Concept -Camp skp -Status accepted | Select-Object CanonicalForm, DisplayForm
+        Accepted skeptic-origin concepts, projected to two fields.
+    .LINK
+        Get-Entity
+    .LINK
+        Show-AITriadHelp
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Position = 0)]
+        [string]$Slug,
+
+        [Parameter()]
+        [ValidateSet('acc', 'saf', 'skp')]
+        [string]$Camp,
+
+        [Parameter()]
+        [ValidateSet('accepted', 'provisional', 'contested', 'deprecated')]
+        [string]$Status,
+
+        [Parameter()]
+        [string]$UsedByNode,
+
+        [Parameter()]
+        [switch]$IncludeColloquial,
+
+        [Parameter()]
+        [string]$DictionaryRoot
+    )
+
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = 'Stop'
+
+    $dictRoot = if ($DictionaryRoot) { $DictionaryRoot } else { Join-Path (Get-DataRoot) 'dictionary' }
+    $stdDir   = Join-Path $dictRoot 'standardized'
+
+    if (-not (Test-Path -LiteralPath $stdDir)) {
+        throw (New-ActionableError -PassThru `
+                -Goal 'Read the standardized dictionary (concepts)' `
+                -Problem "Standardized dictionary directory not found: $stdDir" `
+                -Location 'Get-Concept' `
+                -NextSteps @(
+                    "Confirm the data root is correct (env AI_TRIAD_DATA_ROOT / .aitriad.json) and that '$stdDir' exists",
+                    'Pass -DictionaryRoot to point at a dictionary directory explicitly (fixtures/tests)'
+                ))
+    }
+
+    # Normalize the -Slug filter once: tolerate a leading 'term:' and compare case-insensitively.
+    $slugFilter = ''
+    if ($PSBoundParameters.ContainsKey('Slug') -and $Slug) {
+        $slugFilter = ($Slug -replace '^term:', '').Trim().ToLowerInvariant()
+    }
+
+    # acc/saf/skp -> the full primary_camp_origin value stored on disk.
+    $campMap  = @{ acc = 'accelerationist'; saf = 'safetyist'; skp = 'skeptic' }
+    $campFull = if ($Camp) { $campMap[$Camp] } else { '' }
+
+    $prop = { param($o, $name, $default)
+        if ($o.PSObject.Properties[$name]) { $o.$name } else { $default }
+    }
+
+    $results = [System.Collections.Generic.List[object]]::new()
+
+    # ── Standardized terms ────────────────────────────────────────────────────────────────
+    # Loop bodies use a positive `$keep` guard and NEVER `continue`: a `continue` inside a function
+    # invoked from a Pester It can escape to Pester's own block loop (issue #2669) and silently abort
+    # the run. Loop-locals are named $termCamp/$termStatus (not $camp/$status) because PS variable
+    # names are case-insensitive — `$camp = 'accelerationist'` would re-validate the ValidateSet
+    # parameter $Camp against its set and throw.
+    $stdFiles = @(Get-ChildItem -LiteralPath $stdDir -Filter '*.json' -File | Sort-Object -Property Name)
+    foreach ($file in $stdFiles) {
+        $term = $null
+        try { $term = Get-Content -Raw -LiteralPath $file.FullName -Encoding utf8 | ConvertFrom-Json }
+        catch { Write-Warning "Get-Concept: skipping unparseable dictionary file '$($file.Name)' ($($_.Exception.Message))." }
+
+        if ($null -ne $term) {
+            $canonical  = [string](& $prop $term 'canonical_form' '')
+            $termCamp   = [string](& $prop $term 'primary_camp_origin' '')
+            $termStatus = [string](& $prop $term 'coinage_status' '')
+            $usedBy     = @(& $prop $term 'used_by_nodes' @())
+
+            $keep = $true
+            if ($slugFilter -and $canonical.ToLowerInvariant() -ne $slugFilter) { $keep = $false }
+            if ($campFull   -and $termCamp   -ne $campFull) { $keep = $false }
+            if ($Status     -and $termStatus -ne $Status)   { $keep = $false }
+            if ($PSBoundParameters.ContainsKey('UsedByNode') -and $UsedByNode -and ($usedBy -notcontains $UsedByNode)) { $keep = $false }
+
+            if ($keep) {
+                $results.Add([pscustomobject]@{
+                        CanonicalForm         = $canonical
+                        DisplayForm           = [string](& $prop $term 'display_form' '')
+                        Definition            = [string](& $prop $term 'definition' '')
+                        Camp                  = $termCamp
+                        Status                = $termStatus
+                        UsedByNodes           = $usedBy
+                        CharacteristicPhrases = @(& $prop $term 'characteristic_phrases' @())
+                        SeeAlso               = @(& $prop $term 'see_also' @())
+                        CoinedAt              = [string](& $prop $term 'coined_at' '')
+                        CoinedBy              = [string](& $prop $term 'coined_by' '')
+                        Kind                  = 'standardized'
+                        ResolvesTo            = @()
+                    })
+            }
+        }
+    }
+
+    # ── Colloquial terms (opt-in; different source schema) ─────────────────────────────────
+    if ($IncludeColloquial) {
+        $colDir = Join-Path $dictRoot 'colloquial'
+        if (Test-Path -LiteralPath $colDir) {
+            $colFiles = @(Get-ChildItem -LiteralPath $colDir -Filter '*.json' -File | Sort-Object -Property Name)
+            foreach ($file in $colFiles) {
+                $term = $null
+                try { $term = Get-Content -Raw -LiteralPath $file.FullName -Encoding utf8 | ConvertFrom-Json }
+                catch { Write-Warning "Get-Concept: skipping unparseable colloquial file '$($file.Name)' ($($_.Exception.Message))." }
+
+                if ($null -ne $term) {
+                    $canonical  = [string](& $prop $term 'colloquial_term' '')
+                    $termStatus = [string](& $prop $term 'status' '')
+                    $resolves   = @(& $prop $term 'resolves_to' @())
+
+                    # Colloquial terms carry no camp / used_by / characteristic-phrase data — a
+                    # -Camp or -UsedByNode filter can never match one, so exclude when either is set.
+                    $keep = $true
+                    if ($slugFilter -and $canonical.ToLowerInvariant() -ne $slugFilter) { $keep = $false }
+                    if ($campFull) { $keep = $false }
+                    if ($Status -and $termStatus -ne $Status) { $keep = $false }
+                    if ($PSBoundParameters.ContainsKey('UsedByNode') -and $UsedByNode) { $keep = $false }
+
+                    if ($keep) {
+                        $results.Add([pscustomobject]@{
+                                CanonicalForm         = $canonical
+                                DisplayForm           = $canonical
+                                Definition            = ''
+                                Camp                  = ''
+                                Status                = $termStatus
+                                UsedByNodes           = @()
+                                CharacteristicPhrases = @()
+                                SeeAlso               = $resolves
+                                CoinedAt              = [string](& $prop $term 'first_added' '')
+                                CoinedBy              = ''
+                                Kind                  = 'colloquial'
+                                ResolvesTo            = $resolves
+                            })
+                    }
+                }
+            }
+        }
+        else {
+            Write-Warning "Get-Concept: -IncludeColloquial set but no colloquial directory at '$colDir'."
+        }
+    }
+
+    return $results.ToArray()
+}

--- a/tests/Get-Concept.Tests.ps1
+++ b/tests/Get-Concept.Tests.ps1
@@ -1,0 +1,131 @@
+# Tag: unit (t/3291)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1') -Force -WarningAction SilentlyContinue
+
+    # Build a deterministic fixture dictionary in TestDrive so filter logic is testable without
+    # depending on the live data repo.
+    function New-ConceptFixture {
+        $root = Join-Path $TestDrive "dict-$([guid]::NewGuid())"
+        $std  = Join-Path $root 'standardized'
+        $col  = Join-Path $root 'colloquial'
+        New-Item -ItemType Directory -Path $std -Force | Out-Null
+        New-Item -ItemType Directory -Path $col -Force | Out-Null
+
+        $terms = @(
+            [ordered]@{ canonical_form = 'risk_existential'; display_form = 'risk (existential)'; definition = 'def-x';
+                primary_camp_origin = 'skeptic'; coinage_status = 'accepted'; characteristic_phrases = @('x-risk', 'extinction');
+                see_also = @('risk_systemic'); used_by_nodes = @('skp-beliefs-001', 'saf-beliefs-050'); coined_at = '2026-04-28'; coined_by = 'jpsnover' }
+            [ordered]@{ canonical_form = 'governance_adaptive'; display_form = 'governance (adaptive)'; definition = 'def-g';
+                primary_camp_origin = 'accelerationist'; coinage_status = 'provisional'; characteristic_phrases = @('adaptive rules');
+                see_also = @(); used_by_nodes = @('acc-beliefs-010'); coined_at = '2026-05-01'; coined_by = 'jpsnover' }
+            [ordered]@{ canonical_form = 'oversight_audit'; display_form = 'oversight (audit)'; definition = 'def-o';
+                primary_camp_origin = 'skeptic'; coinage_status = 'contested'; characteristic_phrases = @('audit');
+                see_also = @(); used_by_nodes = @('skp-beliefs-001'); coined_at = '2026-05-02'; coined_by = 'jpsnover' }
+        )
+        foreach ($t in $terms) { $t | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $std "$($t.canonical_form).json") -Encoding utf8 }
+
+        # One colloquial term (different schema).
+        [ordered]@{ colloquial_term = 'accountability'; status = 'accepted'; resolves_to = @('accountability_algorithmic'); first_added = '2026-03-01' } |
+            ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $col 'accountability.json') -Encoding utf8
+
+        return $root
+    }
+}
+
+Describe 'Get-Concept (t/3291)' -Tag 'unit' {
+
+    BeforeEach { $script:dict = New-ConceptFixture }
+
+    Context 'read + shape' {
+        It 'no-arg returns all standardized concepts as objects (not text)' {
+            $r = @(Get-Concept -DictionaryRoot $script:dict)
+            $r.Count | Should -Be 3
+            $r[0] | Should -BeOfType ([pscustomobject])
+        }
+        It 'maps every documented output field' {
+            $x = @(Get-Concept -DictionaryRoot $script:dict -Slug 'risk_existential')[0]
+            $x.CanonicalForm        | Should -Be 'risk_existential'
+            $x.DisplayForm          | Should -Be 'risk (existential)'
+            $x.Definition           | Should -Be 'def-x'
+            $x.Camp                 | Should -Be 'skeptic'
+            $x.Status               | Should -Be 'accepted'
+            $x.CoinedAt             | Should -Be '2026-04-28'
+            $x.CoinedBy             | Should -Be 'jpsnover'
+            $x.Kind                 | Should -Be 'standardized'
+            @($x.UsedByNodes).Count           | Should -Be 2
+            @($x.CharacteristicPhrases).Count | Should -Be 2
+            @($x.SeeAlso).Count               | Should -Be 1
+        }
+        It 'emits concepts sorted deterministically (by file name)' {
+            $names = @(Get-Concept -DictionaryRoot $script:dict | Select-Object -ExpandProperty CanonicalForm)
+            $names | Should -Be @('governance_adaptive', 'oversight_audit', 'risk_existential')
+        }
+    }
+
+    Context 'filters' {
+        It 'filters by -Slug and tolerates a term: prefix' {
+            @(Get-Concept -DictionaryRoot $script:dict -Slug 'risk_existential').Count | Should -Be 1
+            @(Get-Concept -DictionaryRoot $script:dict -Slug 'term:risk_existential').Count | Should -Be 1
+            (Get-Concept -DictionaryRoot $script:dict -Slug 'term:risk_existential')[0].CanonicalForm | Should -Be 'risk_existential'
+        }
+        It 'filters by -Camp (short code -> primary_camp_origin)' {
+            $r = @(Get-Concept -DictionaryRoot $script:dict -Camp skp)
+            $r.Count | Should -Be 2
+            ($r.CanonicalForm | Sort-Object) | Should -Be @('oversight_audit', 'risk_existential')
+        }
+        It 'filters by -Status' {
+            $r = @(Get-Concept -DictionaryRoot $script:dict -Status provisional)
+            $r.Count | Should -Be 1
+            $r[0].CanonicalForm | Should -Be 'governance_adaptive'
+        }
+        It 'combines filters with AND' {
+            @(Get-Concept -DictionaryRoot $script:dict -Camp skp -Status accepted).Count | Should -Be 1
+        }
+    }
+
+    Context 'reverse concept-to-node map (-UsedByNode)' {
+        It 'returns the concepts grounding a given node' {
+            $r = @(Get-Concept -DictionaryRoot $script:dict -UsedByNode 'skp-beliefs-001')
+            ($r.CanonicalForm | Sort-Object) | Should -Be @('oversight_audit', 'risk_existential')
+        }
+        It 'returns empty for a node no concept grounds' {
+            @(Get-Concept -DictionaryRoot $script:dict -UsedByNode 'zzz-none-999').Count | Should -Be 0
+        }
+    }
+
+    Context '-IncludeColloquial' {
+        It 'adds colloquial terms with Kind=colloquial and ResolvesTo populated' {
+            $all = @(Get-Concept -DictionaryRoot $script:dict -IncludeColloquial)
+            $all.Count | Should -Be 4
+            $col = @($all | Where-Object Kind -eq 'colloquial')
+            $col.Count | Should -Be 1
+            $col[0].CanonicalForm | Should -Be 'accountability'
+            @($col[0].ResolvesTo)  | Should -Be @('accountability_algorithmic')
+        }
+        It 'excludes colloquial by default' {
+            @(Get-Concept -DictionaryRoot $script:dict | Where-Object Kind -eq 'colloquial').Count | Should -Be 0
+        }
+    }
+
+    Context 'errors' {
+        It 'raises an ActionableError when the standardized dir is missing' {
+            $missing = Join-Path $TestDrive 'no-such-dict'
+            { Get-Concept -DictionaryRoot $missing } | Should -Throw -ExpectedMessage '*not found*'
+        }
+    }
+
+    Context 'manifest export' {
+        It 'exports Get-Concept' {
+            Get-Command Get-Concept -Module AITriad | Should -Not -BeNullOrEmpty
+        }
+        It 'FunctionsToExport includes Get-Concept' {
+            $manifestPath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psd1'
+            (Test-ModuleManifest -Path $manifestPath).ExportedFunctions.Keys | Should -Contain 'Get-Concept'
+        }
+    }
+}


### PR DESCRIPTION
New public reader cmdlet giving PS/CLI callers object access to the standardized dictionary (concepts, `term:*`) — previously TS-first (`lib/dictionary/DictionaryLoader`) with no PS reader. Follows `/add-ps-cmdlet` (CL-created ticket t/3291).

## Contract
```
Get-Concept [[-Slug] <string>] [-Camp acc|saf|skp]
            [-Status accepted|provisional|contested|deprecated]
            [-UsedByNode <nodeId>] [-IncludeColloquial] [-DictionaryRoot <path>]
```
- **Source:** `<dataRoot>/dictionary/standardized/*.json` (+ `colloquial/*.json` with `-IncludeColloquial`); `<dataRoot>` via `Get-DataRoot` (env `AI_TRIAD_DATA_ROOT` > `.aitriad.json` > fallback) — **not hardcoded** (AC #3).
- **Objects, never text:** CanonicalForm, DisplayForm, Definition, Camp, Status, UsedByNodes[], CharacteristicPhrases[], SeeAlso[], CoinedAt, CoinedBy, Kind (`standardized`|`colloquial`), ResolvesTo[].
- Filters compose (AND). `-Slug` tolerates a `term:` prefix. `-Camp` maps the short code → stored `primary_camp_origin`. **`-UsedByNode`** is the reverse concept↔BDI query, read from each term's `used_by_nodes[]` (single-source; no taxonomy load).
- Missing standardized dir → `New-ActionableError` (AC #4); unparseable term file → warn + skip (non-fatal).

## Tests — `tests/Get-Concept.Tests.ps1` (14)
Shape/field mapping, deterministic order, all filters, reverse `-UsedByNode` (hit + miss), `-IncludeColloquial`, missing-dir ActionableError, manifest export. **14/14 green; `Test-ModuleManifest` passes; `/review-ps` clean.** Validated against **live** data: no-arg = **54** concepts, +colloquial = **87**, `-Slug term:` resolves, reverse map returns real nodes.

## Two PS gotchas caught by the tests + fixed (not shipped)
1. Loop-locals `$camp`/`$status` case-insensitively collide with the ValidateSet params `$Camp`/`$Status` → assigning an out-of-set term value re-validated the parameter and threw. Renamed `$termCamp`/`$termStatus`.
2. `continue` inside a function called from a Pester `It` can escape to Pester's block loop (issue #2669) and abort the run. Restructured to a positive `$keep` guard — continue-free.

## Design gate
`/add-ps-cmdlet` self-cert (new public reader in `Public/`, `Get-DataRoot` resolution, standard conventions, no schema/data-model/cross-module change). **Deviations from the spec's listed output** (additive, non-breaking): added `Kind` (standardized|colloquial discriminator) and `ResolvesTo` (colloquial targets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)