### PR TITLE
feat(analysis): BdiGroundingPanel — surface concept_refs + entity_refs on selected BDI node (t/3292)

### DIFF
--- a/taxonomy-editor/src/renderer/components/analysis/BdiGroundingPanel.css
+++ b/taxonomy-editor/src/renderer/components/analysis/BdiGroundingPanel.css
@@ -1,0 +1,177 @@
+/* Copyright (c) 2026 Jeffrey Snover. All rights reserved. */
+/* Licensed under the MIT License. See LICENSE file in the project root. */
+
+/* Co-located styles for BdiGroundingPanel (t/3292) */
+
+.bdi-gr-root {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 8px 0;
+  overflow-y: auto;
+}
+
+.bdi-gr-empty {
+  color: var(--text-secondary);
+  padding: 16px;
+  font-size: var(--text-sm);
+}
+
+/* ─── Section ─────────────────────────────────────────── */
+
+.bdi-gr-section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.bdi-gr-section-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 2px 4px;
+  border-bottom: 1px solid var(--border-subtle);
+  margin-bottom: 2px;
+}
+
+.bdi-gr-section-title {
+  font-weight: 700;
+  font-size: var(--text-xs);
+  color: var(--text-primary);
+  letter-spacing: 0.03em;
+}
+
+.bdi-gr-section-count {
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
+}
+
+.bdi-gr-section-empty {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  padding: 6px 2px;
+  margin: 0;
+  font-style: italic;
+}
+
+/* ─── DOLCE type badge ────────────────────────────────── */
+
+.bdi-gr-dolce {
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  padding: 1px 5px;
+  border-radius: var(--radius-sm);
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+.bdi-gr-dolce--kind {
+  background: rgba(139, 92, 246, 0.12);
+  color: #8b5cf6;
+  border: 1px solid rgba(139, 92, 246, 0.25);
+}
+
+.bdi-gr-dolce--particular {
+  background: rgba(6, 182, 212, 0.1);
+  color: #0891b2;
+  border: 1px solid rgba(6, 182, 212, 0.25);
+}
+
+/* ─── Row ─────────────────────────────────────────────── */
+
+.bdi-gr-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 5px 6px;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  cursor: pointer;
+  text-align: left;
+  color: var(--text-primary);
+  transition: background 0.1s;
+  font-size: var(--text-xs);
+}
+
+.bdi-gr-row:hover {
+  background: rgba(59, 130, 246, 0.07);
+  border-color: var(--focus-ring);
+}
+
+.bdi-gr-row--proposed {
+  opacity: 0.7;
+  border-style: dashed;
+}
+
+.bdi-gr-row--proposed .bdi-gr-surface {
+  color: var(--text-secondary);
+}
+
+.bdi-gr-surface {
+  font-weight: 500;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bdi-gr-ref {
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.bdi-gr-conf {
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+/* ─── Method badge ────────────────────────────────────── */
+
+.bdi-gr-method {
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  padding: 1px 4px;
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
+}
+
+.bdi-gr-method--surface,
+.bdi-gr-method--exact,
+.bdi-gr-method--alias {
+  background: rgba(34, 197, 94, 0.12);
+  color: #16a34a;
+}
+
+.bdi-gr-method--embedding {
+  background: rgba(249, 115, 22, 0.1);
+  color: #ea580c;
+}
+
+/* ─── Status badge ────────────────────────────────────── */
+
+.bdi-gr-status {
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  padding: 1px 4px;
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
+}
+
+.bdi-gr-status--linked {
+  background: rgba(34, 197, 94, 0.12);
+  color: #16a34a;
+}
+
+.bdi-gr-status--proposed {
+  background: rgba(234, 179, 8, 0.12);
+  color: #ca8a04;
+}

--- a/taxonomy-editor/src/renderer/components/analysis/BdiGroundingPanel.test.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/BdiGroundingPanel.test.tsx
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { ConceptLinkRef, EntityLinkRef } from '@lib/entities/types';
+
+vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => null }));
+
+const setToolbarPanel = vi.fn();
+
+function makeStore(overrides: Record<string, unknown> = {}) {
+  return {
+    selectedNodeId: null,
+    accelerationist: null,
+    safetyist: null,
+    skeptic: null,
+    setToolbarPanel,
+    ...overrides,
+  };
+}
+
+vi.mock('../../hooks/useTaxonomyStore', () => ({
+  useTaxonomyStore: vi.fn(),
+}));
+
+import { useTaxonomyStore } from '../../hooks/useTaxonomyStore';
+const mockStore = useTaxonomyStore as unknown as ReturnType<typeof vi.fn>;
+
+const { BdiGroundingPanel } = await import('./BdiGroundingPanel');
+
+const CONCEPT_LINKED: ConceptLinkRef = {
+  ref: 'term:alignment',
+  surface: 'alignment',
+  method: 'surface',
+  link_confidence: 1.0,
+  status: 'linked',
+};
+
+const CONCEPT_PROPOSED: ConceptLinkRef = {
+  ref: 'term:autonomy_human',
+  surface: 'autonomy',
+  method: 'embedding',
+  link_confidence: 0.59,
+  status: 'proposed',
+};
+
+const ENTITY_LINKED: EntityLinkRef = {
+  ref: 'ent-001',
+  surface: 'Anthropic',
+  method: 'alias',
+  link_confidence: 1.0,
+  match_level: 'exact',
+  status: 'linked',
+};
+
+function makeNode(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'acc-beliefs-001',
+    label: 'Test Node',
+    ...overrides,
+  };
+}
+
+describe('BdiGroundingPanel (t/3292)', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('shows the no-node-selected empty state when selectedNodeId is null', () => {
+    mockStore.mockReturnValue(makeStore());
+    render(<BdiGroundingPanel />);
+    expect(screen.getByText(/Select a BDI node/)).toBeInTheDocument();
+  });
+
+  it('shows the no-node-selected empty state when the node is not found in any POV file', () => {
+    mockStore.mockReturnValue(makeStore({
+      selectedNodeId: 'acc-beliefs-999',
+      accelerationist: { nodes: [] },
+    }));
+    render(<BdiGroundingPanel />);
+    expect(screen.getByText(/Select a BDI node/)).toBeInTheDocument();
+  });
+
+  it('renders Concepts and Entities section headers for a node with no refs', () => {
+    mockStore.mockReturnValue(makeStore({
+      selectedNodeId: 'acc-beliefs-001',
+      accelerationist: { nodes: [makeNode()] },
+    }));
+    render(<BdiGroundingPanel />);
+    expect(screen.getByText('Concepts')).toBeInTheDocument();
+    expect(screen.getByText('Entities')).toBeInTheDocument();
+  });
+
+  it('renders DOLCE badges: "universal · kind" for concepts, "particular" for entities', () => {
+    mockStore.mockReturnValue(makeStore({
+      selectedNodeId: 'acc-beliefs-001',
+      accelerationist: { nodes: [makeNode()] },
+    }));
+    render(<BdiGroundingPanel />);
+    expect(screen.getByText('universal · kind')).toBeInTheDocument();
+    expect(screen.getByText('particular')).toBeInTheDocument();
+  });
+
+  it('renders concept rows with surface, method, status, and confidence', () => {
+    mockStore.mockReturnValue(makeStore({
+      selectedNodeId: 'acc-beliefs-001',
+      accelerationist: { nodes: [makeNode({ concept_refs: [CONCEPT_LINKED] })] },
+    }));
+    render(<BdiGroundingPanel />);
+    expect(screen.getByText('alignment')).toBeInTheDocument();
+    expect(screen.getByText('surface')).toBeInTheDocument();
+    expect(screen.getByText('linked')).toBeInTheDocument();
+    expect(screen.getByText('100%')).toBeInTheDocument();
+  });
+
+  it('applies --proposed class to proposed concept rows', () => {
+    mockStore.mockReturnValue(makeStore({
+      selectedNodeId: 'acc-beliefs-001',
+      accelerationist: { nodes: [makeNode({ concept_refs: [CONCEPT_PROPOSED] })] },
+    }));
+    render(<BdiGroundingPanel />);
+    const row = screen.getByRole('button', { name: /autonomy/ });
+    expect(row.className).toContain('bdi-gr-row--proposed');
+    expect(screen.getByText('proposed')).toBeInTheDocument();
+    expect(screen.getByText('59%')).toBeInTheDocument();
+  });
+
+  it('renders entity rows with surface, ref id, method, status, and confidence', () => {
+    mockStore.mockReturnValue(makeStore({
+      selectedNodeId: 'acc-beliefs-001',
+      accelerationist: { nodes: [makeNode({ entity_refs: [ENTITY_LINKED] })] },
+    }));
+    render(<BdiGroundingPanel />);
+    expect(screen.getByText('Anthropic')).toBeInTheDocument();
+    expect(screen.getByText('ent-001')).toBeInTheDocument();
+    expect(screen.getByText('alias')).toBeInTheDocument();
+  });
+
+  it('shows the normal "No entity links" empty state when entity_refs is absent', () => {
+    mockStore.mockReturnValue(makeStore({
+      selectedNodeId: 'acc-beliefs-001',
+      accelerationist: { nodes: [makeNode({ concept_refs: [CONCEPT_LINKED] })] },
+    }));
+    render(<BdiGroundingPanel />);
+    expect(screen.getByText(/No entity links/)).toBeInTheDocument();
+  });
+
+  it('shows "No concept links" when concept_refs is absent', () => {
+    mockStore.mockReturnValue(makeStore({
+      selectedNodeId: 'acc-beliefs-001',
+      accelerationist: { nodes: [makeNode()] },
+    }));
+    render(<BdiGroundingPanel />);
+    expect(screen.getByText(/No concept links/)).toBeInTheDocument();
+  });
+
+  it('calls setToolbarPanel("vocabulary") when a concept row is clicked', () => {
+    mockStore.mockReturnValue(makeStore({
+      selectedNodeId: 'acc-beliefs-001',
+      accelerationist: { nodes: [makeNode({ concept_refs: [CONCEPT_LINKED] })] },
+    }));
+    render(<BdiGroundingPanel />);
+    fireEvent.click(screen.getByRole('button', { name: /alignment/ }));
+    expect(setToolbarPanel).toHaveBeenCalledWith('vocabulary');
+  });
+
+  it('calls setToolbarPanel("entities") when an entity row is clicked', () => {
+    mockStore.mockReturnValue(makeStore({
+      selectedNodeId: 'acc-beliefs-001',
+      accelerationist: { nodes: [makeNode({ entity_refs: [ENTITY_LINKED] })] },
+    }));
+    render(<BdiGroundingPanel />);
+    fireEvent.click(screen.getByRole('button', { name: /Anthropic/ }));
+    expect(setToolbarPanel).toHaveBeenCalledWith('entities');
+  });
+
+  it('searches safetyist and skeptic files when node is not in accelerationist', () => {
+    mockStore.mockReturnValue(makeStore({
+      selectedNodeId: 'saf-beliefs-001',
+      accelerationist: { nodes: [] },
+      safetyist: { nodes: [{ id: 'saf-beliefs-001', label: 'Safety node', concept_refs: [CONCEPT_LINKED] }] },
+    }));
+    render(<BdiGroundingPanel />);
+    expect(screen.getByText('alignment')).toBeInTheDocument();
+  });
+});

