### PR TITLE
feat(main): fetch-relevant-nodes IPC handler + preload expose (t/3258)

### DIFF
--- a/taxonomy-editor/src/main/__tests__/saveEdges.test.ts
+++ b/taxonomy-editor/src/main/__tests__/saveEdges.test.ts
@@ -50,6 +50,10 @@ vi.mock('../fileIO.js', () => {
 
 vi.mock('../../server/storage/editMeta.js', () => ({ stampNodeAuthorship: (_old: unknown, next: unknown) => next }));
 
+// taxonomyHandlers now imports ../embeddings.js (for fetch-relevant-nodes); mock it so
+// embeddings.ts module-level ONNX/fileIO init doesn't run under vitest.
+vi.mock('../embeddings.js', () => ({ computeEmbeddings: vi.fn(), computeQueryEmbedding: vi.fn() }));
+
 // Imported AFTER the mocks so taxonomyHandlers binds the mocked deps.
 import { registerTaxonomyHandlers } from '../ipc/taxonomyHandlers.js';
 import { ActionableError } from '../../../../lib/debate/errors.js';

--- a/taxonomy-editor/src/main/ipc/taxonomyHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/taxonomyHandlers.ts
@@ -41,6 +41,14 @@ import { recordLockHolder } from '../../../../lib/debate/lockHolder.js';
 import { stampNodeAuthorship } from '../../server/storage/editMeta.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 import { VALID_POV } from '../ipcSchemas.js';
+import {
+  assembleNodeEmbeddings,
+  selectRelevantTaxonomy,
+  type ANClaimInput,
+  type SelectRelevantTaxonomyInput,
+} from '../../../../lib/debate/relevanceSelection.js';
+import { POVER_INFO } from '../../../../lib/debate/poverInfo.js';
+import { computeEmbeddings, computeQueryEmbedding } from '../embeddings.js';
 
 // Recorder-backed sink for the rationale re-merge's "baseline twin matched no incoming edge"
 // case: a real rationale isn't written, logged so a systematic tie-break mismatch is
@@ -461,5 +469,72 @@ export function registerTaxonomyHandlers(): void {
 
   ipcMain.handle('update-synthetic-embeddings', (_event, nodeId: string, pov: string, vectors: number[][]) => {
     updateSyntheticEmbeddings(nodeId, pov, vectors);
+  });
+
+  // t/3258 (T3): fetch-relevant-nodes — main-process mirror of server routes/relevantNodes.ts.
+  // Packaged Electron runs no embedded API server; the renderer reaches relevance selection via IPC.
+  // Logic is field-for-field identical to the server route (parity by construction — both invoke
+  // the same shared-lib assembleNodeEmbeddings + selectRelevantTaxonomy with ONNX embed cbs).
+  ipcMain.handle('fetch-relevant-nodes', async (_event, payload: unknown) => {
+    const POV_FILE_KEYS = new Set(['accelerationist', 'safetyist', 'skeptic']);
+    const b = (payload ?? {}) as {
+      pov: string;
+      topic: string;
+      recentTranscript: string;
+      threshold?: number;
+      session?: {
+        anClaimEmbeddings?: ANClaimInput[];
+        lineageFrame?: { cluster_id: string; label?: string }[];
+        sourceType?: string;
+        excludeGreatestHits?: boolean;
+        greatestHitsList?: string[];
+      };
+    };
+    const { pov, topic, recentTranscript } = b;
+    if (!POV_FILE_KEYS.has(pov)) throw new Error(`Invalid or missing pov (expected accelerationist|safetyist|skeptic), got: ${String(pov)}`);
+    if (typeof topic !== 'string' || typeof recentTranscript !== 'string') throw new Error('Missing topic/recentTranscript');
+
+    // Corpus embed cb — BATCH, mirrors the client's api.computeEmbeddings (t/3257#22).
+    const corpusEmbed = (texts: string[], ids?: string[]): Promise<number[][]> =>
+      computeEmbeddings(texts, ids);
+    // Boundary + topic-query embed cb — per-text, mirrors the client's api.computeQueryEmbedding.
+    const queryEmbed = (texts: string[]): Promise<number[][]> =>
+      Promise.all(texts.map(t => computeQueryEmbedding(t)));
+
+    const povFile = readTaxonomyFile(pov) as { nodes?: SelectRelevantTaxonomyInput['povNodes'] };
+    const povNodes = povFile?.nodes ?? [];
+    const sitFile = readTaxonomyFile('situations') as { nodes?: SelectRelevantTaxonomyInput['situationNodes'] };
+    const situationNodes = sitFile?.nodes ?? [];
+    const policyRaw = readPolicyRegistry() as { policies?: { id: string; action: string; source_povs?: string[] }[] } | null;
+    const policyRegistry = (policyRaw?.policies ?? []).map(p => ({ id: p.id, action: p.action, source_povs: p.source_povs }));
+    const lineageRaw = readLineageCategories() as { mapping?: Record<string, { l2: string }> } | null;
+    const lineageMapping = lineageRaw?.mapping;
+    const povInfo = Object.values(POVER_INFO).find(i => (i as { pov?: string }).pov === pov) as { doctrinal_boundaries?: string[] } | undefined;
+    const doctrinalBoundaries = (povInfo?.doctrinal_boundaries?.length ?? 0) > 0
+      ? { strings: povInfo!.doctrinal_boundaries ?? [] }
+      : undefined;
+
+    // Map loadSyntheticEmbeddings() ({pov,vectors}) → {nodeId: vectors[][]} for assembleNodeEmbeddings.
+    const synthRaw = loadSyntheticEmbeddings();
+    const synth: Record<string, number[][]> | null = synthRaw
+      ? Object.fromEntries(Object.entries(synthRaw).map(([id, e]) => [id, e.vectors]))
+      : null;
+
+    const { nodeEmbeddings } = await assembleNodeEmbeddings(pov, povNodes, situationNodes, corpusEmbed, synth);
+
+    const session = {
+      anClaimEmbeddings: b.session?.anClaimEmbeddings ?? [],
+      lineageFrame: b.session?.lineageFrame,
+      sourceType: b.session?.sourceType,
+      excludeGreatestHits: b.session?.excludeGreatestHits,
+      greatestHitsList: b.session?.greatestHitsList,
+    };
+
+    return selectRelevantTaxonomy({
+      povNodes, situationNodes, policyRegistry, nodeEmbeddings, lineageMapping, doctrinalBoundaries,
+      session,
+      params: { pov, topic, recentTranscript, threshold: b.threshold },
+      embed: queryEmbed,
+    });
   });
 }

--- a/taxonomy-editor/src/main/preload.cts
+++ b/taxonomy-editor/src/main/preload.cts
@@ -194,6 +194,9 @@ try {
   importKeysFromSharing: (payload: unknown, passphrase: string): Promise<string[]> =>
     ipcRenderer.invoke('import-keys-from-sharing', payload, passphrase),
 
+  fetchRelevantNodes: (payload: unknown): Promise<unknown> =>
+    ipcRenderer.invoke('fetch-relevant-nodes', payload),
+
   computeEmbeddings: (texts: string[], ids?: string[]): Promise<{ vectors: number[][] }> =>
     ipcRenderer.invoke('compute-embeddings', texts, ids),
 


### PR DESCRIPTION
## Summary

- Adds `ipcMain.handle("fetch-relevant-nodes", ...)` in `src/main/ipc/taxonomyHandlers.ts`
- Exposes `fetchRelevantNodes` on `window.electronAPI` in `src/main/preload.cts`

**Why:** Packaged Electron runs no embedded API server; the renderer cannot POST to `localhost`. This IPC handler is the Electron transport for the debate relevance-selection endpoint.

**Parity by construction:** mirrors `server/routes/relevantNodes.ts` field-for-field — same shared-lib `assembleNodeEmbeddings` + `selectRelevantTaxonomy`, same synthetic-vector mapping, same session fields. Embed cbs use main's ONNX `computeEmbeddings` / `computeQueryEmbedding` — identical vectors to the server path (t/3257#22).

**Must land together** with Rosetta Stone's renderer half (web-bridge/electron-bridge/client-swap + bridge/types.ts). Draft until joint merge.

## Test plan

- [ ] CI tsc/lint/appapi-completeness passes
- [ ] Joint merge with renderer half (Rosetta Stone coordinates)
- [ ] TL parity GV precedes flip merge (t/3258 gate)

Refs: t/3258, t/3257

🤖 Generated with [Claude Code](https://claude.com/claude-code)