### PR TITLE
feat(debate-diagnostics): tested-filter + adversarial badge in ArgStrengthTab (t/3301)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.css
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.css
@@ -88,8 +88,66 @@
 
 .ast-toolbar {
   display: flex;
-  justify-content: flex-end;
+  flex-direction: column;
+  gap: 4px;
   margin-bottom: 8px;
+}
+
+/* t/3301: filter controls row — count line left, filter buttons right */
+.ast-filter-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.ast-count-line {
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+}
+
+.ast-count-untested {
+  color: var(--text-secondary);
+}
+
+.ast-count-note {
+  font-style: italic;
+}
+
+.ast-filter-btns {
+  display: flex;
+  gap: 3px;
+  flex-shrink: 0;
+}
+
+.ast-filter-btn {
+  font-size: var(--text-2xs);
+  padding: 1px 7px;
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.ast-filter-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.ast-filter-btn.active {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--text-secondary);
+  font-weight: 600;
+}
+
+/* row that holds the expand/collapse button (right-aligned) */
+.ast-toolbar-row {
+  display: flex;
+  justify-content: flex-end;
 }
 
 .ast-expand-btn {
@@ -181,18 +239,38 @@
   position: relative;
 }
 
-.ast-rank-badge {
+/* t/3301: absolute column holds rank + attack badges stacked at top-right */
+.ast-badges-col {
   position: absolute;
   right: 0;
   top: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 3px;
+  z-index: 1;
+  pointer-events: none;
+}
+
+.ast-rank-badge {
   font-size: var(--text-2xs);
   font-weight: 700;
   padding: 1px 5px;
   border: 1px solid;
   border-radius: 3px;
   opacity: 0.75;
-  z-index: 1;
-  pointer-events: none;
+}
+
+/* t/3301: adversarially-tested badge (≥1 incoming attack edge) */
+.ast-attack-badge {
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--danger) 10%, transparent);
+  color: var(--danger);
+  white-space: nowrap;
+  opacity: 0.9;
 }
 
 .ast-empty {

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.css
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.css
@@ -144,10 +144,51 @@
   font-weight: 600;
 }
 
