### PR TITLE
fix(settings): clamp Help dialog to viewport on center + taller default

### DIFF
--- a/taxonomy-editor/src/renderer/components/settings/HelpDialog.css
+++ b/taxonomy-editor/src/renderer/components/settings/HelpDialog.css
@@ -94,9 +94,9 @@
 .helpdialog-version-badge { font-size: 0.8rem; padding: 2px 8px; border-radius: 4px; background: var(--focus-ring); color: #fff; }
 
 .helpdialog-dialog {
-  max-width: none; max-height: none;
+  max-width: none !important; max-height: none !important; min-width: 0 !important;
   display: flex; flex-direction: column; overflow: visible;
-  position: fixed; margin: 0;
+  position: fixed; margin: 0; box-sizing: border-box;
 }
 .helpdialog-title { margin: 0 0 12px; cursor: move; user-select: none; }
 .helpdialog-body { display: flex; gap: 0; flex: 1; min-height: 0; overflow: hidden; }
@@ -125,7 +125,7 @@
 .helpdialog-tab-nav { border-left: 2px solid transparent; color: var(--text-secondary); }
 .helpdialog-tab-nav:hover { color: var(--text-primary); }
 
-.helpdialog-resize-e { position: absolute; right: 0; top: 0; width: 8px; height: 100%; cursor: ew-resize; z-index: 10; }
-.helpdialog-resize-s { position: absolute; bottom: -4px; left: 0; width: 100%; height: 14px; cursor: ns-resize; z-index: 10; }
-.helpdialog-resize-se { position: absolute; right: -4px; bottom: -4px; width: 20px; height: 20px; cursor: nwse-resize; opacity: 0.4; z-index: 11; }
+.helpdialog-resize-e { position: absolute; right: -8px; top: 0; width: 16px; height: 100%; cursor: ew-resize; z-index: 10; pointer-events: auto; }
+.helpdialog-resize-s { position: absolute; bottom: -8px; left: 0; width: 100%; height: 16px; cursor: ns-resize; z-index: 10; pointer-events: auto; }
+.helpdialog-resize-se { position: absolute; right: -8px; bottom: -8px; width: 16px; height: 16px; cursor: nwse-resize; opacity: 0.6; z-index: 11; pointer-events: auto; }
 .helpdialog-resize-icon { display: block; }

--- a/taxonomy-editor/src/renderer/components/settings/HelpDialog.tsx
+++ b/taxonomy-editor/src/renderer/components/settings/HelpDialog.tsx
@@ -358,16 +358,23 @@ export function HelpDialog({ onClose, initialTab }: HelpDialogProps) {
   const [showSupportForm, setShowSupportForm] = useState(false);
   const { unreadCount, fetchCases: fetchSupportCases } = useSupportStore();
   const [pos, setPos] = useState({ x: 0, y: 0 });
-  const [size, setSize] = useState({ w: 900, h: 520 });
+  const [size, setSize] = useState({ w: 900, h: 600 });
   const [centered, setCentered] = useState(true);
   const dialogRef = useRef<HTMLDivElement>(null);
   const dragging = useRef<{ startX: number; startY: number; origX: number; origY: number } | null>(null);
   const resizing = useRef<{ startX: number; startY: number; origW: number; origH: number } | null>(null);
 
-  // Center on first render
+  // Center on first render with viewport bounds checking
   useEffect(() => {
     if (centered) {
-      setPos({ x: (window.innerWidth - size.w) / 2, y: (window.innerHeight - size.h) / 2 });
+      const maxW = Math.max(400, window.innerWidth * 0.95);
+      const maxH = Math.max(300, window.innerHeight * 0.95);
+      const clampedW = Math.min(size.w, maxW);
+      const clampedH = Math.min(size.h, maxH);
+      const x = Math.max(0, (window.innerWidth - clampedW) / 2);
+      const y = Math.max(0, (window.innerHeight - clampedH) / 2);
+      setSize({ w: clampedW, h: clampedH });
+      setPos({ x, y });
     }
   }, [centered, size.w, size.h]);
 


### PR DESCRIPTION
Help dialog could render partly off-screen on small viewports. On center it now clamps width/height to 95% of the viewport (floors 400x300) and pins x/y >= 0; default height 520->600.

- `HelpDialog.tsx`: viewport-bounds clamping in the center effect + taller default size.
- `HelpDialog.css`: accompanying style tweaks (10 lines).

PI (jpsnover) UI change; pushed via a worktree branch per the shared-tree convention (edits were on the shared main checkout). Owner: Settings/Rosetta — routine UI-only change, review + CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)