### PR TITLE
feat(settings): tabify SettingsDialog + wire API Keys deep-link (t/3295, t/3204)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateActionBar.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateActionBar.tsx
@@ -391,7 +391,7 @@ function DebateErrorBanner({
       <span className={dailyLimitPaused ? 'debate-daily-limit-text' : 'debate-error-text'}>{debateError}</span>
       {dailyLimitPaused ? (
         // "Continue now" path for the daily cap is registering a BYOK key (t/3190).
-        <button className="debate-daily-limit-action" onClick={openSettings}>Add API key</button>
+        <button className="debate-daily-limit-action" onClick={() => openSettings('apiKeys')}>Add API key</button>
       ) : (
         <button className="debate-error-retry" onClick={onRetry} disabled={disableAnalysis}>Retry</button>
       )}

--- a/taxonomy-editor/src/renderer/components/settings/SettingsDialog.css
+++ b/taxonomy-editor/src/renderer/components/settings/SettingsDialog.css
@@ -336,3 +336,36 @@
   font-size: 0.78rem;
   font-style: italic;
 }
+
+/* ─── Settings tab bar (t/3295) ───────────────────────── */
+
+.settings-tab-bar {
+  display: flex;
+  gap: 2px;
+  margin-bottom: 14px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.settings-tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 6px 12px;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--text-secondary);
+  cursor: pointer;
+  margin-bottom: -1px;
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+  transition: color 0.12s, border-color 0.12s;
+}
+
+.settings-tab:hover {
+  color: var(--text-primary);
+}
+
+.settings-tab--active {
+  color: var(--text-primary);
+  border-bottom-color: var(--focus-ring);
+  font-weight: 600;
+}