--- a/taxonomy-editor/src/renderer/components/analysis/BdiGroundingPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/BdiGroundingPanel.tsx
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { useMemo } from 'react';
+import { useTaxonomyStore } from '../../hooks/useTaxonomyStore';
+import type { PovNode } from '../../types/taxonomy';
+import type { ConceptLinkRef, EntityLinkRef } from '@lib/entities/types';
+import { getGlobalRecorder } from '@lib/flight-recorder/index';
+import './BdiGroundingPanel.css';
+
+function findNodeInFiles(
+  id: string,
+  files: (({ nodes: PovNode[] } | null) | undefined)[],
+): PovNode | null {
+  for (const file of files) {
+    if (!file) continue;
+    const node = file.nodes.find(n => n.id === id);
+    if (node) return node;
+  }
+  return null;
+}
+
+function confidencePct(v: number): string {
+  return v >= 1 ? '100%' : `${Math.round(v * 100)}%`;
+}
+
+interface ConceptRowProps {
+  linkRef: ConceptLinkRef;
+  onClick: () => void;
+}
+
+function ConceptRow({ linkRef, onClick }: ConceptRowProps) {
+  const isProposed = linkRef.status === 'proposed';
+  return (
+    <button
+      className={`bdi-gr-row${isProposed ? ' bdi-gr-row--proposed' : ''}`}
+      onClick={onClick}
+      title={`${linkRef.ref} — open Vocabulary panel`}
+    >
+      <span className="bdi-gr-surface">{linkRef.surface}</span>
+      <span className={`bdi-gr-method bdi-gr-method--${linkRef.method}`}>{linkRef.method}</span>
+      <span className={`bdi-gr-status bdi-gr-status--${linkRef.status}`}>{linkRef.status}</span>
+      <span className="bdi-gr-conf">{confidencePct(linkRef.link_confidence)}</span>
+    </button>
+  );
+}
+
+interface EntityRowProps {
+  linkRef: EntityLinkRef;
+  onClick: () => void;
+}
+
+function EntityRow({ linkRef, onClick }: EntityRowProps) {
+  const isProposed = linkRef.status === 'proposed';
+  return (
+    <button
+      className={`bdi-gr-row${isProposed ? ' bdi-gr-row--proposed' : ''}`}
+      onClick={onClick}
+      title={`${linkRef.ref} — open entity record`}
+    >
+      <span className="bdi-gr-surface">{linkRef.surface}</span>
+      <span className="bdi-gr-ref">{linkRef.ref}</span>
+      <span className={`bdi-gr-method bdi-gr-method--${linkRef.method}`}>{linkRef.method}</span>
+      <span className={`bdi-gr-status bdi-gr-status--${linkRef.status}`}>{linkRef.status}</span>
+      <span className="bdi-gr-conf">{confidencePct(linkRef.link_confidence)}</span>
+    </button>
+  );
+}
+
+export function BdiGroundingPanel() {
+  const { selectedNodeId, accelerationist, safetyist, skeptic, setToolbarPanel } = useTaxonomyStore();
+
+  const node = useMemo(() => {
+    if (!selectedNodeId) return null;
+    const found = findNodeInFiles(selectedNodeId, [accelerationist, safetyist, skeptic]);
+    if (!found && selectedNodeId) {
+      getGlobalRecorder()?.record({
+        type: 'system.error',
+        component: 'BdiGroundingPanel',
+        level: 'warn',
+        message: `Selected node not found in any POV file: ${selectedNodeId}`,
+        error: { name: 'NotFound', message: `Node ${selectedNodeId} not in acc/saf/skp`, stack: '' },
+      });
+    }
+    return found;
+  }, [selectedNodeId, accelerationist, safetyist, skeptic]);
+
+  if (!selectedNodeId || !node) {
+    return <div className="bdi-gr-empty">Select a BDI node to view its concept and entity links.</div>;
+  }
+
+  const conceptRefs = node.concept_refs ?? [];
+  const entityRefs = node.entity_refs ?? [];
+
+  return (
+    <div className="bdi-gr-root">
+      <section className="bdi-gr-section">
+        <div className="bdi-gr-section-header">
+          <span className="bdi-gr-section-title">Concepts</span>
+          <span className="bdi-gr-dolce bdi-gr-dolce--kind" title="DOLCE: universal · kind">universal · kind</span>
+          <span className="bdi-gr-section-count">{conceptRefs.length}</span>
+        </div>
+        {conceptRefs.length === 0
+          ? <p className="bdi-gr-section-empty">No concept links on this node.</p>
+          : conceptRefs.map(r => (
+            <ConceptRow key={r.ref} linkRef={r} onClick={() => setToolbarPanel('vocabulary')} />
+          ))}
+      </section>
+
+      <section className="bdi-gr-section">
+        <div className="bdi-gr-section-header">
+          <span className="bdi-gr-section-title">Entities</span>
+          <span className="bdi-gr-dolce bdi-gr-dolce--particular" title="DOLCE: particular">particular</span>
+          <span className="bdi-gr-section-count">{entityRefs.length}</span>
+        </div>
+        {entityRefs.length === 0
+          ? <p className="bdi-gr-section-empty">No entity links — this is normal for most nodes.</p>
+          : entityRefs.map(r => (
+            <EntityRow key={r.ref} linkRef={r} onClick={() => setToolbarPanel('entities')} />
+          ))}
+      </section>
+    </div>
+  );
+}

