### PR TITLE
feat(storage): add opts.ref to readTaxonomyFile for corpus pinning (t/3297)

### DIFF
--- a/taxonomy-editor/src/server/storage/fileIO.ts
+++ b/taxonomy-editor/src/server/storage/fileIO.ts
@@ -223,9 +223,9 @@ async function resolveTaxonomyFilePath(pov: string): Promise<string> {
   return path.join(taxDir, `${pov}.json`);
 }
 
-export async function readTaxonomyFile(pov: string): Promise<unknown> {
+export async function readTaxonomyFile(pov: string, opts?: { ref?: string }): Promise<unknown> {
   const filePath = await resolveTaxonomyFilePath(pov);
-  const raw = await backend.readFile(filePath);
+  const raw = await backend.readFile(filePath, opts);
   if (raw === null) throw new ActionableError({
     goal: 'Read taxonomy file',
     problem: `Taxonomy file not found: ${filePath}`,


### PR DESCRIPTION
## Summary
- Adds `opts?: { ref?: string }` to `readTaxonomyFile(pov, opts?)` signature
- Threads `opts` into `backend.readFile(filePath, opts)` so callers can pin a git ref (e.g. `ref: 'main'`) when reading via the GitHub API backend
- No-op for filesystem and Azure blob backends (they ignore the option)

## Motivation
ServerAPI's corpus-relevance route needs to pin `ref:'main'` to avoid reading from session branches when fetching taxonomy files (t/3297, TL-approved).

## Test plan
- [ ] CI green (tsc + vitest)
- [ ] No callers broken — existing call sites pass no `opts`, unchanged behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)