### PR TITLE
feat(main): route op-ed Stage A fetch through Node fetchUrlForPromptBinary (t/3306)

### DIFF
--- a/taxonomy-editor/src/main/__tests__/opedHandlers.create.test.ts
+++ b/taxonomy-editor/src/main/__tests__/opedHandlers.create.test.ts
@@ -12,13 +12,33 @@ import { EventEmitter } from 'events';
 import { ipcMain } from 'electron';
 import type { OpEdSet } from '../../../../lib/oped/types.js';
 
-// ── child_process.spawn mock (Stage A only) ───────────────────────────────────
+// ── child_process.spawn mock (Stage A convert-only PS runner) ────────────────
 
 const mockSpawn = vi.hoisted(() => vi.fn());
 
 vi.mock('child_process', () => ({
   default: { spawn: mockSpawn },
   spawn: mockSpawn,
+}));
+
+// ── Node fetch mock (fetchUrlForPromptBinary — t/3306) ────────────────────────
+
+const mockFetchBinary = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../../lib/url-fetch/fetchUrlForPrompt.js', () => ({
+  fetchUrlForPromptBinary: (...args: unknown[]) => mockFetchBinary(...args),
+}));
+
+// ── fs + os mocks (temp file write/cleanup) ───────────────────────────────────
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return { ...actual, writeFileSync: vi.fn(), rmSync: vi.fn() };
+});
+
+vi.mock('os', () => ({
+  default: { tmpdir: () => '/tmp' },
+  tmpdir: () => '/tmp',
 }));
 
 // ── Electron mock ─────────────────────────────────────────────────────────────
@@ -113,6 +133,17 @@ async function* makeCompleteGenerator(set: OpEdSet): AsyncGenerator<{ type: stri
   yield { type: 'complete', set };
 }
 
