### PR TITLE
feat(main): fail loud on missing/empty data root sentinels at startup (t/3296)

### DIFF
--- a/taxonomy-editor/src/main/__tests__/validateDataRoot.test.ts
+++ b/taxonomy-editor/src/main/__tests__/validateDataRoot.test.ts
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+
+/**
+ * t/3296: validateDataRoot() in fileIO.ts must throw ActionableError when the
+ * resolved data root lacks the expected sentinel directories (taxonomy/,
+ * dictionary/), naming the resolved path and resolution method so the fix is
+ * one glance. Prevention for the t/3290 silent-empty-panels incident.
+ *
+ * Strategy: mock electron + heavy deps so fileIO.ts loads under vitest, then
+ * spy on fs.existsSync to control which sentinel dirs "exist" per test.
+ * AI_TRIAD_DATA_ROOT env var controls the data root (highest priority path,
+ * cleanest way to inject a known root without touching config files).
+ */
+
+vi.mock('electron', () => ({
+  app: { isPackaged: false, getAppPath: () => '/fake/app', getPath: () => '/fake/home' },
+}));
+
+vi.mock('../../../lib/electron-shared/resolveRepoRootForApp.js', () => ({
+  resolveRepoRootForApp: () => '/fake/root',
+}));
+
+vi.mock('../../../lib/debate/persistence.js', () => ({ renameSyncWithRetry: vi.fn() }));
+vi.mock('../../../lib/debate/lockHolder.js', () => ({ recordLockHolder: vi.fn() }));
+vi.mock('../../../lib/flight-recorder/index.js', () => ({ getGlobalRecorder: () => null, setGlobalRecorder: vi.fn(), RECORDER_CAPACITY_SECONDARY: 256 }));
+vi.mock('../../../lib/npy.js', () => ({ parseNpy: vi.fn(), extractNodeVectors: vi.fn() }));
+vi.mock('../../../lib/electron-shared/safeId.js', () => ({ assertSafeId: vi.fn() }));
+vi.mock('../../../lib/edges/serializeEdges.js', () => ({ serializeEdgesJson: vi.fn() }));
+
+import { validateDataRoot } from '../fileIO.js';
+import { ActionableError } from '../../../../lib/debate/errors.js';
+
+const DATA_ROOT = '/test-data-root';
+
+beforeEach(() => {
+  process.env.AI_TRIAD_DATA_ROOT = DATA_ROOT;
+});
+
+afterEach(() => {
+  delete process.env.AI_TRIAD_DATA_ROOT;
+  vi.restoreAllMocks();
+});
+
+describe('validateDataRoot (t/3296)', () => {
+  it('passes when both taxonomy/ and dictionary/ exist', () => {
+    vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
+      const s = String(p);
+      return s.endsWith('taxonomy') || s.endsWith('dictionary');
+    });
+    expect(() => validateDataRoot()).not.toThrow();
+  });
+
+  it('throws ActionableError when taxonomy/ is missing', () => {
+    vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
+      return String(p).endsWith('dictionary');
+    });
+    expect(() => validateDataRoot()).toThrow(ActionableError);
+  });
+
+  it('throws ActionableError when dictionary/ is missing', () => {
+    vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
+      return String(p).endsWith('taxonomy');
+    });
+    expect(() => validateDataRoot()).toThrow(ActionableError);
+  });
+
+  it('throws ActionableError when both sentinel dirs are missing', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    expect(() => validateDataRoot()).toThrow(ActionableError);
+  });
+
+  it('throws ActionableError when taxonomy/ exists but is empty (same silent-degradation class as absent)', () => {
+    vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
+      const s = String(p);
+      return s.endsWith('taxonomy') || s.endsWith('dictionary');
+    });
+    vi.spyOn(fs, 'readdirSync').mockImplementation((p) => {
+      // taxonomy/ is empty, dictionary/ has content
+      return (String(p).endsWith('taxonomy') ? [] : ['somefile.json']) as unknown as fs.Dirent[];
+    });
+    expect(() => validateDataRoot()).toThrow(ActionableError);
+  });
+
+  it('error names the resolved data root path', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    let err: ActionableError | undefined;
+    try { validateDataRoot(); } catch (e) { err = e as ActionableError; }
+    expect(err).toBeInstanceOf(ActionableError);
+    expect(err!.problem).toContain(DATA_ROOT);
+  });
+
+  it('error names AI_TRIAD_DATA_ROOT as resolution method when env var is set', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    let err: ActionableError | undefined;
+    try { validateDataRoot(); } catch (e) { err = e as ActionableError; }
+    expect(err!.problem).toContain('AI_TRIAD_DATA_ROOT env var');
+  });
+
+  it('error names .aitriad.json as resolution method when env var is absent but config file exists', () => {
+    delete process.env.AI_TRIAD_DATA_ROOT;
+    vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
+      // Config file exists; sentinel dirs do not
+      return String(p).endsWith('.aitriad.json');
+    });
+    let err: ActionableError | undefined;
+    try { validateDataRoot(); } catch (e) { err = e as ActionableError; }
+    expect(err).toBeInstanceOf(ActionableError);
+    expect(err!.problem).toContain('.aitriad.json');
+  });
+
+  it('error names PROJECT_ROOT fallback when no env var and no config file', () => {
+    delete process.env.AI_TRIAD_DATA_ROOT;
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    let err: ActionableError | undefined;
+    try { validateDataRoot(); } catch (e) { err = e as ActionableError; }
+    expect(err).toBeInstanceOf(ActionableError);
+    expect(err!.problem).toContain('PROJECT_ROOT fallback');
+  });
+});

