### PR TITLE
infra(ci): add manual boot-flag gate fire-drill — force the t/3247 RED path (t/3247 GV)

### DIFF
--- a/.github/workflows/bootflag-gate-firedrill.yml
+++ b/.github/workflows/bootflag-gate-firedrill.yml
@@ -18,6 +18,9 @@ name: t3247 boot-flag gate fire-drill
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   # Real #1828 boot line captured from Log Analytics — do not synthesize.
   TRUE_LINE: '{"level":30,"time":1788377646519,"pid":7,"hostname":"taxonomy-editor--deploy-b5f65c3-77580-64f77fcbb4-n6hkl","component":"server","embeddingWorkerOffload":true,"msg":"embedding offload flag at boot"}'
@@ -27,7 +30,7 @@ jobs:
     name: control — true line must PASS (stays green)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
       - shell: pwsh
         run: |
           . ./operations/devops/Test-BootFlagEffective.ps1
@@ -42,7 +45,7 @@ jobs:
     name: fire — false line must go RED (Drift)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
       - shell: pwsh
         run: |
           . ./operations/devops/Test-BootFlagEffective.ps1
@@ -60,7 +63,7 @@ jobs:
     name: fire — absent boot line must go RED (NotFound)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
       - shell: pwsh
         run: |
           . ./operations/devops/Test-BootFlagEffective.ps1

--- a/.github/workflows/bootflag-gate-firedrill.yml
+++ b/.github/workflows/bootflag-gate-firedrill.yml
@@ -1,0 +1,74 @@
+name: t3247 boot-flag gate fire-drill
+
+# Manual-only forced-fire drill for the t/3247 in-process offload-flag gate
+# (deploy-azure.yml step "Assert in-process offload flag"). On a healthy deploy that
+# gate only ever exercises the Pass arm, so its exit-1 BLOCKING path is otherwise
+# never run live. This drill forces the two FIRE arms (Drift + NotFound) against the
+# REAL predicate and mirrors the deploy step's exit-mapping, proving the RED/blocking
+# path end-to-end in CI runtime — the "force the fire arm even when observationally
+# pending" discipline (t/3110 / t/3278). A control job feeds the real TRUE line and
+# must stay GREEN, so a red drill can't be a false always-red harness.
+#
+# Dot-sources the SAME predicate the gate and its Pester test use
+# (operations/devops/Test-BootFlagEffective.ps1, t/3010 co-location). The fixtures are
+# the real captured #1828 boot line (rev deploy-b5f65c3-77580) and its flag-flip —
+# same shape as tests/Test-BootFlagEffective.Tests.ps1, so a #1828 emit-shape change
+# breaks this drill too. Zero ongoing cost: workflow_dispatch only.
+
+on:
+  workflow_dispatch:
+
+env:
+  # Real #1828 boot line captured from Log Analytics — do not synthesize.
+  TRUE_LINE: '{"level":30,"time":1788377646519,"pid":7,"hostname":"taxonomy-editor--deploy-b5f65c3-77580-64f77fcbb4-n6hkl","component":"server","embeddingWorkerOffload":true,"msg":"embedding offload flag at boot"}'
+
+jobs:
+  control-effective:
+    name: control — true line must PASS (stays green)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - shell: pwsh
+        run: |
+          . ./operations/devops/Test-BootFlagEffective.ps1
+          $r = Test-BootFlagEffective -BootLogLines @($env:TRUE_LINE)
+          Write-Host "control: Status=$($r.Status) Pass=$($r.Pass) — $($r.Detail)"
+          if ($r.Status -ne 'Effective' -or -not $r.Pass) {
+            Write-Host "::error::DRILL ANOMALY — real true line did not PASS (harness broken)"; exit 2
+          }
+          Write-Host "::notice::control PASS — harness is not always-red"
+
+  fire-drift:
+    name: fire — false line must go RED (Drift)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - shell: pwsh
+        run: |
+          . ./operations/devops/Test-BootFlagEffective.ps1
+          $lines = @($env:TRUE_LINE -replace '"embeddingWorkerOffload":true', '"embeddingWorkerOffload":false')
+          $r = Test-BootFlagEffective -BootLogLines $lines
+          Write-Host "t/3247 in-process flag assert: Status=$($r.Status) Pass=$($r.Pass) — $($r.Detail)"
+          if ($r.Pass -or $r.Status -ne 'Drift') {
+            Write-Host "::error::DRILL ANOMALY — expected Drift/fail, got Status=$($r.Status) Pass=$($r.Pass)"; exit 2
+          }
+          # Mirrors the deploy-azure.yml BLOCKING exit-mapping:
+          Write-Host "::error::t/3247 CONFIG DRIFT (present in ACA config but process not effective) — $($r.Detail)"
+          exit 1
+
+  fire-notfound:
+    name: fire — absent boot line must go RED (NotFound)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - shell: pwsh
+        run: |
+          . ./operations/devops/Test-BootFlagEffective.ps1
+          $r = Test-BootFlagEffective -BootLogLines @()
+          Write-Host "t/3247 in-process flag assert: Status=$($r.Status) Pass=$($r.Pass) — $($r.Detail)"
+          if ($r.Pass -or $r.Status -ne 'NotFound') {
+            Write-Host "::error::DRILL ANOMALY — expected NotFound/fail, got Status=$($r.Status) Pass=$($r.Pass)"; exit 2
+          }
+          # Mirrors the deploy-azure.yml BLOCKING exit-mapping (distinct diagnostic, NOT drift):
+          Write-Host "::error::t/3247 BOOT LINE NOT FOUND (ingestion/calibration, NOT drift) — $($r.Detail)"
+          exit 1


### PR DESCRIPTION
TL condition on the t/3247 warn->blocking flip (#1943): the gate's exit-1 BLOCKING
arm has never run live (all 4 real deploys hit the Pass arm). This manual-dispatch
drill forces both fire arms (Drift=present+false, NotFound=absent) against the REAL
predicate (dot-sourced operations/devops/Test-BootFlagEffective.ps1) and mirrors the
deploy step's exit-mapping, so the RED/blocking path is proven end-to-end in CI
runtime. A control job feeds the real TRUE line and must stay green (guards against a
false always-red harness). Fixtures = real captured #1828 line + flag-flip, same as
the Pester test. workflow_dispatch only (zero ongoing cost); reusable for future
promotions. The force-the-fire-arm discipline (t/3110/t/3278) as standing tooling.

Co-Authored-By: DevOps (Orca) <main.operations-devops@ai-triad-research.orca.local>
Co-Authored-By: Tech Lead (Orca) <main.engineering-tech-lead@ai-triad-research.orca.local>