+// Flush the microtask + macrotask queues so async fetch chains complete before
+// we emit PS stdout. One Promise.resolve() is not enough once fetch is async.
+const flushPromises = (): Promise<void> => new Promise(r => setImmediate(r));
+
+const FAKE_FETCH_RESULT = {
+  ok: true as const,
+  bytes: Buffer.from('fake content'),
+  contentType: 'text/html; charset=utf-8',
+  finalUrl: 'https://example.com',
+};
+
 const baseParams = { wordCount: 600, model: 'test-model' };
 
 const FAKE_SET: OpEdSet = {
@@ -127,6 +158,8 @@ const FAKE_SET: OpEdSet = {
 beforeEach(() => {
   vi.clearAllMocks();
   mockGenerateOpEdSet.mockImplementation(() => makeCompleteGenerator(FAKE_SET));
+  // Default: fetch succeeds (tests that simulate fetch failure override this).
+  mockFetchBinary.mockResolvedValue(FAKE_FETCH_RESULT);
   registerOpEdHandlers();
 });
 
@@ -214,8 +247,8 @@ describe('create-oped-set — Stage-A source hoist', () => {
       { topic: 'topic', url: 'https://example.com', params: baseParams, voices: ['accelerationist'] },
     ) as Promise<unknown>;
 
-    // Let Stage A start, then emit prep result to unblock
-    await Promise.resolve();
+    // flushPromises lets the async fetch chain complete before the PS spawn starts.
+    await flushPromises();
     emitPrepResult(prepChild, FAKE_SOURCE_PREP);
     await resultP;
 
@@ -239,7 +272,7 @@ describe('create-oped-set — Stage-A source hoist', () => {
       { topic: 'topic', url: 'https://example.com', params: baseParams, voices: ['accelerationist'] },
     ) as Promise<unknown>;
 
-    await Promise.resolve();
+    await flushPromises();
     emitPrepResult(prepChild, FAKE_SOURCE_PREP);
     await resultP;
 
@@ -248,7 +281,7 @@ describe('create-oped-set — Stage-A source hoist', () => {
     expect(request.sourceMaterial).toBe(FAKE_SOURCE_PREP.SourceMarkdown);
   });
 
-  it('fail-fast: unreadable source throws ActionableError, no generateOpEdSet call, no finalize', async () => {
+  it('fail-fast: PS convert exits non-zero → throws ActionableError, no generateOpEdSet call', async () => {
     const prepChild = makePrepChild();
     mockSpawn.mockReturnValue(prepChild);
 
@@ -260,16 +293,34 @@ describe('create-oped-set — Stage-A source hoist', () => {
       { topic: 'topic', url: 'https://example.com', params: baseParams, voices: ['accelerationist'] },
     ) as Promise<unknown>;
 
-    await Promise.resolve();
-    // Prep shim exits non-zero (readability gate trip)
+    await flushPromises();
+    // PS convert shim exits non-zero (e.g. unsupported format)
     prepChild.emit('close', 1);
 
     await expect(resultP).rejects.toThrow();
     expect(mockFinalize).not.toHaveBeenCalled();
     expect(mockGenerateOpEdSet).not.toHaveBeenCalled();
-    // Only the prep shim was spawned — no voice shims
+    // Only the convert shim was spawned — no voice shims
     expect(mockSpawn).toHaveBeenCalledTimes(1);
     expect((mockSpawn.mock.calls[0] as [string, string[]])[1][3]).toContain(PREP_SHIM_FILE);
+  });
+
+  it('fail-fast: fetch 403 → throws ActionableError naming HTTP 403, no spawn, no generateOpEdSet call', async () => {
+    mockFetchBinary.mockResolvedValue({ ok: false, reason: 'http-error', status: 403 });
+
+    const { sender } = makeSender();
+    const handler = getHandler('create-oped-set');
+
+    const resultP = handler(
+      { sender },
+      { topic: 'topic', url: 'https://example.com', params: baseParams, voices: ['accelerationist'] },
+    ) as Promise<unknown>;
+
+    await expect(resultP).rejects.toThrow(/403/);
+    // Fetch failed before PS was invoked
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(mockFinalize).not.toHaveBeenCalled();
+    expect(mockGenerateOpEdSet).not.toHaveBeenCalled();
   });
 
   it('no Stage-A spawn when url is absent (topic-only path)', async () => {
@@ -281,6 +332,7 @@ describe('create-oped-set — Stage-A source hoist', () => {
 
     // No spawns at all — Stage A skipped, Stage B is in-process
     expect(mockSpawn).not.toHaveBeenCalled();
+    expect(mockFetchBinary).not.toHaveBeenCalled();
     expect(mockGenerateOpEdSet).toHaveBeenCalledOnce();
   });
 });

--- a/taxonomy-editor/src/main/__tests__/opedHandlers.migration.test.ts
+++ b/taxonomy-editor/src/main/__tests__/opedHandlers.migration.test.ts
@@ -20,10 +20,29 @@ import type { OpEdProgressEvent as LibEvent } from '../../../../lib/oped/generat
 const mockSpawn = vi.hoisted(() => vi.fn());
 vi.mock('child_process', () => ({ default: { spawn: mockSpawn }, spawn: mockSpawn }));
 
+// Node fetch mock (fetchUrlForPromptBinary — t/3306)
+const mockFetchBinary = vi.hoisted(() => vi.fn());
+vi.mock('../../../../lib/url-fetch/fetchUrlForPrompt.js', () => ({
+  fetchUrlForPromptBinary: (...args: unknown[]) => mockFetchBinary(...args),
+}));
+
+// fs + os mocks (temp file write/cleanup)
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return { ...actual, writeFileSync: vi.fn(), rmSync: vi.fn() };
+});
+
+vi.mock('os', () => ({
+  default: { tmpdir: () => '/tmp' },
+  tmpdir: () => '/tmp',
+}));
+
 vi.mock('electron', () => ({
   ipcMain: { handle: vi.fn() },
   dialog: {},
   BrowserWindow: { fromWebContents: vi.fn() },
+  app: { getPath: vi.fn(() => '/tmp') },
+  safeStorage: { isEncryptionAvailable: vi.fn(() => false) },
 }));
 
 vi.mock('../opedIO.js', () => ({
@@ -57,6 +76,15 @@ const mockGenerateOpEdSet = vi.fn();
 vi.mock('../../../../lib/oped/generate.js', () => ({
   generateOpEdSet: (...args: unknown[]) => mockGenerateOpEdSet(...args),
 }));
+
+const FAKE_FETCH_RESULT = {
+  ok: true as const,
+  bytes: Buffer.from('fake content'),
+  contentType: 'text/html; charset=utf-8',
+  finalUrl: 'https://example.com/article',
+};
+
+const flushPromises = (): Promise<void> => new Promise(r => setImmediate(r));
 
 // ── Test helpers ──────────────────────────────────────────────────────────────
 
@@ -104,6 +132,7 @@ beforeEach(() => {
   vi.mocked(saveOpEdSetTemp).mockClear();
   mockGenerateOpEdSet.mockClear();
   mockSpawn.mockClear();
+  mockFetchBinary.mockResolvedValue(FAKE_FETCH_RESULT);
   registerOpEdHandlers();
 });
 
@@ -327,7 +356,7 @@ describe('t/2899: source provenance persisted on the set', () => {
 
     const handler = captureHandler('create-oped-set');
     const p = handler(fakeEvent(makeSender()), { topic: 'topic', url: 'https://example.com/article', params: {}, voices: ['accelerationist'] });
-    await Promise.resolve();
+    await flushPromises();
     emitPrepResult(prep, FAKE_SOURCE_PREP);
     await p;
 
@@ -352,7 +381,7 @@ describe('t/2899: source provenance persisted on the set', () => {
 
     const handler = captureHandler('create-oped-set');
     const p = handler(fakeEvent(makeSender()), { topic: 'topic', url: 'https://example.com/article', params: {}, voices: ['accelerationist'] });
-    await Promise.resolve();
+    await flushPromises();
     emitPrepResult(prep, FAKE_SOURCE_PREP);
     try { await p; } catch { /* abort */ }
 

--- a/taxonomy-editor/src/main/__tests__/opedShimTransport.test.ts
+++ b/taxonomy-editor/src/main/__tests__/opedShimTransport.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { ActionableError } from '../../../../lib/debate/errors.js';
-import { parseShimLine, decodeB64Fields } from '../ipc/opedShimTransport.js';
+import { parseShimLine, decodeB64Fields, buildConvertStdin, parseShimError } from '../ipc/opedShimTransport.js';
 
 // The exact shape that broke it: prose with an embedded `*"..."*` quote + a base64 data-URI.
 const NASTY = '# Title\n\n*"Who is talking to your child?"*\n\nBody with a data URI ![](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ) and a trailing "quote".';
@@ -68,5 +68,58 @@ describe('opedShimTransport — parseShimLine (t/2928)', () => {
 
   it('parses a valid stage line', () => {
     expect(parseShimLine(JSON.stringify({ type: 'stage', stage: 'fetching' }))?.type).toBe('stage');
+  });
+});
+
+// ── Contract-field-name guard (t/3307) ───────────────────────────────────────
+// These tests assert the EXACT field names on the Node parse side so that a rename
+// on either side (shim or handler) causes a failure — mirroring OpEdShimTransport.Tests.ps1.
+
+describe('opedShimTransport — buildConvertStdin contract (t/3307)', () => {
+  it('emits ContentPath and ContentType with exact casing', () => {
+    const payload = JSON.parse(buildConvertStdin('/tmp/file.html', 'text/html')) as Record<string, unknown>;
+    expect(payload['ContentPath']).toBe('/tmp/file.html');
+    expect(payload['ContentType']).toBe('text/html');
+    expect('SourceUrl' in payload).toBe(false);
+  });
+
+  it('includes SourceUrl when provided', () => {
+    const payload = JSON.parse(buildConvertStdin('/tmp/x.pdf', 'application/pdf', 'https://example.com')) as Record<string, unknown>;
+    expect(payload['SourceUrl']).toBe('https://example.com');
+  });
+
+  it('omits SourceUrl when empty string', () => {
+    const payload = JSON.parse(buildConvertStdin('/tmp/x.html', 'text/html', '')) as Record<string, unknown>;
+    expect('SourceUrl' in payload).toBe(false);
+  });
+});
+
+describe('opedShimTransport — parseShimError contract (t/3307)', () => {
+  it('reads ErrorType, Goal, Problem, NextSteps by exact field name', () => {
+    const line = JSON.stringify({
+      ErrorType: 'ContentPathMissing',
+      Goal: 'Convert pre-fetched source content',
+      Problem: 'Content file not found',
+      NextSteps: ['Check the temp file path'],
+    });
+    const result = parseShimError(line);
+    expect(result?.ErrorType).toBe('ContentPathMissing');
+    expect(result?.Goal).toBe('Convert pre-fetched source content');
+    expect(result?.Problem).toBe('Content file not found');
+    expect(result?.NextSteps).toEqual(['Check the temp file path']);
+  });
+
+  it('returns null for non-JSON stderr', () => {
+    expect(parseShimError('not json')).toBeNull();
+  });
+
+  it('returns null when Problem field is absent (not a shim error payload)', () => {
+    expect(parseShimError(JSON.stringify({ ErrorType: 'X', Goal: 'Y' }))).toBeNull();
+  });
+
+  it('SourceMarkdown appears on success data (field name guard)', () => {
+    const data = { SourceMarkdown: b64('# Article'), _b64Fields: ['SourceMarkdown'] };
+    const decoded = decodeB64Fields({ ...data });
+    expect(decoded['SourceMarkdown']).toBe('# Article');
   });
 });

--- a/taxonomy-editor/src/main/ipc/opedHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/opedHandlers.ts
@@ -25,7 +25,7 @@ import { generateOpEdSet } from '../../../../lib/oped/generate.js';
 import type { GenerateOpEdRequest, OpEdGeneratorDeps } from '../../../../lib/oped/generate.js';
 import { makeElectronAIAdapter } from '../electronAIAdapter.js';
 import { validateCreateOpEdPayload } from './opedValidation.js';
-import { parseShimLine, decodeB64Fields } from './opedShimTransport.js';
+import { parseShimLine, decodeB64Fields, buildConvertStdin, parseShimError } from './opedShimTransport.js';
 
 // Shared prompts dir: op-ed-*.prompt artifacts (relocated to lib/oped/prompts by t/2609).
 const PROMPTS_DIR = path.join(PROJECT_ROOT, 'lib', 'oped', 'prompts');
@@ -117,6 +117,7 @@ function runGetOpEdConvert(
   tempPath: string,
   contentType: string,
   signal: AbortSignal,
+  sourceUrl?: string,
 ): Promise<Record<string, unknown>> {
   return new Promise((resolve, reject) => {
     const child = spawn('pwsh', ['-NoProfile', '-NonInteractive', '-File', PREP_SHIM_PATH], {
@@ -146,8 +147,8 @@ function runGetOpEdConvert(
       settle(() => { child.kill('SIGTERM'); reject(new Error('Get-OpEdSource convert timed out')); });
     }, getVoiceTimeoutMs());
 
-    // Contract: { ContentPath, ContentType } (t/3306/t/3307 locked interface).
-    child.stdin.write(JSON.stringify({ ContentPath: tempPath, ContentType: contentType }), 'utf-8');
+    // Contract: { ContentPath, ContentType, SourceUrl? } (t/3306/t/3307 locked interface).
+    child.stdin.write(buildConvertStdin(tempPath, contentType, sourceUrl), 'utf-8');
     child.stdin.end();
 
     let stdoutBuf = '';
@@ -191,15 +192,7 @@ function runGetOpEdConvert(
     child.on('close', (code) => settle(() => {
       if (code !== 0) {
         // Parse structured ActionableError from stderr (t/3307 shim emits JSON on failure).
-        let parsed: { Goal?: string; Problem?: string; NextSteps?: string[] } | null = null;
-        try {
-          /* telemetry — silent by design: stderr may not be JSON (non-shim output) */
-          const lastLine = stderrBuf.trim().split('\n').pop() ?? '';
-          const candidate = JSON.parse(lastLine) as Record<string, unknown>;
-          if (typeof candidate.Problem === 'string') {
-            parsed = candidate as { Goal?: string; Problem?: string; NextSteps?: string[] };
-          }
-        } catch { /* telemetry — silent by design */ }
+        const parsed = parseShimError(stderrBuf.trim().split('\n').pop() ?? '');
         if (parsed?.Problem) {
           reject(new ActionableError({
             goal: parsed.Goal ?? 'Convert op-ed source',
@@ -293,7 +286,7 @@ export function registerOpEdHandlers(): void {
         const fetched = await fetchOpEdSourceBytes(url, getVoiceTimeoutMs());
         tempPath = fetched.tempPath;
         try {
-          const sourcePrep = await runGetOpEdConvert(fetched.tempPath, fetched.contentType, controller.signal);
+          const sourcePrep = await runGetOpEdConvert(fetched.tempPath, fetched.contentType, controller.signal, url);
           // Extract markdown text for the lib/oped sourceMaterial slot ({{SOURCE_MATERIAL}}).
           sourceBrief = sourcePrep.SourceMarkdown != null ? String(sourcePrep.SourceMarkdown) : undefined;
         } finally {

--- a/taxonomy-editor/src/main/ipc/opedHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/opedHandlers.ts
@@ -10,11 +10,13 @@ import { ipcMain, dialog, BrowserWindow } from 'electron';
 import { spawn } from 'child_process';
 import crypto from 'crypto';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 import { ActionableError } from '../../../../lib/debate/errors.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 import { assertSafeId } from '../../../../lib/electron-shared/safeId.js';
+import { fetchUrlForPromptBinary } from '../../../../lib/url-fetch/fetchUrlForPrompt.js';
 import { PROJECT_ROOT, getDataRootPath } from '../fileIO.js';
 import { saveOpEdSetTemp, finalizeOpEdSet, loadOpEdSet, deleteOpEdSet, listOpEdSets, saveOpEdSet } from '../opedIO.js';
 import type { OpEdSet, OpEdMember, OpEdParams } from '../../../../lib/oped/types.js';
@@ -28,7 +30,7 @@ import { parseShimLine, decodeB64Fields } from './opedShimTransport.js';
 // Shared prompts dir: op-ed-*.prompt artifacts (relocated to lib/oped/prompts by t/2609).
 const PROMPTS_DIR = path.join(PROJECT_ROOT, 'lib', 'oped', 'prompts');
 
-// Stage-A fetch shim (FromUrl path only — stays PS, t/2604 P2 will migrate to TS).
+// Stage-A: Node fetches bytes (bypasses PS/WAF fingerprint block — t/3306), PS converts only.
 const PREP_SHIM_PATH = path.join(PROJECT_ROOT, 'taxonomy-editor', 'src', 'main', 'ps', 'invoke-get-oped-source.ps1');
 
 // Read generation.opedVoiceTimeoutMs from {dataRoot}/admin/runtime-config.json on each run.
@@ -61,9 +63,61 @@ interface OpEdProgressEvent {
 
 // Shim stdout line shapes + parse/decode transport live in ./opedShimTransport (pure, unit-tested).
 
-// ── Stage-A: source prep runner ───────────────────────────────────────────────
+// ── Stage-A: fetch bytes via Node (bypasses WAF fingerprint block — t/3306) ──
 
-function runGetOpEdSource(url: string, signal: AbortSignal): Promise<Record<string, unknown>> {
+async function fetchOpEdSourceBytes(
+  url: string,
+  timeoutMs: number,
+): Promise<{ tempPath: string; contentType: string }> {
+  const result = await fetchUrlForPromptBinary(url, { timeoutMs });
+  if (!result.ok) {
+    const statusPart = result.status != null ? ` (HTTP ${result.status})` : '';
+    let problem: string;
+    let nextSteps: string[];
+    if (result.reason === 'http-error' && result.status === 403) {
+      problem = `Could not fetch "${url}": server returned HTTP 403 Forbidden`;
+      nextSteps = [
+        'The server blocked the request — the URL may restrict automated access',
+        'Try a different publicly accessible URL for the same source',
+        'Use the topic-based op-ed mode if the URL is behind a paywall or access control',
+      ];
+    } else if (result.reason === 'http-error') {
+      problem = `Could not fetch "${url}": HTTP error${statusPart}`;
+      nextSteps = [`The server returned an error — check the URL is correct and publicly accessible`];
+    } else if (result.reason === 'timeout') {
+      problem = `Could not fetch "${url}": request timed out`;
+      nextSteps = ['The server did not respond in time — check the URL is accessible and try again'];
+    } else if (result.reason === 'ssrf-blocked') {
+      problem = `Could not fetch "${url}": the URL resolves to a private or restricted network address`;
+      nextSteps = ['Use a publicly accessible URL'];
+    } else if (result.reason === 'too-large') {
+      problem = `Could not fetch "${url}": the response body exceeds the size limit`;
+      nextSteps = ['Use a URL that points to a smaller document'];
+    } else {
+      problem = `Could not fetch "${url}": ${result.reason}`;
+      nextSteps = ['Check the URL is correct and the page is publicly accessible'];
+    }
+    throw new ActionableError({
+      goal: 'Fetch op-ed source material',
+      problem,
+      location: 'opedHandlers → fetchOpEdSourceBytes',
+      nextSteps,
+    });
+  }
+  // Write bytes to temp file for PS converter. Extension is advisory — PS dispatches on ContentType.
+  const ext = result.contentType.includes('pdf') ? '.pdf' : result.contentType.includes('html') ? '.html' : '.bin';
+  const tempPath = path.join(os.tmpdir(), `oped-source-${crypto.randomUUID()}${ext}`);
+  fs.writeFileSync(tempPath, result.bytes);
+  return { tempPath, contentType: result.contentType };
+}
+
+// ── Stage-A: convert-only PS runner (accepts pre-fetched content — t/3306/t/3307) ──
+
+function runGetOpEdConvert(
+  tempPath: string,
+  contentType: string,
+  signal: AbortSignal,
+): Promise<Record<string, unknown>> {
   return new Promise((resolve, reject) => {
     const child = spawn('pwsh', ['-NoProfile', '-NonInteractive', '-File', PREP_SHIM_PATH], {
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -71,6 +125,7 @@ function runGetOpEdSource(url: string, signal: AbortSignal): Promise<Record<stri
 
     let settled = false;
     let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    let stderrBuf = '';
 
     function onAbort(): void {
       settle(() => { child.kill('SIGTERM'); reject(Object.assign(new Error('cancelled'), { name: 'AbortError' })); });
@@ -88,10 +143,11 @@ function runGetOpEdSource(url: string, signal: AbortSignal): Promise<Record<stri
     signal.addEventListener('abort', onAbort, { once: true });
 
     timeoutHandle = setTimeout(() => {
-      settle(() => { child.kill('SIGTERM'); reject(new Error('Get-OpEdSource timed out')); });
+      settle(() => { child.kill('SIGTERM'); reject(new Error('Get-OpEdSource convert timed out')); });
     }, getVoiceTimeoutMs());
 
-    child.stdin.write(JSON.stringify({ Url: url }), 'utf-8');
+    // Contract: { ContentPath, ContentType } (t/3306/t/3307 locked interface).
+    child.stdin.write(JSON.stringify({ ContentPath: tempPath, ContentType: contentType }), 'utf-8');
     child.stdin.end();
 
     let stdoutBuf = '';
@@ -107,7 +163,7 @@ function runGetOpEdSource(url: string, signal: AbortSignal): Promise<Record<stri
           msg = parseShimLine(trimmed);
         } catch (err) {
           // A result-looking line that fails to parse is a hard serialization failure — record it
-          // and surface it, never swallow into the opaque close-handler "No result received" (t/2928).
+          // and surface it, never swallow into the opaque close-handler (t/2928).
           getGlobalRecorder()?.record({
             type: 'system.error', component: 'opedHandlers', level: 'error',
             message: 'Get-OpEdSource emitted an unparseable result line',
@@ -123,16 +179,50 @@ function runGetOpEdSource(url: string, signal: AbortSignal): Promise<Record<stri
     });
 
     child.stderr.on('data', (chunk: Buffer) => {
+      const text = chunk.toString('utf-8');
+      stderrBuf += text;
       getGlobalRecorder()?.record({
         type: 'system.error', component: 'opedHandlers', level: 'warn',
-        message: `Get-OpEdSource stderr: ${chunk.toString('utf-8').slice(0, 500)}`,
+        message: `Get-OpEdSource stderr: ${text.slice(0, 500)}`,
       });
     });
 
     child.on('error', (err) => settle(() => reject(err)));
     child.on('close', (code) => settle(() => {
-      if (code !== 0) reject(new Error(`Get-OpEdSource exited with code ${code}`));
-      else reject(new Error('No result received from Get-OpEdSource'));
+      if (code !== 0) {
+        // Parse structured ActionableError from stderr (t/3307 shim emits JSON on failure).
+        let parsed: { Goal?: string; Problem?: string; NextSteps?: string[] } | null = null;
+        try {
+          /* telemetry — silent by design: stderr may not be JSON (non-shim output) */
+          const lastLine = stderrBuf.trim().split('\n').pop() ?? '';
+          const candidate = JSON.parse(lastLine) as Record<string, unknown>;
+          if (typeof candidate.Problem === 'string') {
+            parsed = candidate as { Goal?: string; Problem?: string; NextSteps?: string[] };
+          }
+        } catch { /* telemetry — silent by design */ }
+        if (parsed?.Problem) {
+          reject(new ActionableError({
+            goal: parsed.Goal ?? 'Convert op-ed source',
+            problem: parsed.Problem,
+            location: 'Get-OpEdSource.ps1',
+            nextSteps: Array.isArray(parsed.NextSteps) ? parsed.NextSteps as string[] : [],
+          }));
+        } else {
+          reject(new ActionableError({
+            goal: 'Convert op-ed source',
+            problem: `Get-OpEdSource exited with code ${code}${stderrBuf.trim() ? `: ${stderrBuf.trim().slice(0, 300)}` : ''}`,
+            location: 'opedHandlers → runGetOpEdConvert',
+            nextSteps: ['Check the server logs for Get-OpEdSource stderr output'],
+          }));
+        }
+      } else {
+        reject(new ActionableError({
+          goal: 'Convert op-ed source',
+          problem: 'No result received from Get-OpEdSource',
+          location: 'opedHandlers → runGetOpEdConvert',
+          nextSteps: ['Check the server logs for unexpected Get-OpEdSource output'],
+        }));
+      }
     }));
   });
 }
@@ -193,32 +283,36 @@ export function registerOpEdHandlers(): void {
       if (!event.sender.isDestroyed()) event.sender.send('oped-progress', data);
     };
 
-    // Stage A: hoist Get-OpEdSource once before generation (FromUrl path).
-    // Fail fast if readability gate trips — don't fan out to draft on garbage (TL cond 3).
+    // Stage A: Node fetches bytes → temp file → PS convert-only (t/3306).
+    // Fail fast if source prep fails — don't fan out to draft on garbage.
     let sourceBrief: string | undefined;
     if (url) {
       send({ set_id: setId, stage: 'preparing-source' });
+      let tempPath: string | undefined;
       try {
-        const sourcePrep = await runGetOpEdSource(url, controller.signal);
-        // Extract markdown text for the lib/oped sourceMaterial slot ({{SOURCE_MATERIAL}}).
-        // Structured fields (SOURCE_AUTHOR etc.) are P2 — empty in P1 (t/2604).
-        sourceBrief = sourcePrep.SourceMarkdown != null ? String(sourcePrep.SourceMarkdown) : undefined;
+        const fetched = await fetchOpEdSourceBytes(url, getVoiceTimeoutMs());
+        tempPath = fetched.tempPath;
+        try {
+          const sourcePrep = await runGetOpEdConvert(fetched.tempPath, fetched.contentType, controller.signal);
+          // Extract markdown text for the lib/oped sourceMaterial slot ({{SOURCE_MATERIAL}}).
+          sourceBrief = sourcePrep.SourceMarkdown != null ? String(sourcePrep.SourceMarkdown) : undefined;
+        } finally {
+          if (tempPath) fs.rmSync(tempPath, { force: true });
+        }
       } catch (err) {
         activeOpEdRuns.delete(setId);
         getGlobalRecorder()?.record({
           type: 'system.error', component: 'opedHandlers', level: 'error',
-          message: `Stage A Get-OpEdSource failed for set ${setId}: ${(err as Error).message}`,
+          message: `Stage A source prep failed for set ${setId}: ${(err as Error).message}`,
           error: { name: (err as Error).name ?? 'Error', message: String((err as Error).message ?? err), stack: (err as Error).stack },
         });
-        const errProblem = err instanceof ActionableError ? err.problem : (err instanceof Error ? err.message : String(err));
+        // Surface the ActionableError directly — fetch/convert already set correct goal/problem/nextSteps.
+        if (err instanceof ActionableError) throw err;
         throw new ActionableError({
           goal: 'Prepare source material for op-ed set',
-          problem: `Get-OpEdSource failed: ${errProblem}`,
+          problem: err instanceof Error ? err.message : String(err),
           location: 'opedHandlers create-oped-set Stage A',
-          nextSteps: [
-            'Check that the URL is publicly accessible',
-            'Verify the page contains sufficient readable text (minimum word count required)',
-          ],
+          nextSteps: ['Check that the URL is publicly accessible'],
           innerError: err,
         });
       }

--- a/taxonomy-editor/src/main/ipc/opedHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/opedHandlers.ts
@@ -13,7 +13,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import { ActionableError } from '../../../../lib/debate/errors.js';
+import { ActionableError, errorMessage } from '../../../../lib/debate/errors.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 import { assertSafeId } from '../../../../lib/electron-shared/safeId.js';
 import { fetchUrlForPromptBinary } from '../../../../lib/url-fetch/fetchUrlForPrompt.js';
@@ -310,7 +310,7 @@ export function registerOpEdHandlers(): void {
         if (err instanceof ActionableError) throw err;
         throw new ActionableError({
           goal: 'Prepare source material for op-ed set',
-          problem: err instanceof Error ? err.message : String(err),
+          problem: err instanceof ActionableError ? err.problem : errorMessage(err),
           location: 'opedHandlers create-oped-set Stage A',
           nextSteps: ['Check that the URL is publicly accessible'],
           innerError: err,

--- a/taxonomy-editor/src/main/ipc/opedShimTransport.ts
+++ b/taxonomy-editor/src/main/ipc/opedShimTransport.ts
@@ -21,6 +21,45 @@ export interface ShimStageLine { type: 'stage'; stage: string }
 export interface ShimResultLine { type: 'result'; data: Record<string, unknown> }
 export type ShimLine = ShimStageLine | ShimResultLine;
 
+/** Locked stdin contract (t/3306/t/3307). Field names are asserted by OpEdShimTransport.Tests.ps1. */
+export interface ConvertStdinPayload {
+  ContentPath: string;
+  ContentType: string;
+  SourceUrl?: string;
+}
+
+/** Locked stderr failure contract emitted by the shim on exit 1 (t/3306#4). */
+export interface ShimErrorPayload {
+  ErrorType?: string;
+  Goal?: string;
+  Problem: string;
+  NextSteps?: string[];
+}
+
+/** Build the JSON stdin string for the PS convert shim. Export keeps field names unit-testable. */
+export function buildConvertStdin(contentPath: string, contentType: string, sourceUrl?: string): string {
+  const payload: ConvertStdinPayload = { ContentPath: contentPath, ContentType: contentType };
+  if (sourceUrl) payload.SourceUrl = sourceUrl;
+  return JSON.stringify(payload);
+}
+
+/**
+ * Parse the last stderr line from the PS convert shim.
+ * Returns the structured payload when present (field `Problem` is the discriminator).
+ * Returns null when stderr is absent, non-JSON, or lacks the expected shape.
+ */
+export function parseShimError(lastStderrLine: string): ShimErrorPayload | null {
+  try {
+    const candidate = JSON.parse(lastStderrLine) as Record<string, unknown>;
+    if (typeof candidate['Problem'] === 'string') {
+      return candidate as unknown as ShimErrorPayload;
+    }
+  } catch {
+    /* telemetry — silent by design: stderr may not be JSON (non-shim output) */
+  }
+  return null;
+}
+
 /** Bounded head+tail excerpt so a 13k-char malformed line doesn't flood the recorder while still
  *  showing where the parse broke (recovery-vs-silent-loss convention). */
 function boundedSnippet(s: string, edge = 160): string {


### PR DESCRIPTION
## Summary

- Routes op-ed Stage A URL fetch through `fetchUrlForPromptBinary` (Node/undici) instead of `Invoke-WebRequest` (PS), fixing WAF fingerprint 403s from senate.gov and similar sites where the .NET/PS TLS fingerprint is blocked but Node undici passes
- PS `Get-OpEdSource` is now **convert-only**: receives `{ContentPath, ContentType}` on stdin (t/3307 locked interface), never fetches
- Surfaces the correct fetch error (HTTP 403 / timeout / ssrf-blocked) instead of hardcoded "minimum word count" next-step

## Test plan

- [ ] CI `test-electron (taxonomy-editor)` green
- [ ] 403-fetch-failure test: mockFetchBinary 403 -> rejects with /403/, no spawn, no finalize
- [ ] PS exit-1 convert failure still throws ActionableError, no finalize, no generate
- [ ] Topic-only path: no spawn, no fetch

Co-Authored-By: ElectronMain (Orca) <main.taxonomy-editor-src-main@ai-triad-research.orca.local>