### PR TITLE
feat(qbaf): testedness observability — WARN on all-prior resolution + per-conflict metric (t/3302)

### DIFF
--- a/scripts/enrich_conflicts_qbaf.py
+++ b/scripts/enrich_conflicts_qbaf.py
@@ -195,6 +195,52 @@ def _detect_edges(instances):
     return edges
 
 
+def _qbaf_testedness(qbaf, instances):
+    """Observability metric for one resolved QBAF (t/3302).
+
+    Surfaces the "how tested is this resolution" signal so all-prior debates (a
+    computed_strength that is purely the unrevised base prior) are visible rather than
+    presenting as substantive. Schema confirmed by CL (t/3302#2). Pure read of the
+    finalized qbaf + its source instances; no side effects.
+
+    testedness tiers:
+      all_prior     — 0 edges: the resolution is unrevised base strengths.
+      support_only  — has edges but 0 attacks: agreement only, never adversarially tested.
+      adversarial   — >=1 attack edge: at least one node was genuinely challenged.
+    """
+    graph = qbaf.get("graph") or {}
+    edges = graph.get("edges") or []
+    nodes = graph.get("nodes") or []
+    n_attack = sum(1 for e in edges if e.get("type") == "attacks")
+    n_support = sum(1 for e in edges if e.get("type") == "supports")
+    attacked = {e.get("target") for e in edges if e.get("type") == "attacks"}
+    n_untested = sum(1 for n in nodes if n.get("id") not in attacked)
+
+    stance_hist = {}
+    for inst in instances:
+        s = str(inst.get("stance", "neutral"))
+        stance_hist[s] = stance_hist.get(s, 0) + 1
+    has_opposing = ("supports" in stance_hist and "disputes" in stance_hist)
+
+    if not edges:
+        tier = "all_prior"
+    elif n_attack == 0:
+        tier = "support_only"
+    else:
+        tier = "adversarial"
+
+    return {
+        "n_instances": len(instances),
+        "n_edges": len(edges),
+        "n_support_edges": n_support,
+        "n_attack_edges": n_attack,
+        "n_untested_nodes": n_untested,
+        "testedness": tier,
+        "has_opposing_stances": has_opposing,
+        "stance_hist": stance_hist,
+    }
+
+
 def _safe_env():
     """Build a minimal environment for subprocess calls — no API keys leaked."""
     import os
@@ -474,6 +520,8 @@ def main():
     enriched = 0
     failed = 0
     no_edges = 0
+    # t/3302 observability — aggregate testedness tiers across this run (CL schema t/3302#2).
+    tier_counts = {"all_prior": 0, "support_only": 0, "adversarial": 0}
 
     # Phase 1: build local graphs (no subprocess)
     pre_results = []  # (index, path, conflict, pre_data_or_qbaf)
@@ -536,6 +584,18 @@ def main():
             qbaf = pre
             no_edges += 1
 
+        # t/3302 observability: record the testedness metric on the qbaf + accumulate the tier.
+        # WARN per-conflict on all_prior (Fallback-Path Logging: a resolution that is purely the
+        # unrevised base prior is a measurement gap); aggregate-count support_only rather than
+        # per-conflict WARN it (CL t/3302#2).
+        tm = _qbaf_testedness(qbaf, conflict.get("instances") or [])
+        qbaf["testedness"] = tm
+        tier_counts[tm["testedness"]] = tier_counts.get(tm["testedness"], 0) + 1
+        if tm["testedness"] == "all_prior":
+            _log(f"  WARN: QBAF all_prior (0 edges) for {conflict.get('claim_id')} — "
+                 f"{tm['n_instances']} instances, stance_hist={tm['stance_hist']}; resolution is "
+                 f"unrevised base strengths (measurement gap, t/3302).")
+
         conflict["qbaf"] = qbaf
         enriched += 1
 
@@ -559,6 +619,12 @@ def main():
     _log(f"  Enriched with QBAF: {enriched}")
     _log(f"  No edges (base strength only): {no_edges}")
     _log(f"  Failed: {failed}")
+    # t/3302 observability — testedness tier distribution across this run.
+    _tt = enriched or 1
+    _log(f"  Testedness: all_prior={tier_counts['all_prior']} "
+         f"({100*tier_counts['all_prior']/_tt:.0f}%) | support_only={tier_counts['support_only']} "
+         f"({100*tier_counts['support_only']/_tt:.0f}%) | adversarial={tier_counts['adversarial']} "
+         f"({100*tier_counts['adversarial']/_tt:.0f}%)")
     if not args.write:
         _log(f"  DRY RUN — use --write to persist")
     _log(f"{'=' * 60}")
