### PR TITLE
fix(vocab): distinct load-error vs empty state + WARN on the empty di…

### DIFF
--- a/taxonomy-editor/src/main/ipc/taxonomyHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/taxonomyHandlers.ts
@@ -190,9 +190,27 @@ export function registerTaxonomyHandlers(): void {
       const stdDir = path.join(dictDir, 'standardized');
       const colDir = path.join(dictDir, 'colloquial');
 
+      // t/3290 (mirrors the server-side t/3289 WARN): a missing/empty standardized dir silently
+      // blanked the Vocabulary panel with no signal. Emit a WARN recording the discriminating cause
+      // (dir-missing vs empty-listing) + the RESOLVED data root, so "which root did getDataRootPath()
+      // resolve to?" is answerable (the suspected Electron root cause — env not inherited at GUI launch).
       const standardized: unknown[] = [];
-      if (fs.existsSync(stdDir)) {
-        for (const f of fs.readdirSync(stdDir).filter(f => f.endsWith('.json'))) {
+      if (!fs.existsSync(stdDir)) {
+        getGlobalRecorder()?.record({
+          type: 'system.error', component: 'ipc-handlers', level: 'warn',
+          message: 'load-dictionary: standardized dir missing — returning empty (t/3290)',
+          data: { dir: stdDir, cause: 'dir-missing', dataRoot: getDataRootPath() },
+        });
+      } else {
+        const stdJson = fs.readdirSync(stdDir).filter(f => f.endsWith('.json'));
+        if (stdJson.length === 0) {
+          getGlobalRecorder()?.record({
+            type: 'system.error', component: 'ipc-handlers', level: 'warn',
+            message: 'load-dictionary: standardized dir present but zero .json files (empty-listing) — returning empty (t/3290)',
+            data: { dir: stdDir, cause: 'empty-listing' },
+          });
+        }
+        for (const f of stdJson) {
           try {
             standardized.push(JSON.parse(fs.readFileSync(path.join(stdDir, f), 'utf-8')));
           } catch { /* telemetry — silent by design;  skip malformed */ }
@@ -200,7 +218,13 @@ export function registerTaxonomyHandlers(): void {
       }
 
       const colloquial: unknown[] = [];
-      if (fs.existsSync(colDir)) {
+      if (!fs.existsSync(colDir)) {
+        getGlobalRecorder()?.record({
+          type: 'system.error', component: 'ipc-handlers', level: 'warn',
+          message: 'load-dictionary: colloquial dir missing — returning empty (t/3290)',
+          data: { dir: colDir, cause: 'dir-missing', dataRoot: getDataRootPath() },
+        });
+      } else {
         for (const f of fs.readdirSync(colDir).filter(f => f.endsWith('.json'))) {
           try {
             colloquial.push(JSON.parse(fs.readFileSync(path.join(colDir, f), 'utf-8')));

--- a/taxonomy-editor/src/renderer/components/shared/VocabularyPanel.css
+++ b/taxonomy-editor/src/renderer/components/shared/VocabularyPanel.css
@@ -345,3 +345,24 @@
   padding: 24px 12px;
   color: var(--text-muted);
 }
+/* t/3290: load-FAILURE state (distinct from a genuine empty result). */
+.vocab-shared .vocab-load-error {
+  color: var(--text-primary);
+}
+.vocab-shared .vocab-load-error button {
+  margin-top: 8px;
+  padding: 4px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font: inherit;
+  cursor: pointer;
+}
+.vocab-shared .vocab-load-error button:hover {
+  background: var(--bg-hover);
+}
+.vocab-shared .vocab-load-error button:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
+}

--- a/taxonomy-editor/src/renderer/components/shared/VocabularyPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/VocabularyPanel.tsx
@@ -33,6 +33,9 @@ export function VocabularyPanel() {
   const [statusFilter, setStatusFilter] = useState<CoinageStatus | 'all'>('all');
   const [expandedTerm, setExpandedTerm] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  // t/3290: distinguish "load failed" (loadError set) from a genuine "no terms" empty result, so
+  // the panel never shows a silent blank list (owner reported no concepts in both Electron + web).
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   // A useRef guard survives React 19 Strict Mode's dev double-invoke of mount
   // effects, so the dictionary is loaded once rather than twice (t/2300, sibling
@@ -47,30 +50,27 @@ export function VocabularyPanel() {
 
   async function loadDictionary() {
     setLoading(true);
+    setLoadError(null);
+    // t/3290: mirror the load through BOTH transports; a throw sets loadError so the render shows a
+    // distinct "load failed" state (not a silent blank). Fallback-Path Logging: WARN, not debug — a
+    // blanked Vocabulary panel is invisible degradation (docs/error-handling.md).
+    const isElectron = typeof window !== 'undefined' && (window as any).electronAPI?.loadDictionary;
     try {
-      if (typeof window !== 'undefined' && (window as any).electronAPI?.loadDictionary) {
-        const data = await (window as any).electronAPI.loadDictionary();
-        setStandardized(data.standardized ?? []);
-        setColloquial(data.colloquial ?? []);
-        setLintResults(data.lintViolations ?? []);
-      } else {
-        // Web/fallback: load via bridge API
-        try {
-          const data = await bridgeGet<{ standardized?: StandardizedTerm[]; colloquial?: ColloquialTerm[]; lintViolations?: LintViolation[] }>('/api/dictionary');
-          setStandardized(data.standardized ?? []);
-          setColloquial(data.colloquial ?? []);
-          setLintResults(data.lintViolations ?? []);
-        } catch (err) {
-          // No dictionary API available — empty state
-          getGlobalRecorder()?.record({
-            type: 'system.error',
-            component: 'vocabulary-panel',
-            level: 'debug',
-            message: 'Dictionary API unavailable',
-            error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
-          });
-        }
-      }
+      const data = isElectron
+        ? await (window as any).electronAPI.loadDictionary()
+        : await bridgeGet<{ standardized?: StandardizedTerm[]; colloquial?: ColloquialTerm[]; lintViolations?: LintViolation[] }>('/api/dictionary');
+      setStandardized(data.standardized ?? []);
+      setColloquial(data.colloquial ?? []);
+      setLintResults(data.lintViolations ?? []);
+    } catch (err) {
+      setLoadError((err as Error).message || 'Unknown error');
+      getGlobalRecorder()?.record({
+        type: 'system.error',
+        component: 'vocabulary-panel',
+        level: 'warn',
+        message: `Dictionary load failed (${isElectron ? 'electron' : 'web'}) — panel shows load-error state`,
+        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+      });
     } finally {
       setLoading(false);
     }
@@ -109,6 +109,19 @@ export function VocabularyPanel() {
 
   if (loading) {
     return <div className="vocabulary-panel loading vocab-shared">Loading dictionary...</div>;
+  }
+
+  // t/3290: distinct load-FAILURE state (vs. a genuine empty result below) — never a silent blank.
+  if (loadError) {
+    return (
+      <div className="vocabulary-panel vocab-shared">
+        <div className="vocab-header"><h3>Vocabulary</h3></div>
+        <div className="empty-state vocab-load-error" role="alert">
+          <p>Couldn&apos;t load the dictionary — {loadError}.</p>
+          <button type="button" onClick={() => void loadDictionary()}>Retry</button>
+        </div>
+      </div>
+    );
   }
 
   return (
@@ -168,6 +181,13 @@ export function VocabularyPanel() {
       <div className="vocab-content">
         {activeTab === 'dictionary' && (
           <div className="vocab-list">
+            {filteredStandardized.length === 0 && (
+              <div className="empty-state">
+                {searchQuery || campFilter !== 'all' || statusFilter !== 'all'
+                  ? 'No terms match the current filters.'
+                  : 'No dictionary terms available.'}
+              </div>
+            )}
             {filteredStandardized.map(term => (
               <div
                 key={term.canonical_form}
@@ -276,6 +296,11 @@ export function VocabularyPanel() {
 
         {activeTab === 'colloquial' && (
           <div className="vocab-list">
+            {filteredColloquial.length === 0 && (
+              <div className="empty-state">
+                {searchQuery ? 'No colloquial terms match the current search.' : 'No colloquial terms available.'}
+              </div>
+            )}
             {filteredColloquial.map(term => (
               <div key={term.colloquial_term} className="vocab-entry colloquial-entry">
                 <div className="vocab-entry-header">


### PR DESCRIPTION
Owner reports the Vocabulary panel shows no concepts in **both Electron + web**; the data is healthy (54 `dictionary/standardized/*.json`), so it's a load/observability fault, not missing data. The panel silently blanked on failure with no way to tell "load failed" from "no terms".

## Panel — shared/VocabularyPanel.tsx + .css (AC #2, my scope)
- Track `loadError`; a throw from **either** transport now renders a distinct load-**FAILURE** state (message + Retry) — never a silent blank. Web catch bumped `debug`→**WARN** (Fallback-Path Logging).
- Genuine-empty results now show per-tab **empty-state** messages (Dictionary/Colloquial; Lint already had one).

## Electron handler — main/ipc/taxonomyHandlers.ts (AC #3) — ⚠ cross-scope (ElectronMain)
Mirrors the TL-blessed **t/3289** server WARN: `load-dictionary` now WARNs on a missing/empty `standardized`/`colloquial` dir with the discriminating cause (dir-missing vs empty-listing) **and the resolved `dataRoot`** — so the suspected Electron root cause (`getDataRootPath()` at GUI launch, env not inherited) is answerable next run. No happy-path change (still returns the 54 terms when present). **Trivial mirror of an approved pattern; holding this PR as draft for ElectronMain's ack on their file.**

## Diagnosis routing (root cause still needs a live run w/ these WARNs)
- **Electron:** → ElectronMain (getDataRootPath resolution / stale build).
- **Web:** → ServerAPI/CL (t/3289 added the server WARN; hypothesis = the 54 files are absent from the GitHub-backed store the server reads).

## Verify
eslint 0, renderer-tsc + main-tsc 0 in changed files, `VocabularyPanel.test.tsx` passes.

Self-cert /trivial-change (panel = UI/observability; handler = approved-pattern mirror).

Commit: 7aee7b98
