### PR TITLE
feat(main): add --review-mode flag for prod-app renderer review (t/3294)

### DIFF
--- a/taxonomy-editor/src/main/main.ts
+++ b/taxonomy-editor/src/main/main.ts
@@ -149,9 +149,12 @@ function createWindow(): void {
   });
   hardenWindow(mainWindow);
 
-  // Use production build if launched with CLI file args (viewer mode) or if packaged
+  // Use production build if launched with CLI file args (viewer mode) or if packaged.
+  // --review-mode (or ELECTRON_REVIEW_MODE=1) forces the prod renderer path without registering
+  // the get-cli-file-arg viewer-mode IPC, so cross-scope agents can attach via CDP for design review.
   const hasFileArg = process.argv.some(a => a.startsWith('--diagnostics-file=') || a.startsWith('--harvest-file='));
-  const isDev = !app.isPackaged && !hasFileArg;
+  const isReviewMode = process.argv.includes('--review-mode') || process.env['ELECTRON_REVIEW_MODE'] === '1';
+  const isDev = !app.isPackaged && !hasFileArg && !isReviewMode;
   if (isDev) {
     console.log('[main] Loading dev URL: http://localhost:5173');
     void mainWindow.loadURL('http://localhost:5173');


### PR DESCRIPTION
## Summary

- Adds `--review-mode` CLI flag (and `ELECTRON_REVIEW_MODE=1` env var) to `main.ts`
- Forces `loadFile(dist/renderer/index.html)` without registering the `get-cli-file-arg` viewer-mode IPC handler
- Unblocks cross-scope design reviews: `npx electron . --review-mode --remote-debugging-port=9222` launches the normal app shell from a static build, CDP-attachable by electron-mcp

Before: dev hardcodes `:5173` (port conflicts on shared fleet); file-arg forces viewer-mode. No clean path existed.

## Test plan

- [ ] `npm run build` then `npx electron . --review-mode --remote-debugging-port=9222` → app loads normal shell, not diagnostics/viewer
- [ ] `ELECTRON_REVIEW_MODE=1 npx electron .` → same behaviour via env var
- [ ] Without flag: dev mode unchanged (still loads `:5173`)
- [ ] CI tsc/lint passes

Closes t/3294

🤖 Generated with [Claude Code](https://claude.com/claude-code)