--- a/taxonomy-editor/src/main/__tests__/validateDataRoot.test.ts
+++ b/taxonomy-editor/src/main/__tests__/validateDataRoot.test.ts
@@ -7,13 +7,12 @@ import fs from 'fs';
 /**
  * t/3296: validateDataRoot() in fileIO.ts must throw ActionableError when the
  * resolved data root lacks the expected sentinel directories (taxonomy/,
- * dictionary/), naming the resolved path and resolution method so the fix is
- * one glance. Prevention for the t/3290 silent-empty-panels incident.
+ * dictionary/) — either absent (ENOENT) or empty (0 entries). Names the resolved
+ * path and resolution method so the fix is one glance. Prevention for t/3290.
  *
- * Strategy: mock electron + heavy deps so fileIO.ts loads under vitest, then
- * spy on fs.existsSync to control which sentinel dirs "exist" per test.
- * AI_TRIAD_DATA_ROOT env var controls the data root (highest priority path,
- * cleanest way to inject a known root without touching config files).
+ * Implementation uses readdirSync + ENOENT catch (mirrors server fs convention).
+ * Tests spy on readdirSync to control per-path counts; existsSync is only spied
+ * for the method-detection (.aitriad.json presence) tests.
  */
 
 vi.mock('electron', () => ({
@@ -36,6 +35,18 @@ import { ActionableError } from '../../../../lib/debate/errors.js';
 
 const DATA_ROOT = '/test-data-root';
 
+/** Stub readdirSync: return non-empty for listed dirs, ENOENT for everything else. */
+function stubReaddirSync(presentDirs: string[]): void {
+  vi.spyOn(fs, 'readdirSync').mockImplementation((p) => {
+    const s = String(p);
+    if (presentDirs.some(d => s.endsWith(d))) {
+      return ['somefile.json'] as unknown as fs.Dirent[];
+    }
+    const err = Object.assign(new Error(`ENOENT: no such file or directory, scandir '${s}'`), { code: 'ENOENT' });
+    throw err;
+  });
+}
+
 beforeEach(() => {
   process.env.AI_TRIAD_DATA_ROOT = DATA_ROOT;
 });
@@ -46,47 +57,39 @@ afterEach(() => {
 });
 
 describe('validateDataRoot (t/3296)', () => {
-  it('passes when both taxonomy/ and dictionary/ exist', () => {
-    vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
-      const s = String(p);
-      return s.endsWith('taxonomy') || s.endsWith('dictionary');
-    });
+  it('passes when both taxonomy/ and dictionary/ are non-empty', () => {
+    stubReaddirSync(['taxonomy', 'dictionary']);
     expect(() => validateDataRoot()).not.toThrow();
   });
 
-  it('throws ActionableError when taxonomy/ is missing', () => {
-    vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
-      return String(p).endsWith('dictionary');
-    });
+  it('throws ActionableError when taxonomy/ is absent (ENOENT)', () => {
+    stubReaddirSync(['dictionary']);
     expect(() => validateDataRoot()).toThrow(ActionableError);
   });
 
-  it('throws ActionableError when dictionary/ is missing', () => {
-    vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
-      return String(p).endsWith('taxonomy');
-    });
+  it('throws ActionableError when dictionary/ is absent (ENOENT)', () => {
+    stubReaddirSync(['taxonomy']);
     expect(() => validateDataRoot()).toThrow(ActionableError);
   });
 
-  it('throws ActionableError when both sentinel dirs are missing', () => {
-    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+  it('throws ActionableError when both sentinels are absent', () => {
+    stubReaddirSync([]);
     expect(() => validateDataRoot()).toThrow(ActionableError);
   });
 
   it('throws ActionableError when taxonomy/ exists but is empty (same silent-degradation class as absent)', () => {
-    vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
-      const s = String(p);
-      return s.endsWith('taxonomy') || s.endsWith('dictionary');
-    });
     vi.spyOn(fs, 'readdirSync').mockImplementation((p) => {
-      // taxonomy/ is empty, dictionary/ has content
-      return (String(p).endsWith('taxonomy') ? [] : ['somefile.json']) as unknown as fs.Dirent[];
+      const s = String(p);
+      if (s.endsWith('dictionary')) return ['somefile.json'] as unknown as fs.Dirent[];
+      if (s.endsWith('taxonomy')) return [] as unknown as fs.Dirent[];
+      const err = Object.assign(new Error(`ENOENT: ${s}`), { code: 'ENOENT' });
+      throw err;
     });
     expect(() => validateDataRoot()).toThrow(ActionableError);
   });
 
   it('error names the resolved data root path', () => {
-    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    stubReaddirSync([]);
     let err: ActionableError | undefined;
     try { validateDataRoot(); } catch (e) { err = e as ActionableError; }
     expect(err).toBeInstanceOf(ActionableError);
@@ -94,7 +97,7 @@ describe('validateDataRoot (t/3296)', () => {
   });
 
   it('error names AI_TRIAD_DATA_ROOT as resolution method when env var is set', () => {
-    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    stubReaddirSync([]);
     let err: ActionableError | undefined;
     try { validateDataRoot(); } catch (e) { err = e as ActionableError; }
     expect(err!.problem).toContain('AI_TRIAD_DATA_ROOT env var');
@@ -102,10 +105,9 @@ describe('validateDataRoot (t/3296)', () => {
 
   it('error names .aitriad.json as resolution method when env var is absent but config file exists', () => {
     delete process.env.AI_TRIAD_DATA_ROOT;
-    vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
-      // Config file exists; sentinel dirs do not
-      return String(p).endsWith('.aitriad.json');
-    });
+    // existsSync: .aitriad.json present; readdirSync: sentinels absent
+    vi.spyOn(fs, 'existsSync').mockImplementation((p) => String(p).endsWith('.aitriad.json'));
+    stubReaddirSync([]);
     let err: ActionableError | undefined;
     try { validateDataRoot(); } catch (e) { err = e as ActionableError; }
     expect(err).toBeInstanceOf(ActionableError);
@@ -115,6 +117,7 @@ describe('validateDataRoot (t/3296)', () => {
   it('error names PROJECT_ROOT fallback when no env var and no config file', () => {
     delete process.env.AI_TRIAD_DATA_ROOT;
     vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    stubReaddirSync([]);
     let err: ActionableError | undefined;
     try { validateDataRoot(); } catch (e) { err = e as ActionableError; }
     expect(err).toBeInstanceOf(ActionableError);

--- a/taxonomy-editor/src/main/fileIO.ts
+++ b/taxonomy-editor/src/main/fileIO.ts
@@ -159,6 +159,7 @@ export function validateDataRoot(): void {
     try {
       entryCount = fs.readdirSync(fullPath).length;
     } catch (fsErr) {
+      /* telemetry — silent by design: ENOENT is immediately surfaced as ActionableError below */
       if ((fsErr as NodeJS.ErrnoException).code === 'ENOENT') {
         entryCount = 0;
       } else {

--- a/taxonomy-editor/src/main/fileIO.ts
+++ b/taxonomy-editor/src/main/fileIO.ts
@@ -123,6 +123,55 @@ export function getDataRootPath(): string {
   return resolveDataPath('.');
 }
 
+/**
+ * Validate the resolved data root at startup. Throws ActionableError when the
+ * expected top-level sentinel directories (taxonomy/, dictionary/) are absent,
+ * naming the resolved path and how it was resolved so the fix is one glance.
+ * Call this before opening the main window so mis-provisioned installs fail loud
+ * instead of showing silent-empty panels (t/3296, prevention for t/3290).
+ */
+export function validateDataRoot(): void {
+  const config = loadDataConfig();
+  const envRoot = process.env.AI_TRIAD_DATA_ROOT;
+  const dataRoot = envRoot
+    ? path.resolve(envRoot)
+    : path.isAbsolute(config.data_root)
+      ? config.data_root
+      : path.resolve(PROJECT_ROOT, config.data_root);
+
+  let method: string;
+  if (envRoot) {
+    method = 'AI_TRIAD_DATA_ROOT env var';
+  } else if (fs.existsSync(path.join(PROJECT_ROOT, '.aitriad.json'))) {
+    method = '.aitriad.json data_root field';
+  } else if (IS_PACKAGED) {
+    method = 'packaged-app platform default (no .aitriad.json override)';
+  } else {
+    method = 'PROJECT_ROOT fallback (dev mode, no .aitriad.json found)';
+  }
+
+  const REQUIRED_DIRS = ['taxonomy', 'dictionary'] as const;
+  for (const dir of REQUIRED_DIRS) {
+    const fullPath = path.join(dataRoot, dir);
+    // Check exists AND non-empty — an empty directory is the same silent-degradation
+    // class as a missing one (every read returns empty, no error) (t/3296).
+    const isEmpty = !fs.existsSync(fullPath) || fs.readdirSync(fullPath).length === 0;
+    if (isEmpty) {
+      throw new ActionableError({
+        goal: 'Load application data',
+        problem: `Data root resolved to "${dataRoot}" (via ${method}) but "${dir}/" is missing or empty`,
+        location: 'main/fileIO.ts → validateDataRoot',
+        nextSteps: [
+          `Set AI_TRIAD_DATA_ROOT to your ai-triad-data clone root (e.g. set AI_TRIAD_DATA_ROOT=C:\\path\\to\\ai-triad-data)`,
+          `Or update "data_root" in ${path.join(PROJECT_ROOT, '.aitriad.json')} to point at the data repo`,
+          `Confirm the ai-triad-data repo is cloned and the path is correct: ${dataRoot}`,
+          `Expected top-level directories inside the data root: ${REQUIRED_DIRS.map(d => d + '/').join(', ')}`,
+        ],
+      });
+    }
+  }
+}
+
 /** Persist a new data_root into .aitriad.json. Caller should relaunch the app afterward. */
 export function setDataRootPath(newRoot: string): void {
   const configPath = path.join(PROJECT_ROOT, '.aitriad.json');

--- a/taxonomy-editor/src/main/fileIO.ts
+++ b/taxonomy-editor/src/main/fileIO.ts
@@ -153,10 +153,19 @@ export function validateDataRoot(): void {
   const REQUIRED_DIRS = ['taxonomy', 'dictionary'] as const;
   for (const dir of REQUIRED_DIRS) {
     const fullPath = path.join(dataRoot, dir);
-    // Check exists AND non-empty — an empty directory is the same silent-degradation
-    // class as a missing one (every read returns empty, no error) (t/3296).
-    const isEmpty = !fs.existsSync(fullPath) || fs.readdirSync(fullPath).length === 0;
-    if (isEmpty) {
+    // Use readdirSync directly — ENOENT = definitive absent (same ActionableError class as empty).
+    // Mirrors the server fs convention; eliminates the TOCTOU gap between existsSync + readdirSync.
+    let entryCount: number;
+    try {
+      entryCount = fs.readdirSync(fullPath).length;
+    } catch (fsErr) {
+      if ((fsErr as NodeJS.ErrnoException).code === 'ENOENT') {
+        entryCount = 0;
+      } else {
+        throw fsErr;
+      }
+    }
+    if (entryCount === 0) {
       throw new ActionableError({
         goal: 'Load application data',
         problem: `Data root resolved to "${dataRoot}" (via ${method}) but "${dir}/" is missing or empty`,

--- a/taxonomy-editor/src/main/main.ts
+++ b/taxonomy-editor/src/main/main.ts
@@ -134,6 +134,14 @@ function createWindow(): void {
     validateDataRoot();
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'main-process', level: 'error',
+      message: 'data-root validation failed at startup',
+      error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+    });
+    // console.error is load-bearing here: getGlobalRecorder() may be uninit this early
+    // (t/3110 sink trap) and app.quit() drains the ring buffer — this is the real stdout signal.
+    console.error('[main] Data root validation failed:', msg);
     dialog.showErrorBox('Data root not found', msg);
     app.quit();
     return;

--- a/taxonomy-editor/src/main/main.ts
+++ b/taxonomy-editor/src/main/main.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 console.log('[main] === STARTUP BEGIN ===');
-import { app, BrowserWindow, ipcMain, Menu, screen, shell } from 'electron';
+import { app, BrowserWindow, dialog, ipcMain, Menu, screen, shell } from 'electron';
 import fs from 'fs';
 import http from 'http';
 import path from 'path';
@@ -20,7 +20,7 @@ import { registerTerminalHandlers, cleanupTerminal } from './terminal.js';
 console.log('[main] terminal import OK');
 import { warmupEmbeddingModel } from './embeddings.js';
 console.log('[main] embeddings import OK');
-import { PROJECT_ROOT } from './fileIO.js';
+import { PROJECT_ROOT, validateDataRoot } from './fileIO.js';
 console.log('[main] fileIO import OK');
 import { registerChatWindowHandlers } from './ipc/chatWindowHandlers.js';
 
@@ -128,6 +128,17 @@ function hardenWindow(win: BrowserWindow): void {
 }
 
 function createWindow(): void {
+  // Fail loud if the data root is mis-provisioned so the user sees an actionable
+  // error dialog instead of silent-empty panels (t/3296, prevention for t/3290).
+  try {
+    validateDataRoot();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    dialog.showErrorBox('Data root not found', msg);
+    app.quit();
+    return;
+  }
+
   const preloadPath = path.join(__dirname, 'preload.cjs');
   console.log('[main] preload path:', preloadPath);
   console.log('[main] app.isPackaged:', app.isPackaged);


### PR DESCRIPTION
## Summary

- Adds `validateDataRoot()` to `fileIO.ts`: checks `taxonomy/` and `dictionary/` under the resolved data root are present **and non-empty** (an empty dir is the same silent-degradation class as absent per TL ruling)
- Names the resolved path + resolution method (env var / `.aitriad.json` / fallback) in the `ActionableError` so the fix is one glance
- Wires into `createWindow()` in `main.ts` via try/catch → `dialog.showErrorBox()` + `app.quit()` — shows a clear native dialog before any window opens
- Adds 8-case `validateDataRoot.test.ts` covering pass, missing/empty sentinels, and all resolution-method labels

**Prevention for t/3290** (silent-empty-panels incident; failure class: silent-fallback/invisible-degradation). TL-approved design at t/3296#1.

**Note:** ServerAPI half (hosted path, GitHub API check — no fs.existsSync) goes to Main (TL) for separate review per TL ruling.

## Test plan

- [ ] CI tsc/lint/vitest passes
- [ ] Manual: launch app with `AI_TRIAD_DATA_ROOT` pointing at an empty dir → error dialog appears, app exits cleanly
- [ ] Manual: launch app with correct data root → no change in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)