### PR TITLE
feat(storage): opedRunStore.ts — blob-backed shared run-control (t/2893)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/opedRunStore.test.ts
+++ b/taxonomy-editor/src/server/__tests__/opedRunStore.test.ts
@@ -1,0 +1,181 @@
+// @vitest-environment node
+// Tests for opedRunStore.ts — t/2893 (blob-backed shared run-control)
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import path from 'path';
+
+// ── Hoisted mock backend ──────────────────────────────────────────────────────
+
+const { _store, mockBackend } = vi.hoisted(() => {
+  // Normalize any path separator to '/' for cross-platform mock consistency.
+  const norm = (p: string) => p.replace(/\\/g, '/');
+  const _store = new Map<string, string>();
+  const readFile = vi.fn(async (p: string) => _store.get(norm(p)) ?? null);
+  const writeFile = vi.fn(async (p: string, c: string) => { _store.set(norm(p), c); });
+  const deleteFile = vi.fn(async (p: string) => { _store.delete(norm(p)); });
+  const listDirectory = vi.fn(async (dir: string) => {
+    const nd = norm(dir);
+    const prefix = nd.endsWith('/') ? nd : nd + '/';
+    return [..._store.keys()]
+      .filter(k => k.startsWith(prefix))
+      .map(k => k.slice(prefix.length).split('/')[0])
+      .filter((v, i, a) => a.indexOf(v) === i);
+  });
+  const fileExists = vi.fn(async (p: string) => _store.has(p));
+  const mockBackend = {
+    readFile, writeFile, deleteFile, listDirectory, fileExists,
+    readBinaryFile: vi.fn(), writeBinaryFile: vi.fn(),
+  };
+  return { _store, mockBackend };
+});
+
+// ── Module mocks ─────────────────────────────────────────────────────────────
+
+vi.mock('../config.js', () => ({
+  resolveDataPath: (rel: string) => `/data/${rel}`,
+  getDataRoot: () => '/data',
+}));
+
+vi.mock('../logger.js', () => ({
+  log: { server: { info: vi.fn(), warn: vi.fn() } },
+}));
+
+const mockIsAnonymousUser = vi.fn(() => false);
+const mockGetStorageUserId = vi.fn(() => 'user-abc');
+
+vi.mock('../security/userContext.js', () => ({
+  isAnonymousUser: () => mockIsAnonymousUser(),
+  getStorageUserId: () => mockGetStorageUserId(),
+}));
+
+vi.mock('../storage/fileIO.js', () => ({
+  getUserContentBackend: () => mockBackend,
+  assertSafeId: (value: string, label: string) => {
+    if (!value || !/^[a-zA-Z0-9_-]+$/.test(value))
+      throw Object.assign(new Error(`Invalid ${label}: "${value}"`), { statusCode: 400 });
+  },
+}));
+
+import {
+  upsertOpedRun,
+  countRunningOpedRuns,
+  getOpedRun,
+  type RunControlRecord,
+} from '../storage/opedRunStore.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeRecord(overrides: Partial<RunControlRecord> = {}): RunControlRecord {
+  return {
+    runId: 'run-001',
+    userId: 'user-abc',
+    setId: 'set-001',
+    status: 'running',
+    perVoice: { acc: 'pending' },
+    startedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  _store.clear();
+  vi.clearAllMocks();
+  mockIsAnonymousUser.mockReturnValue(false);
+  mockGetStorageUserId.mockReturnValue('user-abc');
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('upsertOpedRun', () => {
+  it('writes the blob with the correct path and JSON content', async () => {
+    const record = makeRecord();
+    await upsertOpedRun(record);
+
+    expect(mockBackend.writeFile).toHaveBeenCalledOnce();
+    const [calledPath, calledContent] = mockBackend.writeFile.mock.calls[0];
+    const expectedPath = path.join('/data', 'users', 'user-abc', 'oped-runs', 'oped-run-run-001.json');
+    expect(calledPath).toBe(expectedPath);
+    const parsed = JSON.parse(calledContent);
+    expect(parsed).toEqual(record);
+  });
+
+  it('is a no-op for anonymous users', async () => {
+    mockIsAnonymousUser.mockReturnValue(true);
+    await upsertOpedRun(makeRecord());
+    expect(mockBackend.writeFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('countRunningOpedRuns', () => {
+  it('returns 1 for a single fresh running blob', async () => {
+    const record = makeRecord({ startedAt: Date.now() });
+    await upsertOpedRun(record);
+
+    const count = await countRunningOpedRuns('user-abc');
+    expect(count).toBe(1);
+  });
+
+  it('counts fresh running blob but not stale running blob (both arms)', async () => {
+    // Fresh running blob
+    const fresh = makeRecord({ runId: 'run-fresh', startedAt: Date.now() });
+    await upsertOpedRun(fresh);
+
+    // Stale running blob — started 20 min ago (beyond 15 min TTL)
+    const stale = makeRecord({ runId: 'run-stale', startedAt: Date.now() - 20 * 60_000 });
+    await upsertOpedRun(stale);
+
+    // Verify both blobs exist before counting
+    expect(_store.size).toBe(2);
+
+    const count = await countRunningOpedRuns('user-abc');
+
+    // Fresh blob counted; stale blob not counted
+    expect(count).toBe(1);
+
+    // Stale blob deleted lazily (fire-and-forget — wait a tick)
+    await new Promise(resolve => setTimeout(resolve, 0));
+    const staleKey = '/data/users/user-abc/oped-runs/oped-run-run-stale.json';
+    expect(_store.has(staleKey)).toBe(false);
+  });
+
+  it('does not count terminal states (complete/cancelled/error)', async () => {
+    await upsertOpedRun(makeRecord({ runId: 'run-complete', status: 'complete' }));
+    await upsertOpedRun(makeRecord({ runId: 'run-cancelled', status: 'cancelled' }));
+    await upsertOpedRun(makeRecord({ runId: 'run-error', status: 'error' }));
+
+    const count = await countRunningOpedRuns('user-abc');
+    expect(count).toBe(0);
+  });
+
+  it('returns 0 for anonymous users', async () => {
+    mockIsAnonymousUser.mockReturnValue(true);
+    const count = await countRunningOpedRuns('user-abc');
+    expect(count).toBe(0);
+  });
+
+  it('returns 0 when directory is empty', async () => {
+    const count = await countRunningOpedRuns('user-abc');
+    expect(count).toBe(0);
+  });
+});
+
+describe('getOpedRun', () => {
+  it('returns the parsed record when it exists', async () => {
+    const record = makeRecord({ status: 'complete' });
+    await upsertOpedRun(record);
+
+    const result = await getOpedRun('run-001');
+    expect(result).toEqual(record);
+  });
+
+  it('returns null when the file does not exist', async () => {
+    const result = await getOpedRun('run-missing');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when user context is unavailable', async () => {
+    mockGetStorageUserId.mockReturnValue(null as unknown as string);
+    const result = await getOpedRun('run-001');
+    expect(result).toBeNull();
+  });
+});

--- a/taxonomy-editor/src/server/storage/fileIO.ts
+++ b/taxonomy-editor/src/server/storage/fileIO.ts
@@ -36,6 +36,8 @@ export * from './calibrationStore.js';
 export * from './urlFetch.js';
 export type { OpEdSetSummary } from '../../../../lib/oped/types.js';
 export { listOpedSets, loadOpedSet, saveOpedSetInProgress, loadOpedSetInProgress, finalizeOpedSet, deleteOpedSet, getOpedSetsQuotaStatus } from './opedStore.js';
+export { upsertOpedRun, countRunningOpedRuns, getOpedRun } from './opedRunStore.js';
+export type { RunControlRecord, RunStatus, VoiceState as OpedVoiceState } from './opedRunStore.js';
 // ── Backend injection ──
 
 // Taxonomy / conflicts / calibration / summaries / sources use `backend`.

--- a/taxonomy-editor/src/server/storage/opedRunStore.ts
+++ b/taxonomy-editor/src/server/storage/opedRunStore.ts
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * Op-ed run-control persistence — blob-backed shared store for SSE run records.
+ *
+ * Replaces the per-process `Map<string, OpEdRun>` in routes/oped.ts so that
+ * run state survives across replicas (maxReplicas>1). Re-exported from fileIO.ts.
+ *
+ * Design: authed-only (anonymous path unreachable in hosted mode — double-gated
+ * by allowlist + explicit isAnonymousUser()→403 in oped.ts). Guard retained here
+ * for defence-in-depth.
+ *
+ * Lazy TTL expiry: countRunningOpedRuns deletes stale 'running' blobs (crashed-A
+ * protection) best-effort/fire-and-forget so the count cap is self-healing.
+ */
+
+import path from 'path';
+import { resolveDataPath } from '../config.js';
+import { getUserContentBackend, assertSafeId } from './fileIO.js';
+import { isAnonymousUser, getStorageUserId } from '../security/userContext.js';
+import { log } from '../logger.js';
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+export type RunStatus = 'running' | 'complete' | 'cancelled' | 'error';
+export type VoiceState = 'pending' | 'complete' | 'failed' | 'cancelled';
+
+export interface RunControlRecord {
+  runId: string;
+  userId: string;
+  setId: string;
+  status: RunStatus;
+  perVoice: Record<string, VoiceState>;
+  startedAt: number;
+}
+
+// ── Constants ──────────────────────────────────────────────────────────────────
+
+/** Hard ceiling for a stuck 'running' blob — lazy-expire after this TTL. */
+const RUNNING_STALE_TTL_MS = 15 * 60_000; // 15 min
+
+// ── Dir helper ─────────────────────────────────────────────────────────────────
+
+function getOpedRunsDir(userId: string): string {
+  if (userId === '_local') return resolveDataPath('oped-runs');
+  return resolveDataPath(`users/${userId}/oped-runs`);
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────────
+
+/**
+ * Write or overwrite the run-control blob for this run.
+ * No-op for anonymous users (guard for defence-in-depth; callers are authed-only).
+ */
+export async function upsertOpedRun(record: RunControlRecord): Promise<void> {
+  if (isAnonymousUser()) return;
+  assertSafeId(record.runId, 'oped-run id');
+  const backend = getUserContentBackend();
+  const filePath = path.join(getOpedRunsDir(record.userId), `oped-run-${record.runId}.json`);
+  await backend.writeFile(filePath, JSON.stringify(record, null, 2));
+}
+
+/**
+ * Count running op-ed runs for userId.
+ * Lazy-expires stale 'running' blobs (crashed-A protection) — best-effort delete,
+ * stale blobs are not counted toward the cap.
+ * Returns 0 for anonymous users.
+ */
+export async function countRunningOpedRuns(userId: string): Promise<number> {
+  if (isAnonymousUser()) return 0;
+  const backend = getUserContentBackend();
+  const dir = getOpedRunsDir(userId);
+  const files = await backend.listDirectory(dir);
+  if (files.length === 0) return 0;
+
+  const runFiles = files.filter(f => f.startsWith('oped-run-') && f.endsWith('.json'));
+  let count = 0;
+
+  for (const file of runFiles) {
+    const raw = await backend.readFile(path.join(dir, file));
+    if (raw === null) continue;
+    let record: RunControlRecord;
+    try {
+      record = JSON.parse(raw) as RunControlRecord;
+    } catch {
+      /* telemetry — silent by design */
+      continue;
+    }
+
+    if (record.status !== 'running') continue;
+
+    const isStale = Date.now() - record.startedAt > RUNNING_STALE_TTL_MS;
+    if (isStale) {
+      // Lazy delete — best-effort fire-and-forget; stale blob is NOT counted
+      backend.deleteFile(path.join(dir, file)).catch(() => { /* telemetry — silent by design */ });
+      log.server.warn({ runId: record.runId, startedAt: record.startedAt },
+        'countRunningOpedRuns: lazy-expired stale running blob (crashed-A protection)');
+    } else {
+      count += 1;
+    }
+  }
+
+  return count;
+}
+
+/**
+ * Load run-control record by runId.
+ * Returns null if not found or if user context is unavailable.
+ */
+export async function getOpedRun(runId: string): Promise<RunControlRecord | null> {
+  assertSafeId(runId, 'oped-run id');
+  const userId = getStorageUserId();
+  if (!userId) return null;
+  const backend = getUserContentBackend();
+  const raw = await backend.readFile(path.join(getOpedRunsDir(userId), `oped-run-${runId}.json`));
+  if (raw === null) return null;
+  try {
+    return JSON.parse(raw) as RunControlRecord;
+  } catch {
+    /* telemetry — silent by design */
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `storage/opedRunStore.ts`: blob-backed per-user run-control store fixing the N×cap concurrency bug at `maxReplicas>1`.
- `upsertOpedRun(record)`: write/overwrite `oped-run-<runId>.json` via `getUserContentBackend()`.
- `countRunningOpedRuns(userId)`: counts `status==='running'` blobs with lazy TTL-expire (15 min hard ceiling — prevents crashed-replica wedging the cap forever). Both arms tested.
- `getOpedRun(runId)`: read run-control by runId.
- Re-exported from `fileIO.ts` barrel.
- `src/server/__tests__/opedRunStore.test.ts`: 10/10 tests including stale-running lazy-expire both arms (TL t/2893#8 required).

**ServerAPI wiring needed (oped.ts):** replace `opedRuns Map` + `sweepOpedRuns()` + sync `countRunningOpedRuns()` with the async store calls. Remove `@INMEMORY_JOB_STORE` marker after wiring + verified.

**Anon:** no-op (authed-only confirmed at t/2893#9 — double-gated in oped.ts).

## Test plan
- [x] `opedRunStore.test.ts` 10/10 pass
- [x] tsc: zero new errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_011cG2AtfQ7iRSFCGSbyZzVM