### PR TITLE
infra(deploy): promote in-process offload-flag gate to BLOCKING after calibration (t/3247 GV cond 1)

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -602,20 +602,23 @@ jobs:
           }
           Write-Host "Config verification passed ($($ConfigChecks.Count) checks)"
 
-      - name: Assert in-process offload flag (WARN-only, t/3247)
+      - name: Assert in-process offload flag (BLOCKING, t/3247)
         # Prevention for t/3165. The Verify-Bicep-config step above proves EMBEDDING_WORKER_OFFLOAD
         # is PRESENT in ACA config; this asserts the RUNNING process EVALUATED it truthy, via
         # ServerAPI's #1828 boot log (server.ts:1316 -> "embedding offload flag at boot"
         # {embeddingWorkerOffload:bool}). "Config present" != "flag effective" (t/3165).
         #
-        # GATE PROMOTION (t/3247 GV cond 1): ships WARN-only (continue-on-error: true) for >=1 green
-        # deploy to CALIBRATE the Log Analytics ingestion-lag retry ceiling below; the flip to
-        # blocking (drop continue-on-error) is a SEPARATE TL GV. Predicate is DOT-SOURCED from
-        # operations/devops/Test-BootFlagEffective.ps1 — the single source its Pester both-arms test
-        # also uses (t/3010 co-location). Cond 2: present+false = 'drift'; absent-after-retry is a
-        # DISTINCT 'boot line not found' diagnostic (ingestion/#1828), NOT drift.
+        # GATE PROMOTION (t/3247): BLOCKING (continue-on-error: false). Promoted from warn-only after
+        # calibration — 4/4 real deploys (runs 33748402995 / 33778872175 / 33785227781 / 33891736936)
+        # found the boot line on attempt 1 at ~0s ingest lag with the true-arm read cleanly. The 8x30s
+        # (210s) retry ceiling below is RETAINED as over-provisioned headroom against LA ingestion
+        # spikes (calibration showed ~0s, not a tight bound — shrinking it would remove anti-flake
+        # margin). Predicate is DOT-SOURCED from operations/devops/Test-BootFlagEffective.ps1 — the
+        # single source its Pester both-arms test also uses (t/3010 co-location). Cond 2: present+false
+        # = 'drift' (blocks); absent-after-retry is a DISTINCT 'boot line not found' diagnostic
+        # (ingestion/#1828), NOT drift — also fail-closed (never pass an unverifiable deploy).
         if: steps.acceptance.outputs.accepted == 'true' && steps.persona.outputs.accepted == 'true'
-        continue-on-error: true
+        continue-on-error: false
         shell: pwsh
         env:
           NEW_REVISION: ${{ steps.new_revision.outputs.revision }}
@@ -627,8 +630,9 @@ jobs:
             exit 0
           }
           # Query the NEW revision's boot line only. Bounded retry absorbs LA ingestion lag
-          # (~1-3 min typical). Ceiling deliberately generous in WARN phase — calibrate down from the
-          # observed 'found on attempt N' before the blocking flip (GV cond 1).
+          # (~1-3 min typical). Ceiling RETAINED at 8x30s=210s as headroom — warn-phase calibration
+          # observed attempt-1 / ~0s across 4 deploys (this step runs post-traffic-shift, so boot
+          # logs are already ingested); the margin guards LA ingestion spikes, not a tight bound.
           $q = "ContainerAppConsoleLogs_CL | where RevisionName_s == '$env:NEW_REVISION' | where Log_s has 'embedding offload flag at boot' | project TimeGenerated, Log_s | order by TimeGenerated desc | take 5"
           $lines = @(); $maxAttempts = 8
           for ($i = 1; $i -le $maxAttempts; $i++) {
@@ -640,11 +644,11 @@ jobs:
           Write-Host "t/3247 in-process flag assert: Status=$($r.Status) Pass=$($r.Pass) — $($r.Detail)"
           if (-not $r.Pass) {
             if ($r.Status -eq 'Drift') {
-              Write-Host "::warning::t/3247 CONFIG DRIFT (present in ACA config but process not effective) — $($r.Detail)"
+              Write-Host "::error::t/3247 CONFIG DRIFT (present in ACA config but process not effective) — $($r.Detail)"
             } else {
-              Write-Host "::warning::t/3247 BOOT LINE NOT FOUND (ingestion/calibration, NOT drift) — $($r.Detail)"
+              Write-Host "::error::t/3247 BOOT LINE NOT FOUND (ingestion/calibration, NOT drift) — $($r.Detail)"
             }
-            exit 1   # WARN-only this phase: continue-on-error keeps it non-blocking (visible-yellow)
+            exit 1   # BLOCKING (continue-on-error:false): fail-closed on drift OR unverifiable boot line
           }
           Write-Host "::notice::t/3247 in-process offload flag EFFECTIVE — $($r.Detail)"
 


### PR DESCRIPTION
The t/3247 in-process offload-flag assertion (deploy-azure.yml, #1857) shipped
warn-only to calibrate the LA ingestion-lag retry ceiling over >=1 green deploy
(TL GV cond 1). Calibration is complete: 4/4 real deploys found the boot line on
attempt 1 at ~0s ingest lag with the true-arm read cleanly.

  run 33748402995  Sep 3 11:25Z  attempt 1  ~0s  Effective/True
  run 33778872175  Sep 3 16:36Z  attempt 1  ~0s  Effective/True
  run 33785227781  Sep 3 17:38Z  attempt 1  ~0s  Effective/True
  run 33891736936  Sep 4 15:55Z  attempt 1  ~0s  Effective/True

The step runs post-traffic-shift (after acceptance/persona/warm-gate), so the boot
line is already ingested by the time it queries — hence attempt-1/~0s every time.

Flip: continue-on-error true -> false. Retry ceiling RETAINED at 8x30s=210s as
over-provisioned headroom against LA ingestion spikes (calibration showed ~0s, not
a tight bound — shrinking it would remove anti-flake margin). Annotations promoted
warning -> error. Both fail arms stay fail-closed with distinct diagnostics
(cond 2): present+false = drift (blocks); absent-after-retry = boot-line-not-found
(ingestion/#1828, NOT drift, also blocks — never pass an unverifiable deploy).

HELD DRAFT pending TL Gate Verification sign-off on this promotion (the flip is a
separate, deliberate GV step per Gate Promotion Discipline).

Co-Authored-By: DevOps (Orca) <main.operations-devops@ai-triad-research.orca.local>
Co-Authored-By: Tech Lead (Orca) <main.engineering-tech-lead@ai-triad-research.orca.local>
