### PR TITLE
fix(devops): deploy-drift-check self-ensures the deploy-drift label (t/3278)

### DIFF
--- a/.github/workflows/deploy-drift-check.yml
+++ b/.github/workflows/deploy-drift-check.yml
@@ -120,6 +120,11 @@ jobs:
           AGE_HOURS: ${{ steps.inputs.outputs.age_hours }}
         run: |
           set -uo pipefail
+          # Self-ensure the label exists — a MISSING `deploy-drift` label silently broke the FIRE
+          # arm: `gh issue create --label` errored, so the gate fired (red job) but never opened the
+          # human-reaching issue (t/3278 live-fire finding). --force is idempotent; keep the gate's
+          # signal self-contained rather than depending on an out-of-band repo-config prereq.
+          gh label create "$DRIFT_LABEL" --color B60205 --description 'Prod deploy drift alert (t/3278 deploy-drift-check)' --force >/dev/null 2>&1 || true
           TITLE='⚠️ Prod deploy drift: running image is behind main'
           EXISTING=$(gh issue list --label "$DRIFT_LABEL" --state open --json number --jq '.[0].number // empty')
 


### PR DESCRIPTION
Fast-follow fix for **t/3278**, surfaced by live fire-arm validation.

## Bug (caught live)
Forcing the drift-check's FIRE arm (`threshold_hours=1` vs the real ~9h prod-vs-main lag, after Jeffrey's deploy) showed: the gate fired (red job, exit 1) but its issue **never opened** — `gh issue create --label deploy-drift` errored with `could not add label: 'deploy-drift' not found`. The label was never created in the repo, so the fire arm's **human-reaching signal was silently broken** (the exact "silent-by-another-name" failure the gate exists to prevent).

## Fix
- **Immediate (out-of-band):** created the `deploy-drift` label → re-forced the fire → issue #1924 opened correctly (verified, then closed as a test-fire).
- **This PR (durable):** the workflow now **self-ensures** the label (`gh label create "$DRIFT_LABEL" --force`, idempotent) before the issue block — so the fire signal is self-contained and can't rebreak if the label is ever deleted.

## t/3278 validation status (both non-null arms now proven live)
- **Silent/within-threshold:** running `buildSha=4760f2c81` read non-null, age 9h < N=24h → `Fire=False` (correct, no issue).
- **Fire:** forced N=1h → age 9h > 1h → `Fire=True` → issue opens (post-fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)