### PR TITLE
fix(debate): WARN + marker when anon attribution drops the synthetic-vector merge (t/3298)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/argumentNetwork.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/argumentNetwork.ts
@@ -353,6 +353,19 @@ async function computeTaxonomyAttribution(newNodes: NewAnNode[], speaker: Speake
 
           // Merge synthetic multi-vector embeddings when available
           const synVecs = await loadSyntheticVectors();
+          if (!synVecs) {
+            // t/3298 (t/3297 c-floor): loadSyntheticVectors returned null — the synthetic-embeddings
+            // corpus GET is auth-gated (t/3259), so it 403s for ANON debates → the synthetic
+            // multi-vector merge is DROPPED and claim attribution runs on BASE embeddings only. Make
+            // this degradation observable HERE (Fallback-Path Logging) with a specific WARN + marker,
+            // rather than letting it be inferred from downstream attribution quality or swallowed by
+            // the generic catch below. (Structural fix = the t/3297 (a)-spike, ServerAPI.)
+            getGlobalRecorder()?.record({
+              type: 'system.error', debate_id: debate.id, component: 'debate-store', level: 'warn',
+              message: 'Claim attribution degraded — synthetic-vector merge dropped (synthetic corpus unavailable; likely the anon corpus-gate 403, t/3259). Attribution runs on base embeddings only.',
+              data: { fallback: 'synthetic-merge-skipped', cause: 'synthetic-vectors-null', base_node_count: Object.keys(baseNodeEmbeddings).length },
+            });
+          }
           const nodeEmbeddings = synVecs
             ? mergeSyntheticVectors(baseNodeEmbeddings, synVecs)
             : baseNodeEmbeddings;


### PR DESCRIPTION
TL-ruled **(c) observability floor** for t/3297 (renderer scope, self-cert).

**Problem:** `argumentNetwork.ts` `loadSyntheticVectors()` fetches the synthetic-embeddings corpus, which is auth-gated (t/3259) → **403s for ANON debates** → returns null → the `mergeSyntheticVectors` step was **silently skipped** and claim attribution ran on base embeddings only. Silent degradation — inferable only from downstream quality, and the generic `catch` below would swallow any error too.

**Fix:** when `synVecs` is null, emit a **specific WARN naming the drop** + a machine-readable **fallback marker** (`fallback: 'synthetic-merge-skipped'`, `cause: 'synthetic-vectors-null'`, `base_node_count`) **before** proceeding on base embeddings — per Fallback-Path Logging (docs/error-handling.md). An operator now sees "anon attribution degraded — no synthetic merge" instead of inferring it.

Happy path unchanged (merge still runs when `synVecs` is present). The **structural** fix (restore anon synthetic matching server-side) is the separate t/3297 (a)-spike (ServerAPI).

**Verify:** renderer-tsc 0 · eslint 0 errors · full useDebateStore suite 282 pass.

Commit: a1d5dee2 · self-cert Fallback-Path Logging (no new API/pattern).