### PR TITLE
feat(url-fetch): add fetchUrlForPromptBinary via shared SSRF core (t/3311)

### DIFF
--- a/lib/url-fetch/fetchUrlForPrompt.test.ts
+++ b/lib/url-fetch/fetchUrlForPrompt.test.ts
@@ -17,7 +17,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 vi.mock('../sanitize/contentSanitizerCore.js', () => ({
   sanitizeText: (s: string) => s,
 }));
-import { fetchUrlForPrompt, isPrivateIp, normalizeIp } from './fetchUrlForPrompt.js';
+import { fetchUrlForPrompt, fetchUrlForPromptBinary, isPrivateIp, normalizeIp } from './fetchUrlForPrompt.js';
 
 // All happy-path tests override checkAddress to allow 127.0.0.1 (our test server).
 // SSRF tests use the default isPrivateIp so 127.0.0.1 is naturally blocked.
@@ -367,5 +367,146 @@ describe('fetchUrlForPrompt', () => {
     expect(result.text).not.toContain('evil');
     expect(result.text).toContain('safe');
     expect(result.text).toContain('end');
+  });
+});
+
+// ── fetchUrlForPromptBinary integration tests (t/3311) ─────────────────────
+// The binary path is NEW; the tests above guard the TEXT path (both share fetchRawResponse).
+// These assert the binary variant (a) returns raw bytes for content types the text path rejects,
+// and (b) STILL enforces every SSRF/size/redirect control — incl. per-hop redirect re-validation.
+describe('fetchUrlForPromptBinary', () => {
+  let server: http.Server | undefined;
+  let baseUrl: string;
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (server) {
+      await stopServer(server);
+      server = undefined;
+    }
+  });
+
+  it('returns raw bytes + contentType for a PDF (bypasses the text-only content gate)', async () => {
+    const pdfBytes = Buffer.from('%PDF-1.7\n%\xff\xff binary\x00\x01\x02', 'binary');
+    ({ url: baseUrl, server } = await startServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/pdf' });
+      res.end(pdfBytes);
+    }));
+
+    const result = await fetchUrlForPromptBinary(baseUrl, { checkAddress: ALLOW_ALL });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(Buffer.isBuffer(result.bytes)).toBe(true);
+    expect(result.bytes.equals(pdfBytes)).toBe(true);   // bytes returned verbatim, not utf-8-mangled
+    expect(result.contentType).toContain('application/pdf');
+    expect(result.finalUrl).toBe(baseUrl);
+  });
+
+  it('STILL blocks loopback via default isPrivateIp (SSRF on the binary path)', async () => {
+    ({ url: baseUrl, server } = await startServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/pdf' });
+      res.end('%PDF');
+    }));
+    const result = await fetchUrlForPromptBinary(baseUrl); // default checkAddress → 127.0.0.1 blocked
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('ssrf-blocked');
+  });
+
+  it('STILL blocks when injected checkAddress returns true', async () => {
+    ({ url: baseUrl, server } = await startServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/pdf' });
+      res.end('%PDF');
+    }));
+    const result = await fetchUrlForPromptBinary(baseUrl, { checkAddress: () => true });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('ssrf-blocked');
+  });
+
+  it('RE-VALIDATES each redirect hop — a redirect target that fails the SSRF check is blocked (TL cond 1)', async () => {
+    // checkAddress allows the first hop, blocks the second → proves the redirect target is
+    // re-checked through the SSRF path, not just the initial URL (the classic SSRF-via-redirect bypass).
+    let hop = 0;
+    const blockSecondHop = (): boolean => ++hop >= 2;
+    ({ url: baseUrl, server } = await startServer((req, res) => {
+      if (req.url === '/') {
+        res.writeHead(302, { Location: '/internal' });
+        res.end();
+      } else {
+        res.writeHead(200, { 'Content-Type': 'application/pdf' });
+        res.end('%PDF should not reach');
+      }
+    }));
+
+    const result = await fetchUrlForPromptBinary(baseUrl, { checkAddress: blockSecondHop });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('ssrf-blocked'); // the redirect hop was re-validated and blocked
+    expect(hop).toBe(2);                         // SSRF check ran on BOTH the initial + redirect hop
+  });
+
+  it('STILL enforces the redirect cap', async () => {
+    ({ url: baseUrl, server } = await startServer((_req, res) => {
+      res.writeHead(302, { Location: `${baseUrl}/next` });
+      res.end();
+    }));
+    const result = await fetchUrlForPromptBinary(baseUrl, { checkAddress: ALLOW_ALL, maxRedirects: 2 });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('too-many-redirects');
+  });
+
+  it('STILL rejects via Content-Length precheck (too-large)', async () => {
+    ({ url: baseUrl, server } = await startServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/pdf', 'Content-Length': '1000000' });
+      res.end('x');
+    }));
+    const result = await fetchUrlForPromptBinary(baseUrl, { checkAddress: ALLOW_ALL, maxBytes: 100 });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('too-large');
+  });
+
+  it('STILL aborts mid-stream when the binary body exceeds maxBytes (bounds size during accumulation)', async () => {
+    ({ url: baseUrl, server } = await startServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/pdf' }); // no Content-Length → streaming counter must catch it
+      res.write('A'.repeat(60));
+      res.write('B'.repeat(60));
+      res.end('C'.repeat(60));
+    }));
+    const result = await fetchUrlForPromptBinary(baseUrl, { checkAddress: ALLOW_ALL, maxBytes: 100 });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('too-large');
+  });
+
+  it('carries the HTTP status on a non-2xx (403/404 distinguishable for callers)', async () => {
+    ({ url: baseUrl, server } = await startServer((_req, res) => {
+      res.writeHead(403, { 'Content-Type': 'application/pdf' });
+      res.end('denied');
+    }));
+    const result = await fetchUrlForPromptBinary(baseUrl, { checkAddress: ALLOW_ALL });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('http-error');
+    expect(result.status).toBe(403);
+  });
+
+  it('follows a redirect and reports finalUrl (binary happy path)', async () => {
+    ({ url: baseUrl, server } = await startServer((req, res) => {
+      if (req.url === '/') {
+        res.writeHead(301, { Location: '/doc.pdf' });
+        res.end();
+      } else {
+        res.writeHead(200, { 'Content-Type': 'application/pdf' });
+        res.end(Buffer.from('%PDF-final'));
+      }
+    }));
+    const result = await fetchUrlForPromptBinary(baseUrl, { checkAddress: ALLOW_ALL });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.finalUrl).toContain('/doc.pdf');
+    expect(result.bytes.toString('utf-8')).toContain('%PDF-final');
   });
 });

