### PR TITLE
infra(azure): G8b sweep-stall alert — failed-inline-then-cold obs (t/3279)

### DIFF
--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -1349,6 +1349,62 @@ resource fallbackActive 'Microsoft.Insights/scheduledQueryRules@2023-03-15-previ
   }
 }
 
+// ── G8b Grounding-Sweep Stall Alert (t/3279) ──
+// Detects the failed-inline-then-cold edge: a G8a inline reconcile FAILED (emitting the stdout
+// `log.server.warn 'inline grounding reconcile failed'` from groundingReconcileHook.ts → Log_s;
+// condition 1 pre-verified) AND no `Grounding sweep complete` drained the backlog within N hours.
+// Scoped to the REAL edge, NOT bare sweep-absence — under minReplicas=0, no-sweep-while-cold is
+// benign (cold ⇒ no writes ⇒ no failures ⇒ correctly silent). Grace period: only failures OLDER
+// than N are considered (a fresh failure's sweep may still come — TL GV t/3279#2, cond. 2).
+// Correlation logic mirrors operations/devops/Get-SweepStallVerdict.ps1 (both arms unit-proven);
+// the KQL is validated against real prod Log_s for ≥1 cycle before it's trusted (real-env-first).
+//
+// N = 2h (cond. 4): MUST exceed the 15-min sweep cadence with margin so one benign cold gap +
+// container-warmth jitter can't trip it. windowSize 6h covers a failure + its 2h window + slack.
+resource sweepStallAlert 'Microsoft.Insights/scheduledQueryRules@2023-03-15-preview' = {
+  name: 'alert-grounding-sweep-stall'
+  location: location
+  tags: tags
+  properties: {
+    displayName: 'G8b Grounding Sweep Stalled (failed inline reconcile un-swept > N)'
+    description: 'A G8a inline grounding reconcile FAILED and no G8b sweep drained the backlog within N hours — grounding may be silently stale (the failed-inline-then-cold edge, t/3279).'
+    severity: 2
+    enabled: true
+    scopes: [ logAnalytics.id ]
+    evaluationFrequency: 'PT30M'
+    windowSize: 'PT6H'
+    criteria: {
+      allOf: [
+        {
+          // Rows = inline-reconcile failures older than N with NO sweep-complete in [failTime, failTime+N].
+          // k=1 cross-join is cheap: both markers are rare. Fire iff any such stale failure exists.
+          query: '''
+            let N = 2h;
+            let sweeps = ContainerAppConsoleLogs_CL
+              | where TimeGenerated > ago(6h)
+              | where Log_s has "Grounding sweep complete"
+              | project sweepTime = TimeGenerated, k = 1;
+            ContainerAppConsoleLogs_CL
+            | where TimeGenerated > ago(6h)
+            | where Log_s has "inline grounding reconcile failed"
+            | where TimeGenerated < ago(N)
+            | project failTime = TimeGenerated, k = 1
+            | join kind=leftouter (sweeps) on k
+            | summarize sweptInWindow = countif(sweepTime >= failTime and sweepTime <= failTime + N) by failTime
+            | where sweptInWindow == 0
+          '''
+          timeAggregation: 'Count'
+          operator: 'GreaterThan'
+          threshold: 0
+        }
+      ]
+    }
+    actions: {
+      actionGroups: budgetAlertConfigured ? [ restartAlertActionGroup.id ] : []
+    }
+  }
+}
+
 // Paid Gemini fallback overflow (t/3110). The anon key pool is free-primary +
 // single paid key as overflow-only fallback (t/3111); the default path is free,
 // so paid-fallback usage should be ~0. Any sustained nonzero is a real operational