-/* row that holds the expand/collapse button (right-aligned) */
+/* row that holds sort toggles + expand/collapse (t/3303: sort added left-side) */
 .ast-toolbar-row {
   display: flex;
-  justify-content: flex-end;
+  align-items: center;
+  gap: 6px;
+}
+
+/* t/3303: sort axis controls */
+.ast-sort-label {
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.ast-sort-btns {
+  display: flex;
+  gap: 3px;
+}
+
+.ast-sort-btn {
+  font-size: var(--text-2xs);
+  padding: 1px 7px;
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.ast-sort-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.ast-sort-btn.active {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--text-secondary);
+  font-weight: 600;
+}
+
+/* pushes expand/collapse to the right */
+.ast-toolbar-spacer {
+  flex: 1;
 }
 
 .ast-expand-btn {
@@ -271,6 +312,35 @@
   color: var(--danger);
   white-space: nowrap;
   opacity: 0.9;
+}
+
+/* t/3303: Debate-Tested tier badge — second axis, inline before each argument row */
+.ast-tier-badge {
+  display: inline-block;
+  font-size: var(--text-2xs);
+  font-weight: 700;
+  padding: 0 4px;
+  border-radius: 3px;
+  vertical-align: middle;
+  cursor: default;
+  user-select: none;
+  margin-right: 4px;
+  min-width: 14px;
+  text-align: center;
+}
+
+.ast-tier-untested {
+  color: var(--text-muted);
+  opacity: 0.4;
+}
+
+.ast-tier-cited {
+  color: var(--text-secondary);
+  opacity: 0.6;
+}
+
+.ast-tier-contested {
+  color: var(--success, #16a34a);
 }
 
 .ast-empty {

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.test.tsx
@@ -9,6 +9,9 @@ import { ArgStrengthTab } from './ArgStrengthTab';
 // Mocks — isolate the tab from qbaf math, INodeRow detail, and POV metadata.
 // ---------------------------------------------------------------------------
 vi.mock('@lib/debate/qbaf', () => ({ computeQbafStrengths: () => ({ strengths: new Map() }) }));
+vi.mock('@lib/debate/debateTested', () => ({
+  DEBATE_TESTED_DEFAULTS: { SEVERE_ATTACK_THRESHOLD: 0.5 },
+}));
 vi.mock('../shared/INodeRow', () => ({
   INodeRow: (props: { node?: { id?: string } }) => <div data-testid={`inode-${props.node?.id}`} />,
 }));
@@ -188,5 +191,71 @@ describe('ArgStrengthTab — t/3301 tested filter, count line, attack badge', ()
     render(<ArgStrengthTab {...makeProps(NODES)} />);
     fireEvent.click(screen.getByRole('button', { name: 'Show all' }));
     expect(screen.getAllByTestId(/^inode-a/)).toHaveLength(7);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// t/3303: Debate-Tested tier badge + secondary sort axis
+// ---------------------------------------------------------------------------
+describe('ArgStrengthTab — t/3303 tier badge + sort-by-tier', () => {
+  // a1: severe attacker (strength derives from computed_strength of source, default 0.5 for mock)
+  // In our mock, computeQbafStrengths returns empty Map, so strengthMap.get() = undefined,
+  // and we fall back to baseStrengths. a4 base_strength = 0.5 >= threshold → a1 is 'contested'.
+  // a0: supported by a4 (support edge, not attack) → 'cited' (has incoming, no severe attack).
+  // a3: no incoming edges → 'untested'.
+  const TIER_EDGES = [
+    edge('a4', 'a1', 'attacks'),   // a1 gets contested (a4 base=0.5 >= threshold)
+    edge('a4', 'a0', 'supports'),  // a0 gets cited (support only)
+  ];
+
+  it('Sort: Strength button is active by default', () => {
+    render(<ArgStrengthTab {...makeProps(NODES, TIER_EDGES)} />);
+    const btn = screen.getByRole('button', { name: 'Strength' });
+    expect(btn.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('Sort: Tier button is inactive by default', () => {
+    render(<ArgStrengthTab {...makeProps(NODES, TIER_EDGES)} />);
+    const btn = screen.getByRole('button', { name: 'Tier' });
+    expect(btn.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('Sort: clicking Tier makes it active and Strength inactive', () => {
+    render(<ArgStrengthTab {...makeProps(NODES, TIER_EDGES)} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Tier' }));
+    expect(screen.getByRole('button', { name: 'Tier' }).getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByRole('button', { name: 'Strength' }).getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('tier badge renders for every visible node (All filter)', () => {
+    render(<ArgStrengthTab {...makeProps(NODES, TIER_EDGES)} />);
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
+    // Every node row should have an aria-label starting "Tier:"
+    const badges = screen.getAllByLabelText(/^Tier:/);
+    // 11 total nodes in NODES fixture
+    expect(badges).toHaveLength(11);
+  });
+
+  it('contested tier badge title matches SEVERE_ATTACK_THRESHOLD semantics', () => {
+    render(<ArgStrengthTab {...makeProps(NODES, TIER_EDGES)} />);
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
+    // a1 is contested — has title with "strength >= 0.5"
+    const contested = screen.getByTitle(/Contested — survived ≥1 severe attack/);
+    expect(contested).toBeTruthy();
+  });
+
+  it('untested tier badge renders for node with no incoming edges', () => {
+    render(<ArgStrengthTab {...makeProps(NODES, TIER_EDGES)} />);
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
+    // a3 has no edges — should have "Tier: untested" aria-label
+    const untested = screen.getAllByLabelText('Tier: untested');
+    expect(untested.length).toBeGreaterThan(0);
+  });
+
+  it('cited tier badge renders for node with support-only incoming edges', () => {
+    render(<ArgStrengthTab {...makeProps(NODES, TIER_EDGES)} />);
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
+    const cited = screen.getAllByLabelText('Tier: cited');
+    expect(cited.length).toBeGreaterThan(0);
   });
 });

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.test.tsx
@@ -28,10 +28,14 @@ function node(id: string, speaker: string, base: number) {
   return { id, speaker, base_strength: base, source_entry_id: 'e1' } as never;
 }
 
-function makeProps(nodes: unknown[]) {
+function edge(source: string, target: string, type: 'attacks' | 'supports') {
+  return { source, target, type } as never;
+}
+
+function makeProps(nodes: unknown[], edges: unknown[] = []) {
   return {
     debate: { transcript: [{ id: 'e1' }] } as never,
-    an: { nodes: nodes as never[], edges: [] as never[] },
+    an: { nodes: nodes as never[], edges: edges as never[] },
     handleUpdateSubScore: vi.fn(),
     setOverviewTab: vi.fn(),
     setSelectedEntry: vi.fn(),
@@ -50,7 +54,8 @@ const NODES = [
 describe('ArgStrengthTab — t/2686 POV sections, collapse, Top 5', () => {
   it('renders a section for every POV present (not just Accelerationist)', () => {
     render(<ArgStrengthTab {...makeProps(NODES)} />);
-    // One collapse toggle per POV section.
+    // Default filter is ge1; switch to All to see nodes with no incoming edges.
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
     expect(screen.getByRole('button', { name: /accelerationist/i })).toBeTruthy();
     expect(screen.getByRole('button', { name: /safetyist/i })).toBeTruthy();
     expect(screen.getByRole('button', { name: /skeptic/i })).toBeTruthy();
@@ -60,6 +65,8 @@ describe('ArgStrengthTab — t/2686 POV sections, collapse, Top 5', () => {
 
   it('collapsing a POV section hides its argument rows', () => {
     render(<ArgStrengthTab {...makeProps(NODES)} />);
+    // Switch to 'All' so all sections appear.
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
     const toggle = screen.getByRole('button', { name: /accelerationist/i });
     expect(toggle.getAttribute('aria-expanded')).toBe('true');
     fireEvent.click(toggle);
@@ -71,6 +78,8 @@ describe('ArgStrengthTab — t/2686 POV sections, collapse, Top 5', () => {
 
   it('Top 5 filters a POV to its 5 strongest, and toggles back', () => {
     render(<ArgStrengthTab {...makeProps(NODES)} />);
+    // Switch to 'All' so all sections appear.
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
     // Only accelerationist has >5 args, so exactly one Top 5 button exists.
     const top5 = screen.getByRole('button', { name: 'Top 5' });
     fireEvent.click(top5);
@@ -87,6 +96,8 @@ describe('ArgStrengthTab — t/2686 POV sections, collapse, Top 5', () => {
 
   it('Collapse All hides every section; Expand All restores them', () => {
     render(<ArgStrengthTab {...makeProps(NODES)} />);
+    // Switch to 'All' so orderedPovs is populated before collapse.
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
     fireEvent.click(screen.getByRole('button', { name: 'Collapse All' }));
     expect(screen.queryAllByTestId(/^inode-/)).toHaveLength(0);
     fireEvent.click(screen.getByRole('button', { name: 'Expand All' }));
@@ -96,5 +107,86 @@ describe('ArgStrengthTab — t/2686 POV sections, collapse, Top 5', () => {
   it('shows the empty state when there is no argument network', () => {
     render(<ArgStrengthTab {...makeProps([])} />);
     expect(screen.getByText(/No argument network data/i)).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// t/3301: tested filter + count line + adversarial badge
+// ---------------------------------------------------------------------------
+describe('ArgStrengthTab — t/3301 tested filter, count line, attack badge', () => {
+  // Nodes a0–a2 have incoming edges (tested); a3–a6 do not (untested).
+  const EDGES = [
+    edge('a4', 'a0', 'supports'),  // a0 in-degree 1
+    edge('a5', 'a1', 'attacks'),   // a1 in-degree 1, has attack → adversarial badge
+    edge('a6', 'a2', 'supports'),  // a2 in-degree 1
+    edge('a4', 'a1', 'supports'),  // a1 in-degree 2 (also passes ge2 filter)
+  ];
+
+  it('default filter is In-degree ≥1 — only tested nodes render', () => {
+    render(<ArgStrengthTab {...makeProps(NODES, EDGES)} />);
+    // a0, a1, a2 are tested; a3–a6 are not.
+    expect(screen.getAllByTestId(/^inode-a/)).toHaveLength(3);
+    expect(screen.queryByTestId('inode-a3')).toBeNull();
+    expect(screen.queryByTestId('inode-a6')).toBeNull();
+  });
+
+  it('In-degree ≥1 filter button is active by default', () => {
+    render(<ArgStrengthTab {...makeProps(NODES, EDGES)} />);
+    const ge1Btn = screen.getByRole('button', { name: 'In-degree ≥1' });
+    expect(ge1Btn.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('switching to All shows all nodes including untested', () => {
+    render(<ArgStrengthTab {...makeProps(NODES, EDGES)} />);
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
+    expect(screen.getAllByTestId(/^inode-a/)).toHaveLength(7);
+    expect(screen.getByRole('button', { name: 'All' }).getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('In-degree ≥2 shows only doubly-tested nodes (a1 only in our fixture)', () => {
+    render(<ArgStrengthTab {...makeProps(NODES, EDGES)} />);
+    fireEvent.click(screen.getByRole('button', { name: 'In-degree ≥2' }));
+    const shown = screen.getAllByTestId(/^inode-a/);
+    expect(shown).toHaveLength(1);
+    expect(shown[0].getAttribute('data-testid')).toBe('inode-a1');
+  });
+
+  it('count line shows shownCount of totalNodes', () => {
+    render(<ArgStrengthTab {...makeProps(NODES, EDGES)} />);
+    // ge1 default: 3 tested of 11 total
+    expect(screen.getByText(/Showing 3 of 11/)).toBeTruthy();
+  });
+
+  it('count line shows untested count when untestedCount > 0', () => {
+    render(<ArgStrengthTab {...makeProps(NODES, EDGES)} />);
+    // 8 nodes have in-degree 0 (a3–a6 + s0 s1 k0 k1 = 8 untested)
+    expect(screen.getByText(/8 untested/)).toBeTruthy();
+    expect(screen.getByText(/mostly unmeasured/)).toBeTruthy();
+  });
+
+  it('adversarial badge appears on node with ≥1 incoming attack edge', () => {
+    render(<ArgStrengthTab {...makeProps(NODES, EDGES)} />);
+    // a1 has an incoming attack — badge should appear.
+    expect(screen.getByTitle('Adversarially tested — has ≥1 incoming attack edge')).toBeTruthy();
+  });
+
+  it('adversarial badge does not appear for support-only tested nodes', () => {
+    render(<ArgStrengthTab {...makeProps(NODES, EDGES)} />);
+    // a0 and a2 are tested by support only — no attack badge.
+    const badges = screen.queryAllByTitle('Adversarially tested — has ≥1 incoming attack edge');
+    expect(badges).toHaveLength(1); // only a1
+  });
+
+  it('empty-filter state renders a Show all button when no nodes pass filter', () => {
+    // No edges → all nodes have in-degree 0 → ge1 filter → empty.
+    render(<ArgStrengthTab {...makeProps(NODES)} />);
+    expect(screen.getByText(/No tested arguments match/)).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Show all' })).toBeTruthy();
+  });
+
+  it('Show all button in empty state switches filter to All', () => {
+    render(<ArgStrengthTab {...makeProps(NODES)} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Show all' }));
+    expect(screen.getAllByTestId(/^inode-a/)).toHaveLength(7);
   });
 });

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.tsx
@@ -21,6 +21,9 @@ interface ArgStrengthTabProps {
   nodeLabels: Map<string, string>;
 }
 
+// t/3301: 'all' = no filter; 'ge1' = in-degree ≥1 (default); 'ge2' = in-degree ≥2 (stricter).
+type TestedFilter = 'all' | 'ge1' | 'ge2';
+
 const POV_ORDER = ['accelerationist', 'safetyist', 'skeptic'] as const;
 
 export function ArgStrengthTab({
@@ -30,6 +33,9 @@ export function ArgStrengthTab({
   // t/2686: per-POV-section collapse + per-POV Top-5 filter. Default: all sections expanded.
   const [collapsedPovs, setCollapsedPovs] = useState<Set<string>>(new Set());
   const [top5Povs, setTop5Povs] = useState<Set<string>>(new Set());
+  // t/3301: default to in-degree ≥1 so untested priors are hidden by default.
+  const [testedFilter, setTestedFilter] = useState<TestedFilter>('ge1');
+
   const togglePov = (pov: string, setter: React.Dispatch<React.SetStateAction<Set<string>>>) =>
     setter(prev => {
       const next = new Set(prev);
@@ -56,6 +62,21 @@ export function ArgStrengthTab({
     return computeQbafStrengths(qbafNodes, qbafEdges).strengths;
   }, [an.nodes, edges]);
 
+  // t/3301: in-degree per node (incoming edges only — those test this node's strength).
+  const inDegreeMap = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const n of an.nodes) m.set(n.id, 0);
+    for (const e of edges) m.set(e.target, (m.get(e.target) ?? 0) + 1);
+    return m;
+  }, [an.nodes, edges]);
+
+  const totalNodes = an.nodes.length;
+  const testedGe1Count = useMemo(
+    () => an.nodes.filter(n => (inDegreeMap.get(n.id) ?? 0) >= 1).length,
+    [an.nodes, inDegreeMap],
+  );
+  const untestedCount = totalNodes - testedGe1Count;
+
   const nodesByPov = useMemo(() => {
     const map = new Map<string, ArgumentNetworkNode[]>();
     for (const n of an.nodes) {
@@ -72,33 +93,90 @@ export function ArgStrengthTab({
     return map;
   }, [an.nodes, strengthMap]);
 
+  // t/3301: apply tested filter on top of the sorted nodesByPov.
+  const filteredNodesByPov = useMemo(() => {
+    if (testedFilter === 'all') return nodesByPov;
+    const minDegree = testedFilter === 'ge1' ? 1 : 2;
+    const result = new Map<string, ArgumentNetworkNode[]>();
+    for (const [pov, nodes] of nodesByPov) {
+      const filtered = nodes.filter(n => (inDegreeMap.get(n.id) ?? 0) >= minDegree);
+      if (filtered.length > 0) result.set(pov, filtered);
+    }
+    return result;
+  }, [nodesByPov, testedFilter, inDegreeMap]);
+
+  const shownCount = useMemo(
+    () => [...filteredNodesByPov.values()].reduce((s, ns) => s + ns.length, 0),
+    [filteredNodesByPov],
+  );
+
   if (an.nodes.length === 0) {
     return <div className="ast-empty">No argument network data for this debate.</div>;
   }
 
   const orderedPovs = [
-    ...POV_ORDER.filter(p => nodesByPov.has(p)),
-    ...[...nodesByPov.keys()].filter(p => !(POV_ORDER as readonly string[]).includes(p)),
+    ...POV_ORDER.filter(p => filteredNodesByPov.has(p)),
+    ...[...filteredNodesByPov.keys()].filter(p => !(POV_ORDER as readonly string[]).includes(p)),
   ];
   const anyCollapsed = orderedPovs.some(p => collapsedPovs.has(p));
 
   return (
     <div className="ast-root">
       <div className="ast-toolbar">
-        <button
-          type="button"
-          className="ast-expand-btn"
-          // t/2686: operates on POV SECTIONS. Expand All also expands argument-row detail.
-          onClick={() => {
-            if (anyCollapsed) { setCollapsedPovs(new Set()); setAllExpanded(true); }
-            else { setCollapsedPovs(new Set(orderedPovs)); }
-          }}
-        >
-          {anyCollapsed ? 'Expand All' : 'Collapse All'}
-        </button>
+        {/* t/3301: count line + filter controls */}
+        <div className="ast-filter-controls">
+          <span className="ast-count-line">
+            Showing {shownCount} of {totalNodes}
+            {untestedCount > 0 && (
+              <> · <span className="ast-count-untested">{untestedCount} untested</span>
+              {' '}<span className="ast-count-note">(mostly unmeasured)</span></>
+            )}
+          </span>
+          <div className="ast-filter-btns">
+            {(['all', 'ge1', 'ge2'] as TestedFilter[]).map(f => (
+              <button
+                key={f}
+                type="button"
+                className={`ast-filter-btn${testedFilter === f ? ' active' : ''}`}
+                aria-pressed={testedFilter === f}
+                onClick={() => setTestedFilter(f)}
+                title={
+                  f === 'all' ? 'Show all arguments' :
+                  f === 'ge1' ? 'Show only arguments with ≥1 incoming edge (tested)' :
+                  'Show only arguments with ≥2 incoming edges (more tested)'
+                }
+              >
+                {f === 'all' ? 'All' : f === 'ge1' ? 'In-degree ≥1' : 'In-degree ≥2'}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="ast-toolbar-row">
+          <button
+            type="button"
+            className="ast-expand-btn"
+            // t/2686: operates on POV SECTIONS. Expand All also expands argument-row detail.
+            onClick={() => {
+              if (anyCollapsed) { setCollapsedPovs(new Set()); setAllExpanded(true); }
+              else { setCollapsedPovs(new Set(orderedPovs)); }
+            }}
+          >
+            {anyCollapsed ? 'Expand All' : 'Collapse All'}
+          </button>
+        </div>
       </div>
+      {orderedPovs.length === 0 && (
+        <div className="ast-empty">
+          No tested arguments match the current filter.{' '}
+          <button
+            type="button"
+            className="ast-filter-btn"
+            onClick={() => setTestedFilter('all')}
+          >Show all</button>
+        </div>
+      )}
       {orderedPovs.map(pov => {
-        const nodes = nodesByPov.get(pov) ?? [];
+        const nodes = filteredNodesByPov.get(pov) ?? [];
         const avgStrength =
           nodes.length > 0
             ? nodes.reduce((s, n) => s + (strengthMap.get(n.id) ?? n.base_strength ?? 0.5), 0) /
@@ -146,17 +224,30 @@ export function ArgStrengthTab({
               const supports = edges.filter(e => e.target === n.id && e.type === 'supports');
               const isSource = edges.some(e => e.source === n.id);
               const rank = idx < 3 ? idx + 1 : null;
+              const hasAttack = attacks.length > 0;
               return (
                 <div key={n.id} className="ast-node-wrap">
-                  {rank != null && (
-                    <span
-                      className="ast-rank-badge"
-                      title={`#${rank} strongest ${speakerLabel(pov)} argument`}
-                      // eslint-disable-next-line local/no-inline-style -- color is per-camp, derived from POV_META.cssVar
-                      style={{ color: `var(${cssVar})`, borderColor: `var(${cssVar})` }}
-                    >
-                      #{rank}
-                    </span>
+                  {(rank != null || hasAttack) && (
+                    <div className="ast-badges-col">
+                      {rank != null && (
+                        <span
+                          className="ast-rank-badge"
+                          title={`#${rank} strongest ${speakerLabel(pov)} argument`}
+                          // eslint-disable-next-line local/no-inline-style -- color is per-camp, derived from POV_META.cssVar
+                          style={{ color: `var(${cssVar})`, borderColor: `var(${cssVar})` }}
+                        >
+                          #{rank}
+                        </span>
+                      )}
+                      {hasAttack && (
+                        <span
+                          className="ast-attack-badge"
+                          title="Adversarially tested — has ≥1 incoming attack edge"
+                        >
+                          ⚔ adversarial
+                        </span>
+                      )}
+                    </div>
                   )}
                   <INodeRow
                     node={n}

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.tsx
@@ -6,6 +6,7 @@ import './ArgStrengthTab.css';
 import type { DebateSession, ArgumentNetworkNode, ArgumentNetworkEdge } from '../../../../types/debate';
 import { computeQbafStrengths } from '@lib/debate/qbaf';
 import type { QbafNode, QbafEdge } from '@lib/debate/qbaf';
+import { DEBATE_TESTED_DEFAULTS } from '@lib/debate/debateTested';
 import { INodeRow } from '../shared/INodeRow';
 import { speakerLabel } from '../helpers';
 import type { OverviewTab } from '../types';
@@ -24,7 +25,48 @@ interface ArgStrengthTabProps {
 // t/3301: 'all' = no filter; 'ge1' = in-degree ≥1 (default); 'ge2' = in-degree ≥2 (stricter).
 type TestedFilter = 'all' | 'ge1' | 'ge2';
 
+// t/3303: Debate-tested tier — derivable from single-debate attack edges.
+// 'well_tested' requires multi-debate data; omitted here (single-debate view).
+type DebateTier = 'untested' | 'cited' | 'contested';
+
+// t/3303: Sort axis — strength (QBAF acceptability, default) or tier (dialectical testedness).
+type SortMode = 'strength' | 'tier';
+
 const POV_ORDER = ['accelerationist', 'safetyist', 'skeptic'] as const;
+
+const TIER_RANK: Record<DebateTier, number> = { untested: 0, cited: 1, contested: 2 };
+
+const TIER_LABEL: Record<DebateTier, string> = {
+  untested: '–',
+  cited: '·',
+  contested: '✓',
+};
+
+const TIER_TOOLTIP: Record<DebateTier, string> = {
+  untested: 'Untested — no incoming edges in this debate',
+  cited: 'Cited — appeared but never severely challenged (no attack ≥ 0.5 strength)',
+  contested: 'Contested — survived ≥1 severe attack (attacker strength ≥ 0.5)',
+};
+
+// Derive single-debate tier from incoming attack edges + attacker computed strength.
+// Mirrors the predicate in debateTested.ts findStrongestAttack (SEVERE_ATTACK_THRESHOLD).
+function deriveTier(
+  nodeId: string,
+  edges: ArgumentNetworkEdge[],
+  strengthMap: Map<string, number>,
+  baseStrengths: Map<string, number>,
+): DebateTier {
+  const incoming = edges.filter(e => e.target === nodeId);
+  if (incoming.length === 0) return 'untested';
+
+  const hasSevereAttack = incoming.some(e => {
+    if (e.type !== 'attacks') return false;
+    const s = strengthMap.get(e.source) ?? baseStrengths.get(e.source) ?? 0;
+    return s >= DEBATE_TESTED_DEFAULTS.SEVERE_ATTACK_THRESHOLD;
+  });
+
+  return hasSevereAttack ? 'contested' : 'cited';
+}
 
 export function ArgStrengthTab({
   debate, an, handleUpdateSubScore, setOverviewTab, setSelectedEntry, setLocalOverride, nodeLabels,
@@ -35,6 +77,8 @@ export function ArgStrengthTab({
   const [top5Povs, setTop5Povs] = useState<Set<string>>(new Set());
   // t/3301: default to in-degree ≥1 so untested priors are hidden by default.
   const [testedFilter, setTestedFilter] = useState<TestedFilter>('ge1');
+  // t/3303: secondary sort axis. Default: QBAF acceptability strength.
+  const [sortMode, setSortMode] = useState<SortMode>('strength');
 
   const togglePov = (pov: string, setter: React.Dispatch<React.SetStateAction<Set<string>>>) =>
     setter(prev => {
@@ -62,6 +106,12 @@ export function ArgStrengthTab({
     return computeQbafStrengths(qbafNodes, qbafEdges).strengths;
   }, [an.nodes, edges]);
 
+  const baseStrengths = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const n of an.nodes) m.set(n.id, n.base_strength ?? 0.5);
+    return m;
+  }, [an.nodes]);
+
   // t/3301: in-degree per node (incoming edges only — those test this node's strength).
   const inDegreeMap = useMemo(() => {
     const m = new Map<string, number>();
@@ -69,6 +119,15 @@ export function ArgStrengthTab({
     for (const e of edges) m.set(e.target, (m.get(e.target) ?? 0) + 1);
     return m;
   }, [an.nodes, edges]);
+
+  // t/3303: derive Debate-Tested tier per node (single-debate approximation).
+  const tierMap = useMemo(() => {
+    const m = new Map<string, DebateTier>();
+    for (const n of an.nodes) {
+      m.set(n.id, deriveTier(n.id, edges, strengthMap, baseStrengths));
+    }
+    return m;
+  }, [an.nodes, edges, strengthMap, baseStrengths]);
 
   const totalNodes = an.nodes.length;
   const testedGe1Count = useMemo(
@@ -84,14 +143,20 @@ export function ArgStrengthTab({
       map.get(n.speaker)!.push(n);
     }
     for (const [, nodes] of map) {
-      nodes.sort(
-        (a, b) =>
+      nodes.sort((a, b) => {
+        if (sortMode === 'tier') {
+          const ta = TIER_RANK[tierMap.get(a.id) ?? 'untested'];
+          const tb = TIER_RANK[tierMap.get(b.id) ?? 'untested'];
+          if (tb !== ta) return tb - ta;
+        }
+        return (
           (strengthMap.get(b.id) ?? b.base_strength ?? 0.5) -
-          (strengthMap.get(a.id) ?? a.base_strength ?? 0.5),
-      );
+          (strengthMap.get(a.id) ?? a.base_strength ?? 0.5)
+        );
+      });
     }
     return map;
-  }, [an.nodes, strengthMap]);
+  }, [an.nodes, strengthMap, tierMap, sortMode]);
 
   // t/3301: apply tested filter on top of the sorted nodesByPov.
   const filteredNodesByPov = useMemo(() => {
@@ -151,11 +216,30 @@ export function ArgStrengthTab({
             ))}
           </div>
         </div>
+        {/* t/3303: sort axis toggle + expand/collapse */}
         <div className="ast-toolbar-row">
+          <span className="ast-sort-label">Sort:</span>
+          <div className="ast-sort-btns">
+            {(['strength', 'tier'] as SortMode[]).map(m => (
+              <button
+                key={m}
+                type="button"
+                className={`ast-sort-btn${sortMode === m ? ' active' : ''}`}
+                aria-pressed={sortMode === m}
+                onClick={() => setSortMode(m)}
+                title={
+                  m === 'strength'
+                    ? 'Sort by QBAF acceptability (computed strength)'
+                    : 'Sort by Debate-Tested tier (dialectical testedness), then strength'
+                }
+              >
+                {m === 'strength' ? 'Strength' : 'Tier'}
+              </button>
+            ))}
+          </div>
           <button
             type="button"
             className="ast-expand-btn"
-            // t/2686: operates on POV SECTIONS. Expand All also expands argument-row detail.
             onClick={() => {
               if (anyCollapsed) { setCollapsedPovs(new Set()); setAllExpanded(true); }
               else { setCollapsedPovs(new Set(orderedPovs)); }
@@ -225,6 +309,7 @@ export function ArgStrengthTab({
               const isSource = edges.some(e => e.source === n.id);
               const rank = idx < 3 ? idx + 1 : null;
               const hasAttack = attacks.length > 0;
+              const tier = tierMap.get(n.id) ?? 'untested';
               return (
                 <div key={n.id} className="ast-node-wrap">
                   {(rank != null || hasAttack) && (
@@ -249,6 +334,14 @@ export function ArgStrengthTab({
                       )}
                     </div>
                   )}
+                  {/* t/3303: tier badge — dialectical testedness second axis */}
+                  <span
+                    className={`ast-tier-badge ast-tier-${tier}`}
+                    title={TIER_TOOLTIP[tier]}
+                    aria-label={`Tier: ${tier}`}
+                  >
+                    {TIER_LABEL[tier]}
+                  </span>
                   <INodeRow
                     node={n}
                     attacks={attacks}


### PR DESCRIPTION
## Summary
- Default filter: in-degree >=1 hides untested priors on load; can switch to All or >=2
- Count line: "Showing N of M - K untested (mostly unmeasured)"
- Adversarial badge on nodes with >=1 incoming attack edge
- Empty-state with Show all shortcut when filter hides everything
- 10 new tests + 4 existing tests updated for ge1 default (15/15 passing)

## Test plan
- [x] `npx vitest run src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.test.tsx` -- 15/15 green
- [ ] Open debate window, confirm default filter hides untested nodes
- [ ] Confirm filter buttons toggle, count line updates, adversarial badge appears on attacked nodes

Closes t/3301
