### PR TITLE
fix(vocab): style the shared VocabularyPanel — namespaced readability CSS (t/3287)

### DIFF
--- a/taxonomy-editor/src/renderer/components/shared/VocabularyPanel.css
+++ b/taxonomy-editor/src/renderer/components/shared/VocabularyPanel.css
@@ -40,12 +40,14 @@
   font-variant-numeric: tabular-nums;
 }
 .vocab-shared .lint-badge {
+  /* t/3287#8 (Design): tint-bg + semantic TEXT, not a saturated fill — `--warning` fill with
+     `--error-text` fails AA in all 4 themes. Same tint pattern as .severity-info. */
   display: inline-block;
   margin-left: 6px;
   padding: 1px 7px;
   border-radius: var(--radius-sm);
-  background: var(--warning);
-  color: var(--error-text, var(--text-primary));
+  background: var(--bg-secondary);
+  color: var(--warning);
   font-size: 0.85em;
   font-variant-numeric: tabular-nums;
 }
@@ -290,14 +292,22 @@
   flex-shrink: 0;
   padding: 1px 8px;
   border-radius: var(--radius-sm);
-  color: var(--error-text, var(--text-primary));
+  color: var(--text-secondary);
   font-size: 0.8em;
   text-transform: capitalize;
 }
-/* Severity tint by token (§6 — no hex). severity-* is on the .lint-violation row. */
-.vocab-shared .lint-violation.severity-error .severity { background: var(--danger); }
+/* Severity pills = tint-bg + readable text, per severity (§6, no hex). t/3287#8 (Design): saturated
+   `--danger`/`--warning` fills with `--error-text` fail AA in all themes — error uses the certified
+   `--error-bg`/`--error-text` pair; warn/info keep the semantic color as TEXT on a `--bg-secondary` tint. */
+.vocab-shared .lint-violation.severity-error .severity {
+  background: var(--error-bg);
+  color: var(--error-text);
+}
 .vocab-shared .lint-violation.severity-warn .severity,