--- a/operations/devops/Get-SweepStallVerdict.ps1
+++ b/operations/devops/Get-SweepStallVerdict.ps1
@@ -1,0 +1,68 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    Pure predicate for the G8b sweep-stall alert (t/3279): did a failed inline reconcile
+    sit un-swept past the grace window?
+
+.DESCRIPTION
+    Models the correlation the Azure Monitor scheduledQueryRules `alert-grounding-sweep-stall`
+    runs in KQL, so both arms are unit-provable offline (Guard Testability, t/2971) — the alert's
+    real behavior only surfaces in deployed Azure Monitor, so PR CI can't exercise the KQL directly.
+    Keep this logic in lockstep with the bicep query; the KQL is validated against real prod Log_s
+    for ≥1 cycle before the alert is trusted (real-env-first, TL t/3279#2).
+
+    Scoped to the REAL edge (TL GV t/3279#2), NOT bare sweep-absence: under minReplicas=0, no-sweep-
+    while-cold is benign (cold ⇒ no writes ⇒ no failures ⇒ correctly silent). We fire only when a
+    G8a inline reconcile FAILED (its `log.server.warn 'inline grounding reconcile failed'` reaches
+    stdout → Log_s — condition 1, pre-verified) and NO `Grounding sweep complete` drained it within N.
+
+.PARAMETER FailureAgeHours
+    Hours since the most recent inline-reconcile failure. Negative (or the -1 sentinel) = NO failure
+    in the window → never fire.
+
+.PARAMETER SweptWithinWindow
+    True iff a `Grounding sweep complete` occurred in [failureTime, failureTime + N] (the backlog was
+    drained in time). When true, never fire regardless of age.
+
+.PARAMETER ThresholdHours
+    N — grace window. Fire only once N hours have ELAPSED since the failure with no intervening sweep.
+    MUST exceed the 15-min sweep cadence with margin (default 2h) so one benign cold gap + warmth
+    jitter can't trip it (condition 4). Co-located with the bicep query's `let N`.
+
+.OUTPUTS
+    [pscustomobject] @{ Fire = [bool]; Reason = [string] }
+      Fire=$true  'stalled-backlog'
+      Fire=$false 'no-failure' | 'swept' | 'window-not-elapsed'
+#>
+function Get-SweepStallVerdict {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory)] [double] $FailureAgeHours,
+        [Parameter(Mandatory)] [bool]   $SweptWithinWindow,
+        [double] $ThresholdHours = 2
+    )
+
+    # No inline-reconcile failure in the window → nothing to be stale about (the benign-cold arm:
+    # cold ⇒ no writes ⇒ no failure ⇒ correctly silent).
+    if ($FailureAgeHours -lt 0) {
+        return [pscustomobject]@{ Fire = $false; Reason = 'no-failure' }
+    }
+
+    # A sweep drained the backlog within the grace window — the primary/backstop path worked.
+    if ($SweptWithinWindow) {
+        return [pscustomobject]@{ Fire = $false; Reason = 'swept' }
+    }
+
+    # Grace period (condition 2): a failure whose N-hr window hasn't elapsed is NOT yet an alert —
+    # its sweep may still come. Distinct silent arm.
+    if ($FailureAgeHours -lt $ThresholdHours) {
+        return [pscustomobject]@{ Fire = $false; Reason = 'window-not-elapsed' }
+    }
+
+    # Failed inline reconcile + no sweep within N + window elapsed → the failed-inline-then-cold
+    # backlog is silently stale. FIRE (the whole reason G8b's obs gap needed closing).
+    return [pscustomobject]@{ Fire = $true; Reason = 'stalled-backlog' }
+}