--- a/taxonomy-editor/src/renderer/components/analysis/index.ts
+++ b/taxonomy-editor/src/renderer/components/analysis/index.ts
@@ -11,6 +11,7 @@ export * from './CalibrationReviewViewer';
 export * from './ConvergenceSignalsPanel';
 export * from './ExtractionTimelinePanel';
 export * from './FactsPanel';
+export * from './BdiGroundingPanel';
 export * from './FallacyPanel';
 export * from './GroundingPanel';
 export * from './LineagePanel';


### PR DESCRIPTION
## Summary

- New `BdiGroundingPanel` component in `components/analysis/` that surfaces `concept_refs[]` and `entity_refs[]` on the currently selected BDI node from the taxonomy store
- Two typed sections: **Concepts** (universal·kind DOLCE badge) and **Entities** (particular DOLCE badge), each row showing surface text, method, status, and confidence
- `status: proposed` (dashed border, muted text, yellow status badge) visually distinct from `status: linked` (solid, green) — embedding guesses are not presented as authoritative
- Click-through: concept rows → `setToolbarPanel('vocabulary')`, entity rows → `setToolbarPanel('entities')`
- Empty Entities section renders as a labeled normal state ("No entity links — this is normal for most nodes.")
- Named `BdiGroundingPanel` to avoid colliding with the existing `GroundingPanel` (debate-transcript taxonomy reference viewer used by debate-diagnostics)

## Test plan

- [ ] 12 vitest unit tests pass covering: no-node empty state, node-not-found empty state, concept/entity row rendering, `linked`/`proposed` status distinction, DOLCE badges, `--proposed` CSS class, click-through navigation calls, cross-POV file search (safetyist/skeptic)
- [ ] `/review-ts` clean — no CRITICAL or WARNING findings
- [ ] `tsc` new-file errors: none (3 pre-existing lib errors on origin/main, confirmed unrelated)

Closes t/3292

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AoWKVNhQCeYg5uZZoMUfx3