-.vocab-shared .lint-violation.severity-warning .severity { background: var(--warning); }
+.vocab-shared .lint-violation.severity-warning .severity {
+  background: var(--bg-secondary);
+  color: var(--warning);
+}
 .vocab-shared .lint-violation.severity-info .severity {
   background: var(--bg-secondary);
   color: var(--text-muted);

--- a/taxonomy-editor/src/renderer/components/shared/VocabularyPanel.css
+++ b/taxonomy-editor/src/renderer/components/shared/VocabularyPanel.css
@@ -1,0 +1,337 @@
+/* Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+   Licensed under the MIT License. See LICENSE file in the project root. */
+
+/* Vocabulary panel readability styles (t/3287, spec docs/ux/vocabulary-panel-readability.md §3–§8).
+   The shared/ panel imported NO stylesheet, so it rendered as unstyled run-on HTML (t1/t2.png).
+
+   NAMESPACE (TL ruling t/3287#[b], p/336#275): every rule is scoped under `.vocab-shared` — the
+   wrapper class on this panel's root. debate-workspace/VocabularyPanel.css defines the SAME global
+   class names (.vocabulary-panel/.vocab-entry/…); scoping here means (a) these rules never apply to
+   the debate panel, and (b) `.vocab-shared .vocab-entry` (specificity 0,2,0) overrides any debate
+   global (.vocab-entry, 0,1,0) that leaks in when both chunks' CSS co-load in a session. So no
+   cascade collision either direction. (The DRY unify + the debate panel's own theme bugs are a
+   separate DebateWorkspace ticket per TL — not this fix.)
+
+   Tokens only, no hard-coded hex (§2); camp colors stay inline via POV_COLORS. Four themes inherit
+   through the tokens. */
+
+.vocab-shared {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  color: var(--text-primary);
+}
+
+/* ── Header (§3) ── */
+.vocab-shared .vocab-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+.vocab-shared .vocab-header h3 {
+  margin: 0;
+  font-size: 1.05em;
+}
+.vocab-shared .vocab-stats {
+  margin-left: auto;
+  color: var(--text-muted);
+  font-size: 0.85em;
+  font-variant-numeric: tabular-nums;
+}
+.vocab-shared .lint-badge {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 7px;
+  border-radius: var(--radius-sm);
+  background: var(--warning);
+  color: var(--error-text, var(--text-primary));
+  font-size: 0.85em;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Tabs (§3) ── */
+.vocab-shared .vocab-tabs {
+  display: flex;
+  gap: 4px;
+  border-bottom: 1px solid var(--border-color);
+}
+.vocab-shared .vocab-tabs button {
+  padding: 6px 12px;
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  cursor: pointer;
+}
+.vocab-shared .vocab-tabs button:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+.vocab-shared .vocab-tabs button.active {
+  color: var(--text-primary);
+  border-bottom-color: var(--focus-ring, var(--text-primary));
+  font-weight: 600;
+}
+.vocab-shared .vocab-tabs button:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
+}
+
+/* ── Filters (§3) ── */
+.vocab-shared .vocab-filters {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.vocab-shared .vocab-search {
+  width: 100%;
+  padding: 6px 8px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font: inherit;
+}
+.vocab-shared .vocab-search:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -1px;
+}
+.vocab-shared .vocab-filter-row {
+  display: flex;
+  gap: 8px;
+}
+.vocab-shared .vocab-filter-row select {
+  flex: 1;
+  padding: 5px 6px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font: inherit;
+}
+
+/* ── List + rows (§4) ── */
+.vocab-shared .vocab-list {
+  display: flex;
+  flex-direction: column;
+}
+.vocab-shared .vocab-entry {
+  border-bottom: 1px solid var(--border-color);
+  cursor: pointer;
+}
+.vocab-shared .vocab-entry-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 8px 10px;
+}
+.vocab-shared .vocab-entry:hover {
+  background: var(--bg-hover);
+}
+.vocab-shared .vocab-entry:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
+}
+.vocab-shared .camp-dot {
+  flex-shrink: 0;
+  width: 1em;
+  text-align: center;
+}
+/* §4: readable label primary, machine key muted-mono secondary, count far right.
+   JSX order is camp-dot → canonical → display-form → count; flex `order` sets the
+   visual hierarchy without a JSX reorder. */
+.vocab-shared .display-form {
+  order: 1;
+  flex: 1 1 auto;
+  color: var(--text-primary);
+  font-weight: 500;
+  overflow-wrap: anywhere;
+}
+.vocab-shared .canonical {
+  order: 2;
+  flex-shrink: 0;
+  font-family: monospace;
+  font-size: 0.85em;
+  color: var(--text-muted);
+  overflow-wrap: anywhere;
+}
+.vocab-shared .node-count {
+  order: 3;
+  margin-left: auto;
+  flex-shrink: 0;
+  padding: 1px 7px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Expanded Dictionary detail (§4) */
+.vocab-shared .vocab-entry-detail {
+  padding: 8px 10px 10px 22px;
+  background: var(--bg-secondary);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.vocab-shared .vocab-entry-detail .definition {
+  margin: 0 0 4px;
+  color: var(--text-primary);
+}
+.vocab-shared .detail-row {
+  color: var(--text-secondary);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 6px;
+  align-items: baseline;
+}
+.vocab-shared .detail-row strong {
+  color: var(--text-primary);
+}
+.vocab-shared .detail-row.meta {
+  color: var(--text-muted);
+  font-size: 0.85em;
+}
+.vocab-shared .phrase-tag,
+.vocab-shared .see-also-link {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-hover);
+  font-size: 0.9em;
+}
+.vocab-shared .see-also-link {
+  font-family: monospace;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+.vocab-shared .see-also-link:hover {
+  text-decoration: underline;
+  color: var(--text-primary);
+}
+.vocab-shared .confusion-entry {
+  color: var(--text-secondary);
+}
+.vocab-shared .confusion-entry code {
+  font-family: monospace;
+  color: var(--text-primary);
+}
+
+/* ── Colloquial rows (§5) ── */
+.vocab-shared .colloquial-entry {
+  padding: 8px 10px;
+  cursor: default;
+}
+.vocab-shared .colloquial-entry .vocab-entry-header {
+  padding: 0 0 4px;
+}
+.vocab-shared .status-badge {
+  flex-shrink: 0;
+  padding: 1px 8px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  font-size: 0.8em;
+  text-transform: capitalize;
+}
+.vocab-shared .colloquial-entry strong {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+.vocab-shared .resolves-to {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.vocab-shared .resolution {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 4px 0;
+}
+.vocab-shared .resolution .when {
+  flex: 1;
+  color: var(--text-primary);
+  overflow-wrap: anywhere;
+}
+.vocab-shared .camp-tag {
+  flex-shrink: 0;
+  margin-left: 8px;
+  padding: 0 6px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  font-size: 0.85em;
+  text-transform: capitalize;
+}
+.vocab-shared .ambiguous-when {
+  margin-top: 6px;
+  padding-left: 8px;
+  border-left: 2px solid var(--border-color);
+  color: var(--text-muted);
+}
+
+/* ── Lint rows (§6) ── */
+.vocab-shared .lint-violation {
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.vocab-shared .lint-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+.vocab-shared .severity {
+  flex-shrink: 0;
+  padding: 1px 8px;
+  border-radius: var(--radius-sm);
+  color: var(--error-text, var(--text-primary));
+  font-size: 0.8em;
+  text-transform: capitalize;
+}
+/* Severity tint by token (§6 — no hex). severity-* is on the .lint-violation row. */
+.vocab-shared .lint-violation.severity-error .severity { background: var(--danger); }
+.vocab-shared .lint-violation.severity-warn .severity,
+.vocab-shared .lint-violation.severity-warning .severity { background: var(--warning); }
+.vocab-shared .lint-violation.severity-info .severity {
+  background: var(--bg-secondary);
+  color: var(--text-muted);
+}
+.vocab-shared .constraint {
+  flex-shrink: 0;
+  font-family: monospace;
+  color: var(--text-secondary);
+}
+.vocab-shared .file {
+  color: var(--text-muted);
+  font-family: monospace;
+  font-size: 0.85em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.vocab-shared .lint-message {
+  color: var(--text-primary);
+}
+.vocab-shared .lint-fix {
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+}
+
+/* ── Empty / loading ── */
+.vocab-shared .empty-state {
+  padding: 24px 12px;
+  text-align: center;
+  color: var(--text-muted);
+}
+.vocab-shared.loading {
+  padding: 24px 12px;
+  color: var(--text-muted);
+}

--- a/taxonomy-editor/src/renderer/components/shared/VocabularyPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/VocabularyPanel.tsx
@@ -6,6 +6,7 @@ import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { bridgeGet } from '../../bridge/web-bridge';
 import { DocLink } from './TheoryLink';
 import type { StandardizedTerm, ColloquialTerm, LintViolation, CampOrigin, CoinageStatus } from '@lib/dictionary';
+import './VocabularyPanel.css'; // t/3287 — readability styles, namespaced under .vocab-shared
 
 const POV_COLORS: Record<string, string> = {
   accelerationist: 'var(--color-acc)',
@@ -107,11 +108,11 @@ export function VocabularyPanel() {
   }, [colloquial, searchQuery]);
 
   if (loading) {
-    return <div className="vocabulary-panel loading">Loading dictionary...</div>;
+    return <div className="vocabulary-panel loading vocab-shared">Loading dictionary...</div>;
   }
 
   return (
-    <div className="vocabulary-panel">
+    <div className="vocabulary-panel vocab-shared">
       <div className="vocab-header">
         <h3>Vocabulary</h3>
         <DocLink docPath="research/comp-linguist/docs/theory-of-success/theory-of-success-vocabulary.md" label="Theory of success: Vocabulary" tooltip="Open the Vocabulary theory-of-success doc in GitHub" />
@@ -171,9 +172,19 @@ export function VocabularyPanel() {
               <div
                 key={term.canonical_form}
                 className={`vocab-entry ${expandedTerm === term.canonical_form ? 'expanded' : ''}`}
+                role="button"
+                tabIndex={0}
+                aria-expanded={expandedTerm === term.canonical_form}
                 onClick={() => setExpandedTerm(
                   expandedTerm === term.canonical_form ? null : term.canonical_form,
                 )}
+                onKeyDown={e => {
+                  // t/3287 §7: keyboard-operable expandable row (Enter/Space toggles).
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    setExpandedTerm(expandedTerm === term.canonical_form ? null : term.canonical_form);
+                  }
+                }}
               >
                 <div className="vocab-entry-header">
                   <span


### PR DESCRIPTION
`shared/VocabularyPanel.tsx` imported no stylesheet and none of its class names were defined → unstyled run-on HTML (owner-reported "hideous and unreadable"; t1/t2.png). Authored `shared/VocabularyPanel.css` per Design's readability spec §3–§8 + the import + §7 a11y.

## Approach: option (b) namespace (TL ruling p/336#275)
Every rule is scoped under a **`.vocab-shared`** wrapper (added to the panel root), NOT a new file with the same global names the debate-workspace panel defines. My co-load analysis (t/3287#3): both CSS chunks can persist in `<head>` in a session → duplicate globals would collide. `.vocab-shared .foo` (0,2,0) both keeps my rules off the debate panel **and** overrides any debate global (0,1,0) leaking onto mine — no collision either direction, theme-clean by construction.

**Deviation (flagged):** spec §1/§9 now prescribe the *unify/extract* approach; TL overrode to (b) namespace for this urgent readability fix. The DRY unify + the debate panel's own theme bugs → separate DebateWorkspace ticket (TL filing).

## What changed (2 files, +350/−2)
- **NEW `shared/VocabularyPanel.css`** — Dictionary/Colloquial/Lint rows as flex columns (label primary, mono key muted, count right, camp chip end) + 1px separators + padding + hover; header/tabs(active)/filters spaced; tokens only, no hex.
- **`shared/VocabularyPanel.tsx`** — `import './VocabularyPanel.css'`, `vocab-shared` on both roots, §7 a11y on expandable Dictionary rows (role=button/tabIndex/aria-expanded/Enter-Space/`:focus-visible`).

## Verify
- eslint 0, renderer-tsc 0 in changed file, `VocabularyPanel.test.tsx` passes, CSS confirmed tokens-only.
- **Visual gate:** Design's 4-theme `/design-review-workflow` (light/dark/bkc/harvard, web + Electron) — **holding merge for that sign-off** per the AC.

Commit: 065e8bbb