--- a/tests/Get-SweepStallVerdict.Tests.ps1
+++ b/tests/Get-SweepStallVerdict.Tests.ps1
@@ -1,0 +1,56 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+# Guard Testability (t/2971) for the G8b sweep-stall alert (t/3279). The alert's real behavior only
+# surfaces in deployed Azure Monitor KQL, so both arms are proven here directly against the model
+# predicate. Four cases per TL GV t/3279#2: FIRE = fail + no sweep in N + elapsed; SILENT = swept /
+# no-failure / window-not-elapsed.
+
+BeforeAll {
+    . "$PSScriptRoot/../operations/devops/Get-SweepStallVerdict.ps1"
+}
+
+Describe 'Get-SweepStallVerdict' {
+
+    Context 'FIRE arm — failed inline reconcile sat un-swept past the grace window' {
+        It 'fires when a failure is older than N with no sweep in its window' {
+            $v = Get-SweepStallVerdict -FailureAgeHours 3 -SweptWithinWindow $false -ThresholdHours 2
+            $v.Fire | Should -BeTrue
+            $v.Reason | Should -Be 'stalled-backlog'
+        }
+        It 'fires exactly AT the threshold boundary (>= elapsed)' {
+            $v = Get-SweepStallVerdict -FailureAgeHours 2 -SweptWithinWindow $false -ThresholdHours 2
+            $v.Fire | Should -BeTrue
+        }
+    }
+
+    Context 'SILENT arm — not a stall' {
+        It '(a) is silent when a sweep drained the backlog within N: reason swept' {
+            $v = Get-SweepStallVerdict -FailureAgeHours 5 -SweptWithinWindow $true -ThresholdHours 2
+            $v.Fire | Should -BeFalse
+            $v.Reason | Should -Be 'swept'
+        }
+        It '(b) is silent when there was NO inline failure (benign cold): reason no-failure' {
+            $v = Get-SweepStallVerdict -FailureAgeHours -1 -SweptWithinWindow $false -ThresholdHours 2
+            $v.Fire | Should -BeFalse
+            $v.Reason | Should -Be 'no-failure'
+        }
+        It '(c) is silent when the failure is too recent — window not elapsed (grace period)' {
+            $v = Get-SweepStallVerdict -FailureAgeHours 1 -SweptWithinWindow $false -ThresholdHours 2
+            $v.Fire | Should -BeFalse
+            $v.Reason | Should -Be 'window-not-elapsed'
+        }
+    }
+
+    Context 'Precedence — swept dominates staleness; no-failure dominates all' {
+        It 'reports swept (not stalled) even when the failure is very old but was swept' {
+            $v = Get-SweepStallVerdict -FailureAgeHours 24 -SweptWithinWindow $true -ThresholdHours 2
+            $v.Fire | Should -BeFalse
+            $v.Reason | Should -Be 'swept'
+        }
+        It 'no-failure short-circuits before the swept/elapsed checks' {
+            $v = Get-SweepStallVerdict -FailureAgeHours -1 -SweptWithinWindow $true -ThresholdHours 2
+            $v.Reason | Should -Be 'no-failure'
+        }
+    }
+}


### PR DESCRIPTION
Implements **t/3279** (observability for the G8b sweep silently stalling under scale-to-zero) per TL GV **t/3279#2**.

## What
- **`deploy/azure/main.bicep`** — new `scheduledQueryRules` `alert-grounding-sweep-stall` (reuses `restartAlertActionGroup` + LA workspace, like the sibling alerts). Fires only on the **real edge**: a G8a inline reconcile FAILED (`log.server.warn 'inline grounding reconcile failed'` → `Log_s`, cond. 1 pre-verified) AND no `Grounding sweep complete` in `[failTime, failTime+N]`. NOT bare sweep-absence (benign under `minReplicas=0`). **Grace period** (cond. 2): only failures older than N. **N=2h** > 15-min cadence w/ margin (cond. 4), co-located in the KQL.
- **`operations/devops/Get-SweepStallVerdict.ps1`** + **`tests/Get-SweepStallVerdict.Tests.ps1`** — pure predicate modelling the KQL correlation + **7-case Pester (green)**: TL's 4 cases (fire / swept / no-failure / window-not-elapsed) + boundary + precedence. Guard Testability (t/2971).

## Verification
- `az bicep build` clean (exit 0); alert present in built JSON.
- Pester 7/7 green.
- **Remaining GV item (real-env-first, TL t/3279#2):** validate the KQL against real prod `Log_s` for ≥1 cycle before trusting — the "inline grounding reconcile failed" marker is a rare degraded path, so I'll confirm the query shape against live data (and re-confirm the marker reaches Log_s in the deployed image) as a post-merge step. Flagging that the fire-arm can't be exercised until a real inline failure occurs in prod.

Gate-touching → TL GV (both arms + the cond. 1 emit-sink confirmation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)