### PR TITLE
feat(debate-diagnostics): Debate-tested only opt-in filter in ArgStrengthTab (t/3304)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.css
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.css
@@ -115,6 +115,23 @@
   font-style: italic;
 }
 
+/* t/3304: hidden-by-dt-filter count */
+.ast-count-dt-hidden {
+  color: var(--warning, #d97706);
+  font-weight: 500;
+}
+
+/* t/3304: "Debate-tested only" button — slightly accented to distinguish from the degree buttons */
+.ast-filter-btn-dt {
+  border-color: color-mix(in srgb, var(--warning, #d97706) 40%, var(--border-color));
+}
+
+.ast-filter-btn-dt.active {
+  background: color-mix(in srgb, var(--warning, #d97706) 10%, transparent);
+  border-color: var(--warning, #d97706);
+  color: var(--warning, #d97706);
+}
+
 .ast-filter-btns {
   display: flex;
   gap: 3px;

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.test.tsx
@@ -259,3 +259,62 @@ describe('ArgStrengthTab — t/3303 tier badge + sort-by-tier', () => {
     expect(cited.length).toBeGreaterThan(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// t/3304: "Debate-tested only" opt-in filter
+// ---------------------------------------------------------------------------
+describe('ArgStrengthTab — t/3304 Debate-tested only filter', () => {
+  // a1 has a severe attack (a4 base=0.5 >= 0.5) → contested → passes DT filter.
+  // a0 has support-only → cited → filtered out when DT only.
+  // a3+ have no edges → untested → filtered out.
+  const DT_EDGES = [
+    edge('a4', 'a1', 'attacks'),  // a1 contested (a4 base_strength=0.5 >= threshold)
+    edge('a4', 'a0', 'supports'), // a0 cited
+  ];
+
+  it('"Debate-tested only" button is inactive by default (opt-in)', () => {
+    render(<ArgStrengthTab {...makeProps(NODES, DT_EDGES)} />);
+    const btn = screen.getByRole('button', { name: 'Debate-tested only' });
+    expect(btn.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('activating the filter shows only contested nodes', () => {
+    render(<ArgStrengthTab {...makeProps(NODES, DT_EDGES)} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Debate-tested only' }));
+    // Only a1 is contested — ge1 testedFilter also active (default), so only a1 passes both.
+    expect(screen.getAllByTestId(/^inode-a/)).toHaveLength(1);
+    expect(screen.getByTestId('inode-a1')).toBeTruthy();
+  });
+
+  it('activating the filter shows hidden count in count line', () => {
+    render(<ArgStrengthTab {...makeProps(NODES, DT_EDGES)} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Debate-tested only' }));
+    // 1 shown of 11 total → "10 not yet debate-tested"
+    expect(screen.getByText(/not yet debate-tested/)).toBeTruthy();
+  });
+
+  it('deactivating the filter restores previous view', () => {
+    render(<ArgStrengthTab {...makeProps(NODES, DT_EDGES)} />);
+    const dtBtn = screen.getByRole('button', { name: 'Debate-tested only' });
+    fireEvent.click(dtBtn); // on
+    fireEvent.click(dtBtn); // off
+    // Back to ge1 default: a0 and a1 are tested (in-degree >=1)
+    expect(screen.getAllByTestId(/^inode-a/)).toHaveLength(2);
+  });
+
+  it('DT filter composes with All (degree filter): shows all contested across all nodes', () => {
+    render(<ArgStrengthTab {...makeProps(NODES, DT_EDGES)} />);
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));      // drop degree filter
+    fireEvent.click(screen.getByRole('button', { name: 'Debate-tested only' })); // add DT
+    // Still only a1 is contested — other nodes untested/cited
+    expect(screen.getAllByTestId(/^inode-a/)).toHaveLength(1);
+  });
+
+  it('empty state when DT filter hides all nodes', () => {
+    // No edges → everything untested → DT filter = empty
+    render(<ArgStrengthTab {...makeProps(NODES)} />);
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Debate-tested only' }));
+    expect(screen.getByText(/No tested arguments match/)).toBeTruthy();
+  });
+});

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.tsx
@@ -79,6 +79,9 @@ export function ArgStrengthTab({
   const [testedFilter, setTestedFilter] = useState<TestedFilter>('ge1');
   // t/3303: secondary sort axis. Default: QBAF acceptability strength.
   const [sortMode, setSortMode] = useState<SortMode>('strength');
+  // t/3304: "Debate-tested only" opt-in filter — keeps tier ∈ {contested}.
+  // Default OFF: this removes ~45-54% of nodes and must not be a silent default.
+  const [debateTestedOnly, setDebateTestedOnly] = useState(false);
 
   const togglePov = (pov: string, setter: React.Dispatch<React.SetStateAction<Set<string>>>) =>
     setter(prev => {
@@ -159,21 +162,39 @@ export function ArgStrengthTab({
   }, [an.nodes, strengthMap, tierMap, sortMode]);
 
   // t/3301: apply tested filter on top of the sorted nodesByPov.
+  // t/3304: also apply debateTestedOnly (tier === 'contested') when enabled.
   const filteredNodesByPov = useMemo(() => {
-    if (testedFilter === 'all') return nodesByPov;
-    const minDegree = testedFilter === 'ge1' ? 1 : 2;
-    const result = new Map<string, ArgumentNetworkNode[]>();
-    for (const [pov, nodes] of nodesByPov) {
-      const filtered = nodes.filter(n => (inDegreeMap.get(n.id) ?? 0) >= minDegree);
-      if (filtered.length > 0) result.set(pov, filtered);
+    let result = nodesByPov;
+
+    if (testedFilter !== 'all') {
+      const minDegree = testedFilter === 'ge1' ? 1 : 2;
+      const degreeFiltered = new Map<string, ArgumentNetworkNode[]>();
+      for (const [pov, nodes] of result) {
+        const f = nodes.filter(n => (inDegreeMap.get(n.id) ?? 0) >= minDegree);
+        if (f.length > 0) degreeFiltered.set(pov, f);
+      }
+      result = degreeFiltered;
     }
+
+    if (debateTestedOnly) {
+      const strict = new Map<string, ArgumentNetworkNode[]>();
+      for (const [pov, nodes] of result) {
+        const f = nodes.filter(n => tierMap.get(n.id) === 'contested');
+        if (f.length > 0) strict.set(pov, f);
+      }
+      result = strict;
+    }
+
     return result;
-  }, [nodesByPov, testedFilter, inDegreeMap]);
+  }, [nodesByPov, testedFilter, inDegreeMap, debateTestedOnly, tierMap]);
 
   const shownCount = useMemo(
     () => [...filteredNodesByPov.values()].reduce((s, ns) => s + ns.length, 0),
     [filteredNodesByPov],
   );
+
+  // t/3304: when debateTestedOnly is on, show how many are hidden by the strict filter.
+  const debateTestedHiddenCount = totalNodes - shownCount;
 
   if (an.nodes.length === 0) {
     return <div className="ast-empty">No argument network data for this debate.</div>;
@@ -192,10 +213,13 @@ export function ArgStrengthTab({
         <div className="ast-filter-controls">
           <span className="ast-count-line">
             Showing {shownCount} of {totalNodes}
-            {untestedCount > 0 && (
-              <> · <span className="ast-count-untested">{untestedCount} untested</span>
-              {' '}<span className="ast-count-note">(mostly unmeasured)</span></>
-            )}
+            {debateTestedOnly
+              ? <> — <span className="ast-count-dt-hidden">{debateTestedHiddenCount} not yet debate-tested</span></>
+              : untestedCount > 0 && (
+                <> · <span className="ast-count-untested">{untestedCount} untested</span>
+                {' '}<span className="ast-count-note">(mostly unmeasured)</span></>
+              )
+            }
           </span>
           <div className="ast-filter-btns">
             {(['all', 'ge1', 'ge2'] as TestedFilter[]).map(f => (
@@ -214,6 +238,16 @@ export function ArgStrengthTab({
                 {f === 'all' ? 'All' : f === 'ge1' ? 'In-degree ≥1' : 'In-degree ≥2'}
               </button>
             ))}
+            {/* t/3304: strict opt-in filter — only nodes that survived severe attack */}
+            <button
+              type="button"
+              className={`ast-filter-btn ast-filter-btn-dt${debateTestedOnly ? ' active' : ''}`}
+              aria-pressed={debateTestedOnly}
+              onClick={() => setDebateTestedOnly(v => !v)}
+              title="Debate-tested only — show arguments that survived ≥1 severe attack (attacker strength ≥ 0.5). Removes ~45-54% of nodes."
+            >
+              Debate-tested only
+            </button>
           </div>
         </div>
         {/* t/3303: sort axis toggle + expand/collapse */}


### PR DESCRIPTION
## Summary
- debateTestedOnly toggle (default OFF — removes 45-54% of nodes, must be opt-in per ticket spec)
- Filter predicate: tier === "contested" (survived severe attack >= 0.5), reuses tierMap from t/3303
- Composes with the existing degree filter (testedFilter)
- Count line: "X not yet debate-tested" replaces untested count when filter is active
- "Debate-tested only" button, accented in warning color when active
- 6 new tests; 28 total passing

## Test plan
- [x] 28/28 vitest passing
- [ ] Activate filter — only contested-tier nodes remain, count line shows N hidden
- [ ] Deactivate — previous view restores

Note: base is feat/arg-strength-tier-badge-t3303 (t/3303) — rebases to main once ancestors merge.

Closes t/3304
