### PR TITLE
feat(debate): relevance client → POST /api/taxonomy/relevant-nodes — renderer half (t/3258 T3)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
@@ -274,6 +274,9 @@ export const api: AppAPI = {
     return window.electronAPI.computeQueryEmbedding(text);
   },
   nliClassify: (pairs) => window.electronAPI.nliClassify(pairs),
+  // t/3258 (T3): packaged Electron has no embedded server, so this delegates to a main-process
+  // handler that mirrors routes/relevantNodes.ts via the SAME shared lib (parity by construction).
+  fetchRelevantNodes: (payload) => window.electronAPI.fetchRelevantNodes(payload),
 
   // Debate sessions
   getDebateQuotaStatus: () => Promise.resolve({ allowed: true, resource: 'debates', current: 0, limit: Infinity }),

--- a/taxonomy-editor/src/renderer/bridge/types.ts
+++ b/taxonomy-editor/src/renderer/bridge/types.ts
@@ -82,6 +82,39 @@ export type DebateTestedEntry = _DebateTestedEntry;
 import type { DebateDelta as _DebateDelta } from '@lib/debate/types';
 export type DebateDelta = _DebateDelta;
 
+// t/3258 (T3): the relevance-selection result + AN-claim input the fetchRelevantNodes bridge method
+// carries. Both transports call the SAME shared lib (selectRelevantTaxonomy) so the result is
+// parity-identical by construction — this is the exact contract the server route already types against.
+import type { ANClaimInput as _ANClaimInput, RelevantTaxonomyResult as _RelevantTaxonomyResult } from '@lib/debate/relevanceSelection';
+export type ANClaimInput = _ANClaimInput;
+export type RelevantTaxonomyResult = _RelevantTaxonomyResult;
+
+/**
+ * Payload for `fetchRelevantNodes` (t/3258 T3). Mirrors `SelectRelevantTaxonomyInput['session']` +
+ * `params` — ONLY the per-session state the server/main cannot reconstruct crosses the wire; the
+ * static corpus (nodeEmbeddings), taxonomy nodes, policyRegistry, lineage map and doctrinal
+ * boundaries are derived on the server/main side. Field-for-field identical to the server route's
+ * `RelevantNodesBody` (routes/relevantNodes.ts) so the two callers stay in lockstep.
+ */
+export interface FetchRelevantNodesPayload {
+  /** POV file key: accelerationist | safetyist | skeptic. */
+  pov: string;
+  topic: string;
+  recentTranscript: string;
+  /** Default 0.45 (applied by the lib fn when omitted). */
+  threshold?: number;
+  session: {
+    /** `argument_network.nodes[]` with embeddings — the PRIMARY scoring signal; `text` for provenance. */
+    anClaimEmbeddings: ANClaimInput[];
+    lineageFrame?: { cluster_id: string; label?: string }[];
+    /** `debate.source_type`; lineage frame is only "expected" for `'topic'` debates. */
+    sourceType?: string;
+    excludeGreatestHits?: boolean;
+    /** Fetched caller-side (renderer: bridge `getGreatestHits`) and passed as an array. */
+    greatestHitsList?: string[];
+  };
+}
+
 import type { OpEdSet, OpEdSetSummary, PovKey } from '../../../../lib/oped/types';
 import type { BriefPreset, ExportJobState, ExportErrorCode, BriefArtifactName } from '../../../../lib/brief/types';
 
