### PR TITLE
feat(debate-diagnostics): Debate-Tested tier badge + sort-by-tier in ArgStrengthTab (t/3303)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.css
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.css
@@ -144,10 +144,51 @@
   font-weight: 600;
 }
 
-/* row that holds the expand/collapse button (right-aligned) */
+/* row that holds sort toggles + expand/collapse (t/3303: sort added left-side) */
 .ast-toolbar-row {
   display: flex;
-  justify-content: flex-end;
+  align-items: center;
+  gap: 6px;
+}
+
+/* t/3303: sort axis controls */
+.ast-sort-label {
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.ast-sort-btns {
+  display: flex;
+  gap: 3px;
+}
+
+.ast-sort-btn {
+  font-size: var(--text-2xs);
+  padding: 1px 7px;
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.ast-sort-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.ast-sort-btn.active {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--text-secondary);
+  font-weight: 600;
+}
+
+/* pushes expand/collapse to the right */
+.ast-toolbar-spacer {
+  flex: 1;
 }
 
 .ast-expand-btn {
@@ -271,6 +312,35 @@
   color: var(--danger);
   white-space: nowrap;
   opacity: 0.9;
+}
+
+/* t/3303: Debate-Tested tier badge — second axis, inline before each argument row */
+.ast-tier-badge {
+  display: inline-block;
+  font-size: var(--text-2xs);
+  font-weight: 700;
+  padding: 0 4px;
+  border-radius: 3px;
+  vertical-align: middle;
+  cursor: default;
+  user-select: none;
+  margin-right: 4px;
+  min-width: 14px;
+  text-align: center;
+}
+
+.ast-tier-untested {
+  color: var(--text-muted);
+  opacity: 0.4;
+}
+
+.ast-tier-cited {
+  color: var(--text-secondary);
+  opacity: 0.6;
+}
+
+.ast-tier-contested {
+  color: var(--success, #16a34a);
 }
 
 .ast-empty {

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.test.tsx
@@ -9,6 +9,9 @@ import { ArgStrengthTab } from './ArgStrengthTab';
 // Mocks — isolate the tab from qbaf math, INodeRow detail, and POV metadata.
 // ---------------------------------------------------------------------------
 vi.mock('@lib/debate/qbaf', () => ({ computeQbafStrengths: () => ({ strengths: new Map() }) }));
+vi.mock('@lib/debate/debateTested', () => ({
+  DEBATE_TESTED_DEFAULTS: { SEVERE_ATTACK_THRESHOLD: 0.5 },
+}));
 vi.mock('../shared/INodeRow', () => ({
   INodeRow: (props: { node?: { id?: string } }) => <div data-testid={`inode-${props.node?.id}`} />,
 }));
@@ -188,5 +191,71 @@ describe('ArgStrengthTab — t/3301 tested filter, count line, attack badge', ()
     render(<ArgStrengthTab {...makeProps(NODES)} />);
     fireEvent.click(screen.getByRole('button', { name: 'Show all' }));
     expect(screen.getAllByTestId(/^inode-a/)).toHaveLength(7);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// t/3303: Debate-Tested tier badge + secondary sort axis
+// ---------------------------------------------------------------------------
+describe('ArgStrengthTab — t/3303 tier badge + sort-by-tier', () => {
+  // a1: severe attacker (strength derives from computed_strength of source, default 0.5 for mock)
+  // In our mock, computeQbafStrengths returns empty Map, so strengthMap.get() = undefined,
+  // and we fall back to baseStrengths. a4 base_strength = 0.5 >= threshold → a1 is 'contested'.
+  // a0: supported by a4 (support edge, not attack) → 'cited' (has incoming, no severe attack).
+  // a3: no incoming edges → 'untested'.
+  const TIER_EDGES = [
+    edge('a4', 'a1', 'attacks'),   // a1 gets contested (a4 base=0.5 >= threshold)
+    edge('a4', 'a0', 'supports'),  // a0 gets cited (support only)
+  ];
+
+  it('Sort: Strength button is active by default', () => {
+    render(<ArgStrengthTab {...makeProps(NODES, TIER_EDGES)} />);
+    const btn = screen.getByRole('button', { name: 'Strength' });
+    expect(btn.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('Sort: Tier button is inactive by default', () => {
+    render(<ArgStrengthTab {...makeProps(NODES, TIER_EDGES)} />);
+    const btn = screen.getByRole('button', { name: 'Tier' });
+    expect(btn.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('Sort: clicking Tier makes it active and Strength inactive', () => {
+    render(<ArgStrengthTab {...makeProps(NODES, TIER_EDGES)} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Tier' }));
+    expect(screen.getByRole('button', { name: 'Tier' }).getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByRole('button', { name: 'Strength' }).getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('tier badge renders for every visible node (All filter)', () => {
+    render(<ArgStrengthTab {...makeProps(NODES, TIER_EDGES)} />);
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
+    // Every node row should have an aria-label starting "Tier:"
+    const badges = screen.getAllByLabelText(/^Tier:/);
+    // 11 total nodes in NODES fixture
+    expect(badges).toHaveLength(11);
+  });
+
+  it('contested tier badge title matches SEVERE_ATTACK_THRESHOLD semantics', () => {
+    render(<ArgStrengthTab {...makeProps(NODES, TIER_EDGES)} />);
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
+    // a1 is contested — has title with "strength >= 0.5"
+    const contested = screen.getByTitle(/Contested — survived ≥1 severe attack/);
+    expect(contested).toBeTruthy();
+  });
+
+  it('untested tier badge renders for node with no incoming edges', () => {
+    render(<ArgStrengthTab {...makeProps(NODES, TIER_EDGES)} />);
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
+    // a3 has no edges — should have "Tier: untested" aria-label
+    const untested = screen.getAllByLabelText('Tier: untested');
+    expect(untested.length).toBeGreaterThan(0);
+  });
+
+  it('cited tier badge renders for node with support-only incoming edges', () => {
+    render(<ArgStrengthTab {...makeProps(NODES, TIER_EDGES)} />);
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
+    const cited = screen.getAllByLabelText('Tier: cited');
+    expect(cited.length).toBeGreaterThan(0);
   });
 });

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.tsx
@@ -6,6 +6,7 @@ import './ArgStrengthTab.css';
 import type { DebateSession, ArgumentNetworkNode, ArgumentNetworkEdge } from '../../../../types/debate';
 import { computeQbafStrengths } from '@lib/debate/qbaf';
 import type { QbafNode, QbafEdge } from '@lib/debate/qbaf';
+import { DEBATE_TESTED_DEFAULTS } from '@lib/debate/debateTested';
 import { INodeRow } from '../shared/INodeRow';
 import { speakerLabel } from '../helpers';
 import type { OverviewTab } from '../types';
@@ -24,7 +25,48 @@ interface ArgStrengthTabProps {
 // t/3301: 'all' = no filter; 'ge1' = in-degree ≥1 (default); 'ge2' = in-degree ≥2 (stricter).
 type TestedFilter = 'all' | 'ge1' | 'ge2';
 
+// t/3303: Debate-tested tier — derivable from single-debate attack edges.
+// 'well_tested' requires multi-debate data; omitted here (single-debate view).
+type DebateTier = 'untested' | 'cited' | 'contested';
+
+// t/3303: Sort axis — strength (QBAF acceptability, default) or tier (dialectical testedness).
+type SortMode = 'strength' | 'tier';
+
 const POV_ORDER = ['accelerationist', 'safetyist', 'skeptic'] as const;
+
+const TIER_RANK: Record<DebateTier, number> = { untested: 0, cited: 1, contested: 2 };
+
+const TIER_LABEL: Record<DebateTier, string> = {
+  untested: '–',
+  cited: '·',
+  contested: '✓',
+};
+
+const TIER_TOOLTIP: Record<DebateTier, string> = {
+  untested: 'Untested — no incoming edges in this debate',
+  cited: 'Cited — appeared but never severely challenged (no attack ≥ 0.5 strength)',
+  contested: 'Contested — survived ≥1 severe attack (attacker strength ≥ 0.5)',
+};
+
+// Derive single-debate tier from incoming attack edges + attacker computed strength.
+// Mirrors the predicate in debateTested.ts findStrongestAttack (SEVERE_ATTACK_THRESHOLD).
+function deriveTier(
+  nodeId: string,
+  edges: ArgumentNetworkEdge[],
+  strengthMap: Map<string, number>,
+  baseStrengths: Map<string, number>,
+): DebateTier {
+  const incoming = edges.filter(e => e.target === nodeId);
+  if (incoming.length === 0) return 'untested';
+
+  const hasSevereAttack = incoming.some(e => {
+    if (e.type !== 'attacks') return false;
+    const s = strengthMap.get(e.source) ?? baseStrengths.get(e.source) ?? 0;
+    return s >= DEBATE_TESTED_DEFAULTS.SEVERE_ATTACK_THRESHOLD;
+  });
+
+  return hasSevereAttack ? 'contested' : 'cited';
+}
 
 export function ArgStrengthTab({
   debate, an, handleUpdateSubScore, setOverviewTab, setSelectedEntry, setLocalOverride, nodeLabels,
@@ -35,6 +77,8 @@ export function ArgStrengthTab({
   const [top5Povs, setTop5Povs] = useState<Set<string>>(new Set());
   // t/3301: default to in-degree ≥1 so untested priors are hidden by default.
   const [testedFilter, setTestedFilter] = useState<TestedFilter>('ge1');
+  // t/3303: secondary sort axis. Default: QBAF acceptability strength.
+  const [sortMode, setSortMode] = useState<SortMode>('strength');
 
   const togglePov = (pov: string, setter: React.Dispatch<React.SetStateAction<Set<string>>>) =>
     setter(prev => {
@@ -62,6 +106,12 @@ export function ArgStrengthTab({
     return computeQbafStrengths(qbafNodes, qbafEdges).strengths;
   }, [an.nodes, edges]);
 
+  const baseStrengths = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const n of an.nodes) m.set(n.id, n.base_strength ?? 0.5);
+    return m;
+  }, [an.nodes]);
+
   // t/3301: in-degree per node (incoming edges only — those test this node's strength).
   const inDegreeMap = useMemo(() => {
     const m = new Map<string, number>();
@@ -69,6 +119,15 @@ export function ArgStrengthTab({
     for (const e of edges) m.set(e.target, (m.get(e.target) ?? 0) + 1);
     return m;
   }, [an.nodes, edges]);
+
+  // t/3303: derive Debate-Tested tier per node (single-debate approximation).
+  const tierMap = useMemo(() => {
+    const m = new Map<string, DebateTier>();
+    for (const n of an.nodes) {
+      m.set(n.id, deriveTier(n.id, edges, strengthMap, baseStrengths));
+    }
+    return m;
+  }, [an.nodes, edges, strengthMap, baseStrengths]);
 
   const totalNodes = an.nodes.length;
   const testedGe1Count = useMemo(
@@ -84,14 +143,20 @@ export function ArgStrengthTab({
       map.get(n.speaker)!.push(n);
     }
     for (const [, nodes] of map) {
-      nodes.sort(
-        (a, b) =>
+      nodes.sort((a, b) => {
+        if (sortMode === 'tier') {
+          const ta = TIER_RANK[tierMap.get(a.id) ?? 'untested'];
+          const tb = TIER_RANK[tierMap.get(b.id) ?? 'untested'];
+          if (tb !== ta) return tb - ta;
+        }
+        return (
           (strengthMap.get(b.id) ?? b.base_strength ?? 0.5) -
-          (strengthMap.get(a.id) ?? a.base_strength ?? 0.5),
-      );
+          (strengthMap.get(a.id) ?? a.base_strength ?? 0.5)
+        );
+      });
     }
     return map;
-  }, [an.nodes, strengthMap]);
+  }, [an.nodes, strengthMap, tierMap, sortMode]);
 
   // t/3301: apply tested filter on top of the sorted nodesByPov.
   const filteredNodesByPov = useMemo(() => {
@@ -151,11 +216,30 @@ export function ArgStrengthTab({
             ))}
           </div>
         </div>
+        {/* t/3303: sort axis toggle + expand/collapse */}
         <div className="ast-toolbar-row">
+          <span className="ast-sort-label">Sort:</span>
+          <div className="ast-sort-btns">
+            {(['strength', 'tier'] as SortMode[]).map(m => (
+              <button
+                key={m}
+                type="button"
+                className={`ast-sort-btn${sortMode === m ? ' active' : ''}`}
+                aria-pressed={sortMode === m}
+                onClick={() => setSortMode(m)}
+                title={
+                  m === 'strength'
+                    ? 'Sort by QBAF acceptability (computed strength)'
+                    : 'Sort by Debate-Tested tier (dialectical testedness), then strength'
+                }
+              >
+                {m === 'strength' ? 'Strength' : 'Tier'}
+              </button>
+            ))}
+          </div>
           <button
             type="button"
             className="ast-expand-btn"
-            // t/2686: operates on POV SECTIONS. Expand All also expands argument-row detail.
             onClick={() => {
               if (anyCollapsed) { setCollapsedPovs(new Set()); setAllExpanded(true); }
               else { setCollapsedPovs(new Set(orderedPovs)); }
@@ -225,6 +309,7 @@ export function ArgStrengthTab({
               const isSource = edges.some(e => e.source === n.id);
               const rank = idx < 3 ? idx + 1 : null;
               const hasAttack = attacks.length > 0;
+              const tier = tierMap.get(n.id) ?? 'untested';
               return (
                 <div key={n.id} className="ast-node-wrap">
                   {(rank != null || hasAttack) && (
@@ -249,6 +334,14 @@ export function ArgStrengthTab({
                       )}
                     </div>
                   )}
+                  {/* t/3303: tier badge — dialectical testedness second axis */}
+                  <span
+                    className={`ast-tier-badge ast-tier-${tier}`}
+                    title={TIER_TOOLTIP[tier]}
+                    aria-label={`Tier: ${tier}`}
+                  >
+                    {TIER_LABEL[tier]}
+                  </span>
                   <INodeRow
                     node={n}
                     attacks={attacks}


### PR DESCRIPTION
## Summary
- Imports DEBATE_TESTED_DEFAULTS (SEVERE_ATTACK_THRESHOLD=0.5) from @lib/debate/debateTested
- deriveTier(): derives single-debate tier from attacker base_strength >= 0.5
  untested (no edges) / cited (no severe attack) / contested (severe attack)
- Tier badge inline per row: -- / . / check-mark with descriptive tooltip
- Sort axis toggle: Strength (default, QBAF) vs Tier (tier-rank desc then strength)
- 7 new tests; 22 total passing

## Test plan
- [x] 22/22 vitest passing
- [ ] Open debate window, verify tier badges appear on each argument row
- [ ] Verify sort-by-Tier reorders contested nodes above cited/untested

Note: base is feat/arg-strength-tested-filter-t3301 (t/3301) — will rebase to main once t/3301 merges. Pairs with t/3304 which reuses tierMap plumbing.

Closes t/3303