--- a/taxonomy-editor/src/renderer/components/settings/SettingsDialog.test.tsx
+++ b/taxonomy-editor/src/renderer/components/settings/SettingsDialog.test.tsx
@@ -1,6 +1,7 @@
 ﻿import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useSettingsDialog } from '../../hooks/useSettingsDialog';
 
 const { mockApi } = vi.hoisted(() => ({
   mockApi: {
@@ -80,13 +81,16 @@ describe('SettingsDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockDescMode = 'plain';
+    useSettingsDialog.setState({ isOpen: false, requestedSection: null });
   });
 
-  it('renders with heading and all setting sections', () => {
+  it('renders with heading and all setting sections', async () => {
+    const user = userEvent.setup();
     render(<SettingsDialog onClose={onClose} />);
     expect(screen.getByText('Settings')).toBeInTheDocument();
     expect(screen.getByText('AI Backend')).toBeInTheDocument();
     expect(screen.getByText('Model')).toBeInTheDocument();
+    await user.click(screen.getByRole('tab', { name: 'Appearance' }));
     expect(screen.getByText('Theme')).toBeInTheDocument();
     expect(screen.getByText('Pane 2 Item Spacing')).toBeInTheDocument();
     expect(screen.getByText('Description Display')).toBeInTheDocument();
@@ -104,8 +108,10 @@ describe('SettingsDialog', () => {
     );
   });
 
-  it('renders theme options', () => {
+  it('renders theme options', async () => {
+    const user = userEvent.setup();
     render(<SettingsDialog onClose={onClose} />);
+    await user.click(screen.getByRole('tab', { name: 'Appearance' }));
     expect(screen.getByText('Light')).toBeInTheDocument();
     expect(screen.getByText('Dark')).toBeInTheDocument();
     expect(screen.getByText('Harvard')).toBeInTheDocument();
@@ -129,16 +135,18 @@ describe('SettingsDialog', () => {
   it('changes theme when a new option is selected', async () => {
     const user = userEvent.setup();
     render(<SettingsDialog onClose={onClose} />);
-    const selects = screen.getAllByRole('combobox');
-    const themeSelect = selects.find(s =>
+    await user.click(screen.getByRole('tab', { name: 'Appearance' }));
+    const themeSelect = screen.getAllByRole('combobox').find(s =>
       Array.from(s.querySelectorAll('option')).some(o => o.textContent === 'Dark'),
     )!;
     await user.selectOptions(themeSelect, 'dark');
     expect(mockSetColorScheme).toHaveBeenCalledWith('dark');
   });
 
-  it('renders description mode radio buttons with correct selection', () => {
+  it('renders description mode radio buttons with correct selection', async () => {
+    const user = userEvent.setup();
     render(<SettingsDialog onClose={onClose} />);
+    await user.click(screen.getByRole('tab', { name: 'Appearance' }));
     const plainRadio = screen.getByRole('radio', { name: 'Plain' });
     const formalRadio = screen.getByRole('radio', { name: 'Formal' });
     expect(plainRadio).toBeChecked();
@@ -148,6 +156,7 @@ describe('SettingsDialog', () => {
   it('saves API key and shows success message', async () => {
     const user = userEvent.setup();
     render(<SettingsDialog onClose={onClose} />);
+    await user.click(screen.getByRole('tab', { name: 'API Keys' }));
     const keyInput = screen.getByPlaceholderText('AIza...');
     await user.type(keyInput, 'AIzaSyTestKey');
     await user.click(screen.getByText('Save'));

--- a/taxonomy-editor/src/renderer/components/settings/SettingsDialog.tsx
+++ b/taxonomy-editor/src/renderer/components/settings/SettingsDialog.tsx
@@ -11,7 +11,10 @@ import { AI_BACKENDS, MODELS_BY_BACKEND, initAIModels } from '../../hooks/useTax
 import { KeySharingDialog } from './KeySharingDialog';
 import { useDescriptionMode, type DescriptionMode } from '../shared/DescriptionToggle';
 import { backendSelectState, type BackendAvailabilityEntry } from '../shared/backendSelectState';
+import { useSettingsDialog } from '../../hooks/useSettingsDialog';
 import './SettingsDialog.css';
+
+type SettingsTab = 'ai' | 'apiKeys' | 'appearance';
 
 interface SettingsDialogProps {
   onClose: () => void;
@@ -503,6 +506,16 @@ function ApiKeyEntrySection({
 }
 
 export function SettingsDialog({ onClose }: SettingsDialogProps) {
+  const requestedSection = useSettingsDialog(s => s.requestedSection);
+  const [activeTab, setActiveTab] = useState<SettingsTab>(() =>
+    requestedSection === 'apiKeys' ? 'apiKeys' : 'ai',
+  );
+
+  // t/3295: sync tab when caller passes a section target (e.g. QuotaBanner → 'apiKeys')
+  useEffect(() => {
+    if (requestedSection) setActiveTab(requestedSection);
+  }, [requestedSection]);
+
   const { colorScheme, setColorScheme, paneSpacing, setPaneSpacing, aiBackend, setAIBackend, geminiModel, setGeminiModel } = useTaxonomyStore();
   const [descMode, setDescMode] = useDescriptionMode();
   const [hasKey, setHasKey] = useState<Record<string, boolean>>({});
@@ -617,126 +630,146 @@ export function SettingsDialog({ onClose }: SettingsDialogProps) {
       <div className="dialog settings-dialog" onClick={(e) => e.stopPropagation()}>
         <h3>Settings</h3>
 
-        <div className="settings-row">
-          <label className="settings-label">AI Backend</label>
-          <select
-            className="settings-select"
-            value={aiBackend}
-            onChange={(e) => setAIBackend(e.target.value as AIBackend)}
-          >
-            {AI_BACKENDS.map((b) => {
-              // t/2036 3-state: has-key→plain; no-key-but-BYOK-permitted→selectable "(bring your
-              // own key)"; tier-forbidden (web anon/free)→disabled "(sign in to use)". Never
-              // disable merely for a missing key — that was the ADR-002-violating conflation.
-              const state = backendSelectState(availByReason[b.value], !!hasKey[b.value]);
-              return (
-                <option key={b.value} value={b.value} disabled={!state.selectable}>
-                  {b.label}{state.suffix}
-                </option>
-              );
-            })}
-          </select>
-        </div>
-
-        <div className="settings-row">
-          <label className="settings-label">Model</label>
-          <div className="settings-model-row">
-            <select
-              className="settings-select"
-              value={geminiModel}
-              onChange={(e) => setGeminiModel(e.target.value as AIModel)}
-            >
-              {models.map((m) => (
-                <option key={m.value} value={m.value}>{m.label}</option>
-              ))}
-            </select>
+        <div className="settings-tab-bar" role="tablist">
+          {(['ai', 'apiKeys', 'appearance'] as SettingsTab[]).map(tab => (
             <button
-              className="btn btn-sm settings-refresh-btn"
-              onClick={handleRefresh}
-              disabled={refreshing}
-              title="Query provider APIs for available models and update ai-models.json"
+              key={tab}
+              role="tab"
+              aria-selected={activeTab === tab}
+              className={`settings-tab${activeTab === tab ? ' settings-tab--active' : ''}`}
+              onClick={() => setActiveTab(tab)}
             >
-              {refreshing ? 'Refreshing...' : 'Refresh Models'}
+              {tab === 'ai' ? 'AI' : tab === 'apiKeys' ? 'API Keys' : 'Appearance'}
             </button>
-          </div>
+          ))}
         </div>
 
-        <RefreshModelsResult result={refreshResult} error={refreshError} />
+        {activeTab === 'ai' && (
+          <>
+            <div className="settings-row">
+              <label className="settings-label">AI Backend</label>
+              <select
+                className="settings-select"
+                value={aiBackend}
+                onChange={(e) => setAIBackend(e.target.value as AIBackend)}
+              >
+                {AI_BACKENDS.map((b) => {
+                  // t/2036 3-state: has-key→plain; no-key-but-BYOK-permitted→selectable "(bring your
+                  // own key)"; tier-forbidden (web anon/free)→disabled "(sign in to use)". Never
+                  // disable merely for a missing key — that was the ADR-002-violating conflation.
+                  const state = backendSelectState(availByReason[b.value], !!hasKey[b.value]);
+                  return (
+                    <option key={b.value} value={b.value} disabled={!state.selectable}>
+                      {b.label}{state.suffix}
+                    </option>
+                  );
+                })}
+              </select>
+            </div>
 
-        <div className="settings-divider" />
+            <div className="settings-row">
+              <label className="settings-label">Model</label>
+              <div className="settings-model-row">
+                <select
+                  className="settings-select"
+                  value={geminiModel}
+                  onChange={(e) => setGeminiModel(e.target.value as AIModel)}
+                >
+                  {models.map((m) => (
+                    <option key={m.value} value={m.value}>{m.label}</option>
+                  ))}
+                </select>
+                <button
+                  className="btn btn-sm settings-refresh-btn"
+                  onClick={handleRefresh}
+                  disabled={refreshing}
+                  title="Query provider APIs for available models and update ai-models.json"
+                >
+                  {refreshing ? 'Refreshing...' : 'Refresh Models'}
+                </button>
+              </div>
+            </div>
 
-        <ApiKeyEntrySection
-          aiBackend={aiBackend}
-          hasKey={hasKey}
-          endpointInput={endpointInput}
-          setEndpointInput={setEndpointInput}
-          keyInput={keyInput}
-          setKeyInput={setKeyInput}
-          savingKey={savingKey}
-          onSaveKey={handleSaveKey}
-          keyError={keyError}
-          keySuccess={keySuccess}
-        />
-
-        <div className="settings-key-actions-row">
-          <TestKeysButton hasKey={hasKey} />
-          <button className="btn btn-sm" onClick={() => setShowKeySharing(true)}>
-            Share / Import Keys via QR
-          </button>
-          <ShowKeysSection onKeysChanged={() => setKeyRefreshTrigger(n => n + 1)} />
-        </div>
-
-        {showKeySharing && (
-          <KeySharingDialog
-            onClose={() => setShowKeySharing(false)}
-            onKeysImported={() => setKeySuccess('Keys imported via QR')}
-          />
+            <RefreshModelsResult result={refreshResult} error={refreshError} />
+          </>
         )}
 
-        <div className="settings-divider" />
+        {activeTab === 'apiKeys' && (
+          <>
+            <ApiKeyEntrySection
+              aiBackend={aiBackend}
+              hasKey={hasKey}
+              endpointInput={endpointInput}
+              setEndpointInput={setEndpointInput}
+              keyInput={keyInput}
+              setKeyInput={setKeyInput}
+              savingKey={savingKey}
+              onSaveKey={handleSaveKey}
+              keyError={keyError}
+              keySuccess={keySuccess}
+            />
 
-        <div className="settings-row">
-          <label className="settings-label">Theme</label>
-          <select
-            className="settings-select"
-            value={colorScheme}
-            onChange={(e) => setColorScheme(e.target.value as ColorScheme)}
-          >
-            <option value="light">Light</option>
-            <option value="dark">Dark</option>
-            <option value="bkc">BKC</option>
-            <option value="harvard">Harvard</option>
-            <option value="system">System</option>
-          </select>
-        </div>
+            <div className="settings-key-actions-row">
+              <TestKeysButton hasKey={hasKey} />
+              <button className="btn btn-sm" onClick={() => setShowKeySharing(true)}>
+                Share / Import Keys via QR
+              </button>
+              <ShowKeysSection onKeysChanged={() => setKeyRefreshTrigger(n => n + 1)} />
+            </div>
 
-        <div className="settings-row">
-          <label className="settings-label">Pane 2 Item Spacing</label>
-          <select
-            className="settings-select"
-            value={paneSpacing}
-            onChange={(e) => setPaneSpacing(e.target.value as 'normal' | 'concise')}
-          >
-            <option value="normal">Normal</option>
-            <option value="concise">Concise</option>
-          </select>
-        </div>
+            {showKeySharing && (
+              <KeySharingDialog
+                onClose={() => setShowKeySharing(false)}
+                onKeysImported={() => setKeySuccess('Keys imported via QR')}
+              />
+            )}
+          </>
+        )}
 
-        <div className="settings-divider" />
+        {activeTab === 'appearance' && (
+          <>
+            <div className="settings-row">
+              <label className="settings-label">Theme</label>
+              <select
+                className="settings-select"
+                value={colorScheme}
+                onChange={(e) => setColorScheme(e.target.value as ColorScheme)}
+              >
+                <option value="light">Light</option>
+                <option value="dark">Dark</option>
+                <option value="bkc">BKC</option>
+                <option value="harvard">Harvard</option>
+                <option value="system">System</option>
+              </select>
+            </div>
 
-        <div className="settings-row">
-          <label className="settings-label">Description Display</label>
-          <div className="settings-radio-group" role="radiogroup" aria-label="Default description view">
-            <label className="settings-radio-label">
-              <input type="radio" name="descMode" value="formal" checked={descMode === 'formal'} onChange={() => setDescMode('formal')} />
-              Formal
-            </label>
-            <label className="settings-radio-label">
-              <input type="radio" name="descMode" value="plain" checked={descMode === 'plain'} onChange={() => setDescMode('plain')} />
-              Plain
-            </label>
-          </div>
-        </div>
+            <div className="settings-row">
+              <label className="settings-label">Pane 2 Item Spacing</label>
+              <select
+                className="settings-select"
+                value={paneSpacing}
+                onChange={(e) => setPaneSpacing(e.target.value as 'normal' | 'concise')}
+              >
+                <option value="normal">Normal</option>
+                <option value="concise">Concise</option>
+              </select>
+            </div>
+
+            <div className="settings-row">
+              <label className="settings-label">Description Display</label>
+              <div className="settings-radio-group" role="radiogroup" aria-label="Default description view">
+                <label className="settings-radio-label">
+                  <input type="radio" name="descMode" value="formal" checked={descMode === 'formal'} onChange={() => setDescMode('formal')} />
+                  Formal
+                </label>
+                <label className="settings-radio-label">
+                  <input type="radio" name="descMode" value="plain" checked={descMode === 'plain'} onChange={() => setDescMode('plain')} />
+                  Plain
+                </label>
+              </div>
+            </div>
+          </>
+        )}
 
         <div className="dialog-actions">
           <button className="btn btn-primary" onClick={onClose}>Close</button>

--- a/taxonomy-editor/src/renderer/components/shared/QuotaBanner.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/QuotaBanner.tsx
@@ -53,7 +53,7 @@ export function QuotaBanner() {
       {warning.level === 'error' && (
         <button
           className="quota-banner-action"
-          onClick={openSettings}
+          onClick={() => openSettings('apiKeys')}
         >
           Add API key
         </button>

--- a/taxonomy-editor/src/renderer/hooks/useSettingsDialog.ts
+++ b/taxonomy-editor/src/renderer/hooks/useSettingsDialog.ts
@@ -7,17 +7,22 @@ import { create } from 'zustand';
  * Global signal for opening the Settings dialog from surfaces outside the
  * Toolbar (t/3190). The dialog itself is rendered/owned by the Toolbar, which
  * subscribes to `isOpen`; any component (e.g. the daily-quota banners) can call
- * `useSettingsDialog.getState().open()` to route the user to Settings → API Keys
- * without threading callbacks through the tree.
+ * `useSettingsDialog.getState().open('apiKeys')` to route the user to Settings →
+ * API Keys without threading callbacks through the tree (t/3295).
  */
+
+export type SettingsSection = 'apiKeys';
+
 interface SettingsDialogStore {
   isOpen: boolean;
-  open: () => void;
+  requestedSection: SettingsSection | null;
+  open: (section?: SettingsSection) => void;
   close: () => void;
 }
 
 export const useSettingsDialog = create<SettingsDialogStore>((set) => ({
   isOpen: false,
-  open: () => set({ isOpen: true }),
-  close: () => set({ isOpen: false }),
+  requestedSection: null,
+  open: (section) => set({ isOpen: true, requestedSection: section ?? null }),
+  close: () => set({ isOpen: false, requestedSection: null }),
 }));


### PR DESCRIPTION
## Summary
- `SettingsDialog.tsx`: single-scroll → 3-tab layout (AI / API Keys / Appearance)
- `useSettingsDialog.ts`: `open(section?: SettingsSection)` + `requestedSection` state
- `SettingsDialog`: initializes and syncs `activeTab` from `requestedSection` on open
- `QuotaBanner`, `DebateActionBar`: `open()` → `open('apiKeys')` so "Add API key" deep-links to the API Keys tab

Closes t/3295 and t/3204.

## Notes
- Cross-scope caller changes (QuotaBanner, DebateActionBar) are trivial 1-liners — no behavioral change with the prior single-scroll layout, now correctly deep-links
- Pre-existing worktree TSC noise (pptxgenjs, decode-named-character-reference in lib/) — not caused by this change; main checkout passes 0/0

## Test plan
- [x] QuotaBanner.test.tsx — 28 tests pass (covers existing Add API key behavior)
- [x] DebateActionBar.test.tsx — included in the 28 pass count
- [x] TSC errors confined to pre-existing lib/ package resolution (not my files)
- [x] Pre-self-merge verification: base=main, head matches push, CI pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)