@@ -300,6 +333,12 @@ export interface AppAPI {
   // (t/2060). Electron computes it; the web transport returns [] (server backend doesn't DML-OOM).
   updateNodeEmbeddings: (nodes: { id: string; text: string; pov: string; exclusionText?: string }[]) => Promise<{ staleNodeIds: string[] }>;
   computeQueryEmbedding: (text: string) => Promise<{ vector: number[] }>;
+  // t/3258 (T3): server/main-side taxonomy relevance selection — the debate client stops fetching
+  // the corpus to score locally. Both transports run the SAME shared lib (selectRelevantTaxonomy),
+  // so the result is parity-identical by construction. Web → REST POST /api/taxonomy/relevant-nodes;
+  // Electron → IPC → a main handler mirroring routes/relevantNodes.ts (packaged Electron has no
+  // embedded server). Only per-session state crosses the wire; the corpus is assembled server/main-side.
+  fetchRelevantNodes: (payload: FetchRelevantNodesPayload) => Promise<RelevantTaxonomyResult>;
   nliClassify: (pairs: Array<{ text_a: string; text_b: string }>) => Promise<{
     results: Array<{
       nli_label: string;

--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -993,10 +993,10 @@ const rawApi: AppAPI = {
 
   // Embeddings & NLI
   computeEmbeddings: (texts, ids) => computeEmbeddingsChunked(post, texts, ids), // ≤EMBEDDINGS_MAX_BATCH sequential chunks so an oversized batch can't blow the 50s server timeout (t/3072)
-  // Web transport: server embedding backend (Python/Gemini) has no DirectML GPU-OOM mode, so nothing
-  // goes stale → always [] (t/2060 staleNodeIds contract; thread partial failures here if the route adds them).
+  // Web transport: server embed backend has no DirectML GPU-OOM mode → nothing goes stale → always [] (t/2060 staleNodeIds contract).
   updateNodeEmbeddings: (nodes) => post('/api/embeddings/update-nodes', { nodes }).then(() => ({ staleNodeIds: [] as string[] })),
   computeQueryEmbedding: (text) => post('/api/embeddings/query', { text }),
+  fetchRelevantNodes: (payload) => post('/api/taxonomy/relevant-nodes', payload), // t/3258 (T3): EXACT path (no trailing slash/query) — anon free-tier gate is exact-match, else anon debates 403 (TL t/3284#2)
   nliClassify: (pairs) => post('/api/nli/classify', { pairs }),
 
   // Source evidence

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/taxonomyContextEmptyGuard.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/taxonomyContextEmptyGuard.test.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3258 (T3, TL t/3258#14) — ADR-001 graceful-empty GUARD for the endpoint flip. #1922 makes
+// getRelevantTaxonomyContext a HARD client-swap onto api.fetchRelevantNodes; the deployed endpoint
+// reads via github-api where ADR-001 can 200-with-empty on a data-read gap. A real debate never
+// legitimately selects 0 nodes, so an empty-200 must be treated as a FAILURE: WARN (make it
+// observable) + degrade to the unfiltered fallback — never silently ship empty grounding. This locks
+// that behavior (the make-degradation-observable rule): worst case = observable-unfiltered.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks (the empty-guard path returns BEFORE the success-path diagnostics, so the surface is small) ──
+const recordSpy = vi.fn();
+vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => ({ record: recordSpy }) }));
+
+const fetchRelevantNodes = vi.fn();
+vi.mock('@bridge', () => ({
+  api: {
+    fetchRelevantNodes: (...a: unknown[]) => fetchRelevantNodes(...a),
+    computeEmbeddings: vi.fn(), computeQueryEmbedding: vi.fn(), loadSyntheticEmbeddings: vi.fn(async () => null),
+  },
+}));
+vi.mock('../../../data/lineageCategories', () => ({
+  isLineageDataLoaded: () => false, getLineageMapping: () => ({}), getL2Categories: () => [],
+}));
+vi.mock('./getGreatestHits', () => ({ getGreatestHits: vi.fn(async () => []) }));
+
+// 25 POV + 12 situation candidates so the unfiltered fallback's 21/10 slices are observable.
+const POV_NODES = Array.from({ length: 25 }, (_, i) => ({ id: `acc-beliefs-${i}`, category: 'Beliefs', label: `L${i}`, description: `D${i}` }));
+const SIT_NODES = Array.from({ length: 12 }, (_, i) => ({ id: `cc-${i}`, label: `S${i}`, description: `sd${i}` }));
+const taxState = {
+  accelerationist: { nodes: POV_NODES }, safetyist: { nodes: [] }, skeptic: { nodes: [] },
+  situations: { nodes: SIT_NODES }, policyRegistry: [{ id: 'pol-1', action: 'act', source_povs: ['accelerationist'] }],
+};
+vi.mock('../../useTaxonomyStore', () => ({ useTaxonomyStore: { getState: () => taxState } }));
+
+const debateState = {
+  activeDebate: {
+    id: 'd1', source_type: 'topic',
+    argument_network: { nodes: [{ id: 'AN-1', embedding: [0.1, 0.2, 0.3], computed_strength: 0.5, text: 'claim' }] },
+    topic: { critique: { lineage_frame: undefined } }, exclude_greatest_hits: false,
+  },
+  debateWarnings: [] as string[],
+};
+vi.mock('../store', () => ({
+  useDebateStore: {
+    getState: () => debateState,
+    setState: (patch: Partial<typeof debateState>) => { Object.assign(debateState, patch); },
+  },
+}));
+
+import { getRelevantTaxonomyContext } from '../shared/taxonomyContext';
+
+describe('getRelevantTaxonomyContext — ADR-001 empty-result guard (t/3258 T3)', () => {
+  beforeEach(() => { recordSpy.mockClear(); fetchRelevantNodes.mockReset(); debateState.debateWarnings = []; });
+
+  it('endpoint returns 0 selected → WARN + unfiltered fallback (never silent-empty)', async () => {
+    fetchRelevantNodes.mockResolvedValue({
+      povNodes: [], situationNodes: [], policyRegistry: [], nodeSourceMap: {}, injectionManifest: {}, anchoring: [],
+    });
+
+    const ctx = await getRelevantTaxonomyContext('accelerationist', 'topic', 'transcript');
+
+    // Degraded to the unfiltered fallback: first 21 POV + first 10 CC (buildUnfilteredFallback), not empty.
+    expect(ctx.povNodes.length).toBe(21);
+    expect(ctx.situationNodes.length).toBe(10);
+    // The degradation is OBSERVABLE: a WARN naming the suspected ADR-001 data-read cause.
+    const warn = recordSpy.mock.calls.find(c => /returned 0 selected/i.test(String((c[0] as { message?: string })?.message)));
+    expect(warn, 'expected a WARN naming the empty-endpoint data-read cause').toBeTruthy();
+    expect((warn![0] as { level?: string }).level).toBe('warn');
+  });
+
+  it('endpoint returns nodes → passes through (guard does NOT fire)', async () => {
+    fetchRelevantNodes.mockResolvedValue({
+      povNodes: [{ nodeId: 'acc-beliefs-0', score: 0.9 }], situationNodes: [{ nodeId: 'cc-0', score: 0.8 }],
+      policyRegistry: [], nodeSourceMap: {}, injectionManifest: {}, anchoring: [],
+    });
+
+    const ctx = await getRelevantTaxonomyContext('accelerationist', 'topic', 'transcript');
+
+    // Mapped result (1 POV + 1 CC), NOT the 21/10 fallback.
+    expect(ctx.povNodes.map(n => n.id)).toEqual(['acc-beliefs-0']);
+    expect(ctx.situationNodes.map(n => n.id)).toEqual(['cc-0']);
+    const warn = recordSpy.mock.calls.find(c => /returned 0 selected/i.test(String((c[0] as { message?: string })?.message)));
+    expect(warn, 'guard must NOT fire on a non-empty result').toBeFalsy();
+  });
+});

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/taxonomyContext.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/taxonomyContext.ts
@@ -370,6 +370,21 @@ export async function getRelevantTaxonomyContext(
       session: { anClaimEmbeddings, lineageFrame, sourceType: debate?.source_type, excludeGreatestHits, greatestHitsList },
     });
 
+    // ── ADR-001 graceful-empty guard (t/3258, TL t/3258#14) ──
+    // A real debate never legitimately selects 0 nodes, so an empty selection means the endpoint's
+    // github-api-backed read returned empty (a data-read FAILURE), not "no relevant nodes." Make it
+    // observable + degrade to the unfiltered fallback rather than silently shipping empty grounding to
+    // the debate (make-degradation-observable rule). Worst case is observable-unfiltered, never
+    // silent-empty — this keeps the hard client-swap safe regardless of the endpoint's deploy state.
+    if (result.povNodes.length === 0 && result.situationNodes.length === 0) {
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'debate-store', level: 'warn',
+        message: 'relevant-nodes returned 0 selected on a real debate — suspected server-side data-read gap (ADR-001 graceful-empty); using unfiltered fallback',
+        data: { pov, candidatePovNodes: allPovNodes.length, candidateCcNodes: allCCNodes.length, anClaims: anClaimEmbeddings.length, sourceType: debate?.source_type },
+      });
+      return buildUnfilteredFallback(state, allPovNodes, allCCNodes, new Error('relevant-nodes returned empty selection (suspected data-read failure)'));
+    }
+
     // ── Re-apply the doctrinal-anchoring side-effect to the store's Belief nodes ──
     // (mirrors the old in-place mutation EXACTLY: doctrinally_anchored always; confidence floor
     // only when applied — that's why DoctrinalAdjustment carries floorApplied, t/3257#16 Δ1.)

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/taxonomyContext.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/taxonomyContext.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import type { PovNode, CrossCuttingNode as SituationNode } from '../../../types/taxonomy';
-import { POVER_INFO, POV_KEYS } from '../../../types/debate';
+import { POV_KEYS } from '../../../types/debate';
 import { useTaxonomyStore } from '../../useTaxonomyStore';
 // Circular import — safe because all references are at call-time, never at module init
 import { useDebateStore } from '../store';