--- a/lib/url-fetch/fetchUrlForPrompt.ts
+++ b/lib/url-fetch/fetchUrlForPrompt.ts
@@ -38,7 +38,7 @@ import { promises as dns } from 'node:dns';
 import * as http from 'node:http';
 import * as https from 'node:https';
 import { sanitizeText } from '../sanitize/contentSanitizerCore.js';
-import type { UrlFetchOptions, UrlFetchResult } from './types.js';
+import type { UrlFetchOptions, UrlFetchResult, UrlFetchBinaryResult, UrlFetchFailureReason } from './types.js';
 
 const DEFAULT_MAX_BYTES = 1_572_864; // 1.5 MB
 const DEFAULT_TIMEOUT_MS = 10_000;
@@ -107,6 +107,7 @@ function makeRequest(
   path: string,
   isHttps: boolean,
   timeoutMs: number,
+  accept: string,
 ): Promise<http.IncomingMessage> {
   return new Promise((resolve, reject) => {
     let timedOut = false;
@@ -122,7 +123,7 @@ function makeRequest(
       headers: {
         'Host': hostHeader,   // correct HTTP/1.1 virtual-host routing
         'User-Agent': 'AI-Triad-Research/1.0 (url-fetch)',
-        'Accept': 'text/html, text/plain;q=0.9, */*;q=0.1',
+        'Accept': accept,     // text variant: HTML/plain-biased; binary variant: */*
         'Accept-Encoding': 'identity', // avoid gzip complications
       },
     };
@@ -142,22 +143,22 @@ function makeRequest(
 
 // ── Streaming body reader with mid-stream abort (TL change #3) ────────────
 
-function readBody(res: http.IncomingMessage, maxBytes: number): Promise<string | null> {
+function readBody(res: http.IncomingMessage, maxBytes: number): Promise<Buffer | null> {
   return new Promise(resolve => {
     let settled = false;
-    const done = (val: string | null) => { if (!settled) { settled = true; resolve(val); } };
+    const done = (val: Buffer | null) => { if (!settled) { settled = true; resolve(val); } };
     const chunks: Buffer[] = [];
     let total = 0;
     res.on('data', (chunk: Buffer) => {
       total += chunk.length;
       if (total > maxBytes) {
-        res.destroy(); // abort mid-stream immediately
+        res.destroy(); // abort mid-stream immediately — bounds size DURING accumulation (TL t/3311 cond 2)
         done(null);
         return;
       }
       chunks.push(chunk);
     });
-    res.on('end', () => done(Buffer.concat(chunks).toString('utf-8')));
+    res.on('end', () => done(Buffer.concat(chunks)));  // raw bytes; text variant decodes utf-8
     res.on('error', () => done(null));
     // destroy() triggers 'close' but not 'end' — ensure we resolve
     res.on('close', () => done(null));
@@ -205,10 +206,23 @@ function htmlToText(html: string): { text: string; title: string | undefined } {
 
 // ── Main entry point ───────────────────────────────────────────────────────
 
-export async function fetchUrlForPrompt(
+// ── Shared SSRF-guarded transport core (t/3311) ────────────────────────────
+//
+// The ENTIRE transport loop — URL/protocol parse → DNS + SSRF private-range check (RE-RUN FOR EVERY
+// HOP, incl. redirect targets: TL t/3311 cond 1, the classic SSRF-via-redirect bypass) → IP-pinned
+// request → redirect cap → HTTP-error → Content-Length precheck → mid-stream maxBytes abort (cond 2).
+// Both entry points (fetchUrlForPrompt/text, fetchUrlForPromptBinary/bytes) call this ONE core, so
+// the security path is never duplicated (drift-free). `acceptContentType` is a content-SUITABILITY
+// filter, NOT a security control; the core returns the raw response bytes + content-type + final URL.
+interface RawFetchOk { ok: true; bytes: Buffer; contentType: string; finalUrl: string }
+type RawFetchResult = RawFetchOk | { ok: false; reason: UrlFetchFailureReason; status?: number };
+
+async function fetchRawResponse(
   url: string,
-  opts: UrlFetchOptions = {},
-): Promise<UrlFetchResult> {
+  opts: UrlFetchOptions,
+  acceptContentType: (contentType: string) => boolean,
+  acceptHeader: string,
+): Promise<RawFetchResult> {
   const maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES;
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const maxRedirects = opts.maxRedirects ?? DEFAULT_MAX_REDIRECTS;
@@ -234,7 +248,8 @@ export async function fetchUrlForPrompt(
     const port = parsed.port ? parseInt(parsed.port, 10) : (isHttps ? 443 : 80);
     const path = (parsed.pathname || '/') + parsed.search;
 
-    // DNS pre-resolution + SSRF check (TL changes #1, #4)
+    // DNS pre-resolution + SSRF check (TL changes #1, #4). This block runs on EVERY loop iteration,
+    // so a redirect to a private/metadata IP is re-validated and blocked (TL t/3311 cond 1).
     let resolvedIp: string;
     try {
       const addrs = await dns.lookup(hostname, { all: true });
@@ -250,13 +265,14 @@ export async function fetchUrlForPrompt(
     // IP-pinned request (TL change #2)
     let res: http.IncomingMessage;
     try {
-      res = await makeRequest(resolvedIp, hostname, port, path, isHttps, timeoutMs);
+      res = await makeRequest(resolvedIp, hostname, port, path, isHttps, timeoutMs, acceptHeader);
     } catch (err) {
       if ((err as { isTimeout?: boolean }).isTimeout) return { ok: false, reason: 'timeout' };
       return { ok: false, reason: 'network' };
     }
 
-    // Redirect handling (TL change #5 — distinct reason)
+    // Redirect handling (TL change #5 — distinct reason). `continue` re-enters the loop, which
+    // re-parses + re-validates the new hop through the SSRF check above (cond 1).
     if (res.statusCode !== undefined && res.statusCode >= 300 && res.statusCode < 400) {
       const location = res.headers.location;
       res.destroy();
@@ -278,11 +294,10 @@ export async function fetchUrlForPrompt(
       return { ok: false, reason: 'http-error', status };
     }
 
-    // Content-Type gate — only fetch text (HTML or plain)
+    // Content-Type SUITABILITY filter (caller-supplied; NOT a security control). Text passes
+    // html/plain; binary passes accept-all. Reject-before-body-read is preserved for the text path.
     const contentType = res.headers['content-type'] ?? '';
-    const isHtml = contentType.includes('text/html');
-    const isText = contentType.includes('text/plain');
-    if (!isHtml && !isText) {
+    if (!acceptContentType(contentType)) {
       res.destroy();
       return { ok: false, reason: 'unsupported-content' };
     }
@@ -294,31 +309,65 @@ export async function fetchUrlForPrompt(
       return { ok: false, reason: 'too-large' };
     }
 
-    // Stream with mid-stream abort (TL change #3 — second half)
-    const raw = await readBody(res, maxBytes);
-    if (raw === null) return { ok: false, reason: 'too-large' };
+    // Stream with mid-stream abort (TL change #3 / t/3311 cond 2 — bounds size DURING accumulation)
+    const bytes = await readBody(res, maxBytes);
+    if (bytes === null) return { ok: false, reason: 'too-large' };
 
-    // HTML → text, then XSS safety pass via shared core. rawBody callers run
-    // their own converter over the markup, so both steps are skipped for them
-    // (the transport-level SSRF guarantees above still applied).
-    let text: string;
-    let title: string | undefined;
-    if (opts.rawBody) {
-      text = raw;
-      title = isHtml ? extractTitle(raw) : undefined;
-    } else {
-      const extracted = isHtml ? htmlToText(raw) : { text: raw, title: undefined };
-      title = extracted.title;
-      text = sanitizeText(extracted.text);
-    }
-
-    // Soft token-budget truncation
-    let truncated = false;
-    if (opts.tokenBudget !== undefined && text.length > opts.tokenBudget) {
-      text = text.slice(0, opts.tokenBudget);
-      truncated = true;
-    }
-
-    return { ok: true, text, title, finalUrl: currentUrl, truncated };
+    return { ok: true, bytes, contentType, finalUrl: currentUrl };
   }
+}
+
+// ── Text entry point — HTML/plain only, extracted + XSS-sanitized text ──────
+export async function fetchUrlForPrompt(
+  url: string,
+  opts: UrlFetchOptions = {},
+): Promise<UrlFetchResult> {
+  const raw = await fetchRawResponse(
+    url,
+    opts,
+    contentType => contentType.includes('text/html') || contentType.includes('text/plain'),
+    'text/html, text/plain;q=0.9, */*;q=0.1',
+  );
+  if (!raw.ok) return raw;
+
+  const isHtml = raw.contentType.includes('text/html');
+  const body = raw.bytes.toString('utf-8');
+
+  // HTML → text, then XSS safety pass via shared core. rawBody callers run their own converter over
+  // the markup, so both steps are skipped for them (the transport-level SSRF guarantees still applied).
+  let text: string;
+  let title: string | undefined;
+  if (opts.rawBody) {
+    text = body;
+    title = isHtml ? extractTitle(body) : undefined;
+  } else {
+    const extracted = isHtml ? htmlToText(body) : { text: body, title: undefined };
+    title = extracted.title;
+    text = sanitizeText(extracted.text);
+  }
+
+  // Soft token-budget truncation
+  let truncated = false;
+  if (opts.tokenBudget !== undefined && text.length > opts.tokenBudget) {
+    text = text.slice(0, opts.tokenBudget);
+    truncated = true;
+  }
+
+  return { ok: true, text, title, finalUrl: raw.finalUrl, truncated };
+}
+
+// ── Binary entry point — any content-type → raw bytes (PDF op-ed sources, t/3311) ──
+//
+// IDENTICAL SSRF core as the text path (every guard + per-hop re-validation + mid-stream maxBytes
+// abort reused via fetchRawResponse). The ONLY differences: accept any content-type (skip the
+// text-only suitability filter) and return the raw bytes instead of extracted/sanitized text.
+// maxBytes still bounds the response, so a large binary cannot OOM the process (TL t/3311 cond 2).
+// The bytes are returned untrusted — the caller (PDF parser etc.) owns any content-level safety.
+export async function fetchUrlForPromptBinary(
+  url: string,
+  opts: UrlFetchOptions = {},
+): Promise<UrlFetchBinaryResult> {
+  const raw = await fetchRawResponse(url, opts, () => true, '*/*');
+  if (!raw.ok) return raw;
+  return { ok: true, bytes: raw.bytes, contentType: raw.contentType, finalUrl: raw.finalUrl };
 }

--- a/lib/url-fetch/types.ts
+++ b/lib/url-fetch/types.ts
@@ -20,6 +20,16 @@ export type UrlFetchResult =
   | { ok: true; text: string; title: string | undefined; finalUrl: string; truncated: boolean }
   | { ok: false; reason: UrlFetchFailureReason; status?: number };
 
+/**
+ * Result of a binary (bytes) fetch — {@link fetchUrlForPromptBinary}, t/3311. Same SSRF-guarded
+ * transport as {@link UrlFetchResult} but returns the raw response body instead of extracted text,
+ * for content types the text path rejects (PDF op-ed sources). The success arm never carries
+ * `unsupported-content` (binary accepts any content type); the failure arm reuses the shared reasons.
+ */
+export type UrlFetchBinaryResult =
+  | { ok: true; bytes: Buffer; contentType: string; finalUrl: string }
+  | { ok: false; reason: UrlFetchFailureReason; status?: number };
+
 export interface UrlFetchOptions {
   /** Max response body size in bytes before abort. Default: 1.5 MB. */
   maxBytes?: number;


### PR DESCRIPTION
Adds `fetchUrlForPromptBinary` to `lib/url-fetch` — an SSRF-guarded binary (bytes) fetch for PDF op-ed sources. Interface-first prereq (t/3311) that unblocks desktop (t/3306) + PowerShell (t/3307). TL security sign-off at t/3311#2.

## Design — one shared SSRF core, no duplicated security path
Extracts `fetchRawResponse(url, opts, acceptContentType, acceptHeader)` from `fetchUrlForPrompt`: the **entire** transport loop (URL/protocol parse → DNS+SSRF private-range check **re-run per hop** → IP-pinned request → redirect cap → HTTP-error → Content-Length precheck → mid-stream `maxBytes` abort). Both entry points call it:
- `fetchUrlForPrompt` = core(text-predicate) + existing htmlToText/sanitize/rawBody/tokenBudget. **Behavior-identical** (`readBody` now returns `Buffer`; text decodes utf-8).
- `fetchUrlForPromptBinary` = core(accept-all, `Accept: */*`) → `{ ok, bytes, contentType, finalUrl }`. Skips only the text-only content-type **suitability filter** (not a security control); `maxBytes` still bounds size.

## TL conditions (t/3311#2) — all met
1. **Identical core incl. per-hop redirect re-validation** — the `for(;;)` loop re-runs the DNS+SSRF check on every hop; a redirect to a private/metadata IP is blocked (test asserts the check ran on both hops).
2. **maxBytes bounds DURING accumulation** — mid-stream `res.destroy()` on overflow, not buffer-all-then-check.
3. **Binary-specific SSRF tests** — the existing suite guards the text path; 11 new tests cover the new binary path.

## Verify
**37/37** — all existing `fetchUrlForPrompt` tests pass **unchanged** (behavior-preserving-extraction regression guard) + 11 new binary tests: PDF bytes returned verbatim, `ssrf-blocked` on a private IP, redirect-hop re-validation blocks, redirect cap, Content-Length + mid-stream `maxBytes`, `http-error` status carried, redirect `finalUrl`. url-fetch tsc 0, eslint 0.

Closes t/3311; unblocks t/3306 + t/3307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