@@ -570,6 +636,7 @@ def main():
         "enriched": enriched,
         "no_edges": no_edges,
         "failed": failed,
+        "testedness_tiers": tier_counts,
     }, sys.stdout, indent=2)
     print()
 

--- a/scripts/test_enrich_conflicts_qbaf.py
+++ b/scripts/test_enrich_conflicts_qbaf.py
@@ -121,6 +121,42 @@ def test_same_debate_doc_same_stance_produces_support_edge():
     assert edges[0]["type"] == "supports"
 
 
+# _qbaf_testedness — observability metric (t/3302)
+
+def _qbaf(nodes, edges):
+    return {"graph": {"nodes": nodes, "edges": edges}}
+
+
+def test_testedness_all_prior_when_no_edges():
+    q = _qbaf([{"id": "inst-0"}, {"id": "inst-1"}], [])
+    tm = eq._qbaf_testedness(q, [_inst("supports", "d1"), _inst("supports", "d2")])
+    assert tm["testedness"] == "all_prior"
+    assert tm["n_edges"] == 0 and tm["n_attack_edges"] == 0
+    assert tm["n_untested_nodes"] == 2          # nothing attacked
+    assert tm["has_opposing_stances"] is False
+    assert tm["stance_hist"] == {"supports": 2}
+
+
+def test_testedness_support_only_when_edges_but_no_attacks():
+    q = _qbaf([{"id": "inst-0"}, {"id": "inst-1"}],
+              [{"source": "inst-0", "target": "inst-1", "type": "supports"}])
+    tm = eq._qbaf_testedness(q, [_inst("supports", "d1"), _inst("supports", "d2")])
+    assert tm["testedness"] == "support_only"
+    assert tm["n_support_edges"] == 1 and tm["n_attack_edges"] == 0
+    assert tm["n_untested_nodes"] == 2          # no attacks → all untested
+
+
+def test_testedness_adversarial_when_attack_present():
+    q = _qbaf([{"id": "inst-0"}, {"id": "inst-1"}],
+              [{"source": "inst-0", "target": "inst-1", "type": "attacks"}])
+    tm = eq._qbaf_testedness(q, [_inst("supports", "d1"), _inst("disputes", "d2")])
+    assert tm["testedness"] == "adversarial"
+    assert tm["n_attack_edges"] == 1
+    assert tm["n_untested_nodes"] == 1          # inst-1 attacked, inst-0 not
+    assert tm["has_opposing_stances"] is True
+    assert tm["stance_hist"] == {"supports": 1, "disputes": 1}
+
+
 if __name__ == "__main__":
     import pytest
 


### PR DESCRIPTION
Prevention-per-incident for the QBAF edge-density gap (t/3302). Investigation (t/3302#1) found the root cause is **stance skew** (96.4% supports / 2.6% disputes / 0% qualifies) — the detector works; the tension is semantic (CL t/3302#2). This PR ships the **observability half**; the detection lever (semantic-opposition edges, fork B) is a separate cross-role design → TL.

## What
Makes silent all-prior QBAF resolutions (pure unrevised base priors) **visible** instead of presenting as substantive. Schema confirmed + extended by CL (t/3302#2).

- **`_qbaf_testedness(qbaf, instances)`** — per-conflict metric: `n_instances, n_edges, n_support_edges, n_attack_edges, n_untested_nodes, testedness` (`all_prior`|`support_only`|`adversarial`), `has_opposing_stances`, `stance_hist`.
- Main loop records `qbaf.testedness` on each resolved conflict; **WARNs per-conflict on `all_prior`** (Fallback-Path Logging); **aggregate-counts** the tiers (no per-conflict WARN for `support_only`, per CL). Run summary logs the tier distribution + adds `testedness_tiers` to the stdout JSON.

## Safety
Additive only — **does not change** the QBAF algorithm / edges / `computed_strength` / `resolution`. `qbaf.testedness` is derived observability metadata; the conflict `qbaf` shape has no strict Zod on the read path (renderer `validation.ts` is `.passthrough()`), so the additive field is read-safe for DebateTool.

## Tests
3 new cases (`test_enrich_conflicts_qbaf.py`) — all_prior / support_only / adversarial tiers + field mapping + untested-node counting. **11/11 pass** (covered by the `test-python` CI job).

## Design gate
Observability addition to a PS-owned script, CL-confirmed schema, additive field, no algorithm/model change — `/trivial-change` self-cert. Flagging the additive `qbaf.testedness` field to DebateTool (ignore-safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)