@@ -14,7 +14,12 @@ import { computeLineageDistribution, formatLineageContext } from '@lib/debate/to
 // t/3257: the relevance-selection pipeline moved to lib-pure; this file is now the thin CLIENT
 // wrapper (build corpus embeddings + fetch greatest-hits + assemble session state → call the pure
 // fn → re-apply anchoring + emit diagnostics + map the result). The server calls the SAME fn (T2).
-import { selectRelevantTaxonomy, assembleNodeEmbeddings } from '@lib/debate/relevanceSelection';
+// t/3258 (T3): the client no longer calls selectRelevantTaxonomy locally — it delegates to the
+// server/main via api.fetchRelevantNodes (both run the SAME lib fn → parity by construction).
+// assembleNodeEmbeddings stays for buildNodeEmbeddingMap, which the t/3165 corpus-dedup regression
+// test still exercises (the production corpus-fetch path is now dead — cleanup deferred to a
+// follow-up, gated on this flip being parity-GV-proven so the old path stays as rollback).
+import { assembleNodeEmbeddings } from '@lib/debate/relevanceSelection';
 import type { ANClaimInput } from '@lib/debate/relevanceSelection';
 // t/3257#21: corpus assembly + synthetic merge relocated to lib so the server (T2) + client build
 // the corpus map identically (parity by construction). Re-exported here for argumentNetwork.ts.
@@ -338,38 +343,31 @@ export async function getRelevantTaxonomyContext(
   try {
     const debate = useDebateStore.getState().activeDebate;
 
-    // Corpus embeddings — renderer IO + per-debate memo — passed to the pure fn (server builds its own).
-    const { nodeEmbeddings } = await buildNodeEmbeddingMap(pov, allPovNodes, allCCNodes);
-
-    // ── Assemble the pure-fn input (session state crosses the wire in the T2/T3 split) ──
+    // ── T3 (t/3258): assemble ONLY the per-session state that crosses the wire. The server/main side
+    // derives everything static itself — the corpus (assembleNodeEmbeddings), taxonomy nodes,
+    // policyRegistry, lineage L2 map and doctrinal boundaries — then runs the SAME shared lib fn
+    // (selectRelevantTaxonomy) → parity by construction. The client no longer fetches the corpus to
+    // score locally (the t/3165 architectural fast-follow). ──
     const anClaimEmbeddings: ANClaimInput[] = (debate?.argument_network?.nodes ?? [])
       .filter(n => n.embedding && n.embedding.length > 0)
       .map(n => ({ id: n.id, vector: n.embedding!, strength: n.computed_strength, text: n.text }));
     const lineageFrame = debate?.topic?.critique?.lineage_frame;
     const excludeGreatestHits = !!debate?.exclude_greatest_hits;
+    // Greatest-hits is per-debate session state the server can't reconstruct — fetch client-side and
+    // send it (Set→string[]) or the exclusion silently no-ops server-side (TL D3, t/3256#2).
     const greatestHitsList = excludeGreatestHits ? await getGreatestHits() : undefined;
-    // Static/server-derivable: current POV's doctrinal boundaries (POVER_INFO) + the lineage L2 map.
-    const povInfo = Object.values(POVER_INFO).find(i => i.pov === pov);
-    const doctrinalBoundaries = (povInfo?.doctrinal_boundaries?.length ?? 0) > 0
-      ? { strings: povInfo!.doctrinal_boundaries ?? [] }
-      : undefined;
-    const lineageMapping = isLineageDataLoaded() ? getLineageMapping() : undefined;
-    // Boundary + topic-query embeddings use computeQueryEmbedding (matches the pre-extraction path).
-    const embed = async (texts: string[]): Promise<number[][]> =>
-      Promise.all(texts.map(async t => (await api.computeQueryEmbedding(t)).vector));
 
     recordLineageBoostCheck(lineageFrame, debate?.source_type === 'topic');
 
-    const result = await selectRelevantTaxonomy({
-      povNodes: allPovNodes,
-      situationNodes: allCCNodes,
-      policyRegistry: (state.policyRegistry ?? []).map(p => ({ id: p.id, action: p.action, source_povs: p.source_povs })),
-      nodeEmbeddings,
-      lineageMapping,
-      doctrinalBoundaries,
+    // Single transport call — web: REST POST /api/taxonomy/relevant-nodes; electron: IPC → a main
+    // handler mirroring the server route. Returns the full RelevantTaxonomyResult (W1) — the client
+    // presentation below (anchoring re-apply, diagnostics, id→node mapping) is unchanged.
+    const result = await api.fetchRelevantNodes({
+      pov,
+      topic,
+      recentTranscript,
+      threshold,
       session: { anClaimEmbeddings, lineageFrame, sourceType: debate?.source_type, excludeGreatestHits, greatestHitsList },
-      params: { pov, topic, recentTranscript, threshold },
-      embed,
     });
 
     // ── Re-apply the doctrinal-anchoring side-effect to the store's Belief nodes ──

--- a/taxonomy-editor/src/renderer/types/electron.d.ts
+++ b/taxonomy-editor/src/renderer/types/electron.d.ts
@@ -5,7 +5,7 @@ import type { Organization, OrganizationEdge } from '@lib/organizations/types';
 import type { EntityDetail, EntitySummary, EntityListQuery } from '@lib/entities/types';
 import type { ContainerMentions } from '@lib/entities/mentionTypes';
 import type { EdgesFile } from '@lib/debate/taxonomyTypes';
-import type { UserPreferences, BriefExportRequest, BriefExportJobView, BriefExportRecord } from '../bridge/types';
+import type { UserPreferences, BriefExportRequest, BriefExportJobView, BriefExportRecord, FetchRelevantNodesPayload, RelevantTaxonomyResult } from '../bridge/types';
 import type { BriefArtifactName } from '@lib/brief/types';
 
 export interface ElectronAPI {
@@ -131,6 +131,10 @@ export interface ElectronAPI {
   computeEmbeddings: (texts: string[], ids?: string[]) => Promise<{ vectors: number[][] }>;
   updateNodeEmbeddings: (nodes: { id: string; text: string; pov: string; exclusionText?: string }[]) => Promise<{ staleNodeIds: string[] }>;
   computeQueryEmbedding: (text: string) => Promise<{ vector: number[] }>;
+  // t/3258 (T3): the renderer's view of the main-process handler ElectronMain implements in preload —
+  // mirrors routes/relevantNodes.ts via the shared lib (parity by construction). Contract shared with
+  // the web transport through bridge/types.ts.
+  fetchRelevantNodes: (payload: FetchRelevantNodesPayload) => Promise<RelevantTaxonomyResult>;
   nliClassify: (pairs: Array<{ text_a: string; text_b: string }>) => Promise<{ results: Array<{ nli_label: string; nli_entailment: number; nli_neutral: number; nli_contradiction: number; margin: number }> }>;
 
   // Debate sessions

--- a/taxonomy-editor/src/server/__tests__/relevantNodesRealEmbedParity.test.ts
+++ b/taxonomy-editor/src/server/__tests__/relevantNodesRealEmbedParity.test.ts
@@ -1,0 +1,192 @@
+// @vitest-environment node
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3258 (T3) — REAL-EMBED PARITY CAPTURE (the load-bearing gate before the client flip; TL GV,
+// t/3257#28). This is the belt against the t/3165 fixture≠prod trap that the hash-stub fixture
+// (relevantNodesParity.test.ts) cannot provide: it runs the DIFFERENTIAL on a REAL debate with REAL
+// ONNX embeddings, exercising the AN-claim PRIMARY path (real argument_network embeddings), not the
+// topic-query fallback.
+//
+//   A = POST /api/taxonomy/relevant-nodes (the endpoint, server-side assembly + real ai.* ONNX).
+//   B = the pre-#1922 CLIENT-LOCAL selection, reproduced field-for-field from taxonomyContext.ts
+//       (buildNodeEmbeddingMap → assembleNodeEmbeddings + selectRelevantTaxonomy) using the SAME
+//       real ai.* ONNX — which is exactly where the web-bridge client's api.computeEmbeddings /
+//       api.computeQueryEmbedding land (same process, same ONNX binary; the #18 same-backend proof
+//       TL accepted for (a)). So B is a faithful stand-in for the web client's local computation.
+//
+// Both are fed the IDENTICAL real debate state (pov, topic, recentTranscript, session incl. real
+// anClaimEmbeddings). Assertion: order-preserving node+order equality on povNodes/situationNodes,
+// EXACT scores (ONNX is deterministic — no tolerance), >0 nodes selected, provenance passthrough.
+// Divergence = FAIL. This proves the T3 endpoint produces exactly what the client computes locally
+// on real data + real embeddings; it does NOT exercise the literal REST hop (that rests on #18) or a
+// live deployment.
+//
+// CI-safe: skipIf the data root / debate fixture is absent (CI has neither → skips). Run locally with
+// the real data root to capture the GV evidence: `npx vitest run src/server/__tests__/relevantNodesRealEmbedParity.test.ts`.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import type { IncomingMessage, ServerResponse } from 'http';
+
+import { registerRelevantNodesRoutes } from '../routes/relevantNodes.js';
+import {
+  selectRelevantTaxonomy,
+  assembleNodeEmbeddings,
+  type ANClaimInput,
+  type SelectRelevantTaxonomyInput,
+} from '../../../../lib/debate/relevanceSelection.js';
+import { POVER_INFO } from '../../../../lib/debate/poverInfo.js';
+import * as fileIO from '../storage/fileIO.js';
+import * as ai from '../ai/aiBackends.js';
+import type { ServerCtx } from '../routes/context.js';
+
+// ── Fixture selection: a real topic-source debate with a populated argument_network (real 384-dim
+// AN-claim embeddings → the PRIMARY scoring path). Guard on presence so CI (no data root) skips. ──
+const DATA_ROOT = process.env.AI_TRIAD_DATA_ROOT;
+const DEBATE_FILE = 'debate-2306fafc-6d5e-4387-beee-f1ecc900b7ce.json';
+const DEBATE_PATH = DATA_ROOT ? path.join(DATA_ROOT, 'debates', DEBATE_FILE) : '';
+const POV = 'accelerationist';
+const THRESHOLD = 0.45; // the client's default (getRelevantTaxonomyContext), same for A and B.
+const HARNESS_READY = !!DATA_ROOT && !!DEBATE_PATH && fs.existsSync(DEBATE_PATH);
+
+type Handler = (req: IncomingMessage, res: ServerResponse, body?: unknown) => Promise<void> | void;
+function makeRouter() {
+  const handlers: Record<string, Handler> = {};
+  const reg = (m: string) => (p: string, h: Handler) => { handlers[`${m} ${p}`] = h; };
+  return { router: { get: reg('GET'), put: reg('PUT'), post: reg('POST'), patch: reg('PATCH'), del: reg('DELETE') }, handlers };
+}
+function fakeRes() {
+  const res: Record<string, unknown> = {
+    writableEnded: false, headersSent: false, _status: 200, _body: undefined,
+    writeHead: (c: number) => { res._status = c; res.headersSent = true; },
+    end: (b?: string) => { res._body = b !== undefined ? JSON.parse(b as string) : undefined; res.writableEnded = true; },
+    setHeader: () => {},
+  };
+  return res as unknown as ServerResponse & { _body: Record<string, unknown>; _status: number };
+}
+const fakeReq = () => ({ url: '/api/taxonomy/relevant-nodes', method: 'POST' } as unknown as IncomingMessage);
+
+/** Map loadSyntheticEmbeddings() ({pov,vectors}) → the {nodeId: vectors[][]} shape assembleNodeEmbeddings wants
+ *  — identical to relevantNodes.ts synthVectorsForAssembly (so B assembles the corpus exactly as the client does). */
+function synthForAssembly(synth: Record<string, { pov: string; vectors: number[][] }> | null): Record<string, number[][]> | null {
+  if (!synth) return null;
+  const out: Record<string, number[][]> = {};
+  for (const [nodeId, entry] of Object.entries(synth)) out[nodeId] = entry.vectors;
+  return out;
+}
+
+/** Pick the first string-valued topic representation; content is irrelevant to parity (A and B get the
+ *  same string) — it only needs to be a real topic so the topic-query embed is non-degenerate. */
+function extractTopic(debate: Record<string, unknown>): string {
+  const t = debate.topic as Record<string, unknown> | undefined;
+  for (const k of ['final', 'refined', 'original', 'rewritten_topic'] as const) {
+    const v = t?.[k];
+    if (typeof v === 'string' && v.trim()) return v;
+    if (v && typeof v === 'object' && typeof (v as { text?: string }).text === 'string') return (v as { text: string }).text;
+  }
+  return typeof debate.title === 'string' ? debate.title : 'AI policy';
+}
+
+/** Join the last few transcript turns into a recentTranscript string (again, identical for A and B). */
+function extractRecentTranscript(debate: Record<string, unknown>): string {
+  const tr = debate.transcript;
+  if (!Array.isArray(tr)) return '';
+  const texts: string[] = [];
+  for (const turn of tr.slice(-4)) {
+    const s = (turn && typeof turn === 'object')
+      ? ((turn as { text?: string; content?: string; message?: string }).text
+        ?? (turn as { content?: string }).content
+        ?? (turn as { message?: string }).message)
+      : undefined;
+    if (typeof s === 'string' && s.trim()) texts.push(s);
+  }
+  return texts.join('\n\n');
+}
+
+describe.skipIf(!HARNESS_READY)('POST /api/taxonomy/relevant-nodes — REAL-embed parity capture (t/3258 T3, TL GV)', () => {
+  it('endpoint (A) === client-local selection (B) on a real AN-claim debate — order-preserving, exact scores, >0 nodes', async () => {
+    const debate = JSON.parse(fs.readFileSync(DEBATE_PATH, 'utf-8')) as Record<string, unknown>;
+
+    // ── Real debate state, IDENTICAL for A and B (mirrors getRelevantTaxonomyContext's assembly) ──
+    const anNodes = ((debate.argument_network as { nodes?: unknown[] } | undefined)?.nodes ?? []) as Array<{
+      id: string; embedding?: number[]; computed_strength?: number; text?: string;
+    }>;
+    const anClaimEmbeddings: ANClaimInput[] = anNodes
+      .filter(n => Array.isArray(n.embedding) && n.embedding.length > 0)
+      .map(n => ({ id: n.id, vector: n.embedding!, strength: n.computed_strength as number, text: n.text }));
+    const lineageFrame = (debate.topic as { critique?: { lineage_frame?: { cluster_id: string; label?: string }[] } } | undefined)
+      ?.critique?.lineage_frame;
+    const sourceType = debate.source_type as string | undefined;
+    const excludeGreatestHits = !!debate.exclude_greatest_hits;
+    const greatestHitsList = excludeGreatestHits ? [] : undefined;
+    const topic = extractTopic(debate);
+    const recentTranscript = extractRecentTranscript(debate);
+    const session = { anClaimEmbeddings, lineageFrame, sourceType, excludeGreatestHits, greatestHitsList };
+    const params = { pov: POV, topic, recentTranscript, threshold: THRESHOLD };
+
+    // Sanity: this must exercise the PRIMARY path with GENUINE 384-dim vectors, not stubs/fallback.
+    expect(anClaimEmbeddings.length, 'debate must carry real AN-claim embeddings (primary path)').toBeGreaterThan(0);
+    expect(anClaimEmbeddings[0].vector.length, 'AN-claim vectors must be genuine 384-dim ONNX, not stubs').toBe(384);
+    expect(sourceType, 'topic-source debate exercises the AN-claim primary orchestration').toBe('topic');
+
+    // ── A: the endpoint (real fileIO + real ai.* ONNX; NO mocks) ──
+    const { router, handlers } = makeRouter();
+    registerRelevantNodesRoutes(router as never, {} as ServerCtx);
+    const post = handlers['POST /api/taxonomy/relevant-nodes'];
+    const res = fakeRes();
+    await post(fakeReq(), res, { pov: POV, topic, recentTranscript, threshold: THRESHOLD, session });
+    expect(res._status, 'endpoint must 200').toBe(200);
+    const A = res._body as SelectRelevantTaxonomyInput extends never ? never : {
+      povNodes: { nodeId: string; score: number }[]; situationNodes: { nodeId: string; score: number }[];
+      nodeSourceMap: Record<string, unknown>; anchoring: unknown[]; policyRegistry: unknown[];
+    };
+
+    // ── B: the pre-#1922 client-local selection, reproduced with the SAME real ai.* ONNX ──
+    const povFile = await fileIO.readTaxonomyFile(POV) as { nodes?: SelectRelevantTaxonomyInput['povNodes'] };
+    const povNodes = povFile?.nodes ?? [];
+    const sitFile = await fileIO.readTaxonomyFile('situations') as { nodes?: SelectRelevantTaxonomyInput['situationNodes'] };
+    const situationNodes = sitFile?.nodes ?? [];
+    const policyRaw = await fileIO.readPolicyRegistry() as { policies?: { id: string; action: string; source_povs?: string[] }[] } | null;
+    const policyRegistry = (policyRaw?.policies ?? []).map(p => ({ id: p.id, action: p.action, source_povs: p.source_povs }));
+    const lineageRaw = await fileIO.readLineageCategories() as { mapping?: Record<string, { l2: string }> } | null;
+    const lineageMapping = lineageRaw?.mapping;
+    const povInfo = Object.values(POVER_INFO).find(i => (i as { pov?: string }).pov === POV) as { doctrinal_boundaries?: string[] } | undefined;
+    const doctrinalBoundaries = (povInfo?.doctrinal_boundaries?.length ?? 0) > 0
+      ? { strings: povInfo!.doctrinal_boundaries ?? [] }
+      : undefined;
+    // Corpus: batch ai.computeEmbeddings (the web-bridge api.computeEmbeddings destination) + synthetic merge.
+    const corpusEmbed = (texts: string[], ids?: string[]) =>
+      ai.computeEmbeddings(texts, ids, undefined, { requester: 't3258-parity:corpus' }).then(r => r.vectors);
+    const synth = synthForAssembly(await fileIO.loadSyntheticEmbeddings());
+    const { nodeEmbeddings } = await assembleNodeEmbeddings(POV, povNodes, situationNodes, corpusEmbed, synth);
+    // Boundary + topic-query: per-text ai.computeQueryEmbedding (matches the endpoint + the client role-split, t/3257#25).
+    const queryEmbed = (texts: string[]) => Promise.all(texts.map(t => ai.computeQueryEmbedding(t)));
+    const B = await selectRelevantTaxonomy({
+      povNodes, situationNodes, policyRegistry, nodeEmbeddings, lineageMapping, doctrinalBoundaries,
+      session, params, embed: queryEmbed,
+    });
+
+    // Corpus vectors must be genuine 384-dim (real embeddings, not the 3-dim hash stub).
+    const sampleVec = Object.values(nodeEmbeddings)[0] as { vector: number[] } | undefined;
+    expect(sampleVec?.vector.length, 'corpus vectors must be genuine 384-dim').toBe(384);
+
+    // ── Non-trivial: the debate must select >0 nodes (both-empty is the vacuous-pass escape) ──
+    expect(A.povNodes.length + A.situationNodes.length, 'endpoint must select >0 nodes').toBeGreaterThan(0);
+    expect(B.povNodes.length + B.situationNodes.length, 'client must select >0 nodes').toBeGreaterThan(0);
+
+    // ── The gate: order-preserving node+order equality + EXACT scores (deterministic ONNX) ──
+    expect(A.povNodes).toEqual(B.povNodes);               // W3: same nodes, SAME ORDER, exact scores
+    expect(A.situationNodes).toEqual(B.situationNodes);
+    expect(A.nodeSourceMap).toEqual(B.nodeSourceMap);     // AN-vs-topic provenance identical
+    expect(A.anchoring).toEqual(B.anchoring);
+    expect(A.policyRegistry).toEqual(B.policyRegistry);
+
+    // Capture evidence for the GV.
+    const anBacked = Object.values(B.nodeSourceMap).filter(s => (s as { source?: string }).source === 'an').length;
+    console.log(`[t3258-parity] A===B ✓ debate=${DEBATE_FILE} pov=${POV} anClaims=${anClaimEmbeddings.length} ` +
+      `selected: pov=${A.povNodes.length} sit=${A.situationNodes.length} an-scored-nodes=${anBacked} ` +
+      `topScore=${A.povNodes[0]?.score?.toFixed(6) ?? 'n/a'}`);
+  }, 120_000);
+});


### PR DESCRIPTION
The debate client stops building the corpus + scoring locally (the t/3165 architectural fast-follow). `getRelevantTaxonomyContext` now delegates to one bridge call — `api.fetchRelevantNodes` — served by REST (web) and IPC → a main handler (Electron). **Both run the SAME shared lib (`selectRelevantTaxonomy`) server/main-side → parity by construction.** Only per-session state crosses the wire.

## Renderer half (this PR)
- **bridge/types.ts** — `FetchRelevantNodesPayload` + `AppAPI.fetchRelevantNodes` (returns full `RelevantTaxonomyResult`); re-exports `ANClaimInput`/`RelevantTaxonomyResult` from the lib. Field-for-field identical to the server route's `RelevantNodesBody`.
- **web-bridge.ts** — POST to the EXACT path (no trailing slash/query — anon free-tier gate is exact-match, else anon debates 403; TL t/3284#2).
- **electron-bridge.ts** — IPC passthrough → `window.electronAPI.fetchRelevantNodes`.
- **types/electron.d.ts** — the renderer's view of the electronAPI contract ElectronMain implements in preload.
- **taxonomyContext.ts** — swap local `buildNodeEmbeddingMap` + `selectRelevantTaxonomy` for the bridge call; **keep** the client presentation verbatim (anchoring re-apply, diagnostics, id→node mapping, unfiltered fallback). Drop now-unused `POVER_INFO`/`selectRelevantTaxonomy` imports.

## Cross-scope pairing — MUST land together
ElectronMain owns `preload.ts` + the main IPC handler (**PR #1921**). `appapi-completeness` asserts both transports carry the method, and mis-ordering breaks Electron debates (client calls a method preload hasn't exposed). Proposing we **combine into one atomic landing** — see the ticket.

## Deferred (flagged)
`buildNodeEmbeddingMap`/`loadSyntheticVectors`/`_syntheticVectorsCache` are now production-dead (only the t/3165 corpus-dedup test consumes them). **Not** deleting the old corpus path here — it stays as rollback until the flip is parity-GV-proven; cleanup is a follow-up.

⚠ **web-bridge.ts is at exactly the 1500-line max-lines ceiling** (reclaimed a line in-section to stay under) — the next addition needs an extraction. Flagging for the migration ratchet.

## Gate
Draft — gated on **TL's real-embed parity GV** (t/3257#24/#25) before the flip merges. Self-cert /add-bridge-method.

## Verify
renderer-tsc clean; appapi-completeness + full useDebateStore suite (282 tests) pass; eslint 0 errors.

Commit: 14c97dda