### PR TITLE
feat(storage): listDirectory WARN floor at all 3 swallow sites (t/3300)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/listDirectoryWarnFloor.test.ts
+++ b/taxonomy-editor/src/server/__tests__/listDirectoryWarnFloor.test.ts
@@ -1,0 +1,162 @@
+// @vitest-environment node
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3300 — listDirectory WARN floor: each of the 3 swallow sites in
+// GitHubAPIBackend.listDirectory emits log.server.warn (stdout → Log_s) so
+// false-empties are diagnosable in production logs.
+//
+// TL t/3300#2 non-negotiable: test MUST assert log.server.warn (the real
+// stdout sink), NOT getGlobalRecorder().record() (ring buffer / t/3110 trap).
+//
+// Swallow sites covered:
+//   (1) Circuit breaker tripped → WARN cause='circuit-breaker-open'
+//   (2) No GitHub credentials → WARN cause='no-credentials'
+//   (3) GitHub API non-ok response → WARN cause='api-non-ok'
+//   (4) Happy path → no WARN for any of the three causes
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks (hoisted before imports) ──
+
+const { serverWarn, mockIsTripped, mockRequest, mockGetCredentials } = vi.hoisted(() => ({
+  serverWarn: vi.fn(),
+  mockIsTripped: vi.fn().mockReturnValue(false),
+  mockRequest: vi.fn(),
+  mockGetCredentials: vi.fn(),
+}));
+
+vi.mock('../logger.js', () => ({
+  log: {
+    api: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    server: { info: vi.fn(), warn: serverWarn, error: vi.fn(), debug: vi.fn() },
+  },
+  getRequestId: () => 'req-test',
+  LOG_MAX_LINE_BYTES: 65536,
+  writeFramedNdjson: vi.fn(),
+}));
+
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({
+  getGlobalRecorder: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('fs/promises', () => ({
+  default: {
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    readFile: vi.fn().mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' })),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    rename: vi.fn().mockResolvedValue(undefined),
+    unlink: vi.fn().mockResolvedValue(undefined),
+    rm: vi.fn().mockResolvedValue(undefined),
+    readdir: vi.fn().mockResolvedValue([]),
+    stat: vi.fn().mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' })),
+  },
+}));
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  const src = (actual.default ?? actual) as Record<string, unknown>;
+  const patched = {
+    ...src,
+    promises: { ...(src.promises as object), rename: vi.fn().mockResolvedValue(undefined) },
+  };
+  return { ...patched, default: patched };
+});
+
+vi.mock('../security/githubAppAuth.js', () => ({
+  getCredentials: mockGetCredentials,
+  getRepoSlug: vi.fn().mockReturnValue('testowner/testrepo'),
+  getTokenExpiryMs: vi.fn().mockReturnValue(0),
+}));
+
+vi.mock('../storage/githubRestClient.js', () => ({
+  GitHubRestClient: class {
+    isTripped = mockIsTripped;
+    request = mockRequest;
+  },
+  normalizeErrorForEvent: vi.fn(),
+}));
+
+import { GitHubAPIBackend } from '../storage/githubAPIBackend.js';
+
+// ── Helpers ──
+
+const TEST_CREDS = { repo: 'testowner/testrepo', token: 'test-tok', mode: 'pat' as const };
+
+function makeBackend(): GitHubAPIBackend {
+  return new GitHubAPIBackend({ cacheDir: '/fake/cache' });
+}
+
+function warnCauses(): string[] {
+  return serverWarn.mock.calls
+    .map(([ctx]: [{ cause?: string }]) => ctx?.cause)
+    .filter(Boolean) as string[];
+}
+
+// ── Tests ──
+
+describe('listDirectory WARN floor (t/3300)', () => {
+  beforeEach(() => {
+    serverWarn.mockClear();
+    mockIsTripped.mockReturnValue(false);
+    mockRequest.mockReset();
+    mockGetCredentials.mockReset();
+  });
+
+  it('(1) emits log.server.warn with cause=circuit-breaker-open when breaker is tripped', async () => {
+    mockIsTripped.mockReturnValue(true);
+    const backend = makeBackend();
+
+    const result = await backend.listDirectory('taxonomy');
+
+    expect(result).toEqual([]);
+    expect(warnCauses()).toContain('circuit-breaker-open');
+    const call = serverWarn.mock.calls.find(([ctx]: [{ cause?: string }]) => ctx?.cause === 'circuit-breaker-open');
+    expect(call).toBeDefined();
+    expect(call?.[1]).toMatch(/false-empty/);
+  });
+
+  it('(2) emits log.server.warn with cause=no-credentials when credentials unavailable', async () => {
+    mockIsTripped.mockReturnValue(false);
+    mockGetCredentials.mockResolvedValue(null);
+    const backend = makeBackend();
+
+    const result = await backend.listDirectory('taxonomy');
+
+    expect(result).toEqual([]);
+    expect(warnCauses()).toContain('no-credentials');
+    const call = serverWarn.mock.calls.find(([ctx]: [{ cause?: string }]) => ctx?.cause === 'no-credentials');
+    expect(call).toBeDefined();
+    expect(call?.[1]).toMatch(/false-empty/);
+  });
+
+  it('(3) emits log.server.warn with cause=api-non-ok on GitHub API non-ok response', async () => {
+    mockIsTripped.mockReturnValue(false);
+    mockGetCredentials.mockResolvedValue(TEST_CREDS);
+    mockRequest.mockResolvedValue({ ok: false, status: 503, error: 'Service Unavailable' });
+    const backend = makeBackend();
+
+    const result = await backend.listDirectory('taxonomy');
+
+    expect(result).toEqual([]);
+    expect(warnCauses()).toContain('api-non-ok');
+    const call = serverWarn.mock.calls.find(([ctx]: [{ cause?: string }]) => ctx?.cause === 'api-non-ok');
+    expect(call).toBeDefined();
+    expect(call?.[0]?.status).toBe(503);
+    expect(call?.[1]).toMatch(/false-empty/);
+  });
+
+  it('(4) happy path — no WARN when listing returns entries', async () => {
+    mockIsTripped.mockReturnValue(false);
+    mockGetCredentials.mockResolvedValue(TEST_CREDS);
+    mockRequest.mockResolvedValue({ ok: true, data: [{ name: 'file1.json' }, { name: 'file2.json' }] });
+    const backend = makeBackend();
+
+    const result = await backend.listDirectory('taxonomy');
+
+    expect(result).toContain('file1.json');
+    expect(warnCauses().filter(c =>
+      c === 'circuit-breaker-open' || c === 'no-credentials' || c === 'api-non-ok',
+    )).toHaveLength(0);
+  });
+});

--- a/taxonomy-editor/src/server/storage/githubAPIBackend.ts
+++ b/taxonomy-editor/src/server/storage/githubAPIBackend.ts
@@ -28,7 +28,7 @@ import type { FlightRecorder, RecordInput } from '../../../../lib/flight-recorde
 import { getCurrentUserId, getSessionBranchName } from '../security/userContext.js';
 import { GitHubRestClient, normalizeErrorForEvent, type CircuitState } from './githubRestClient.js';
 import { getDataRoot } from '../config.js';
-import { writeFramedNdjson } from '../logger.js';
+import { writeFramedNdjson, log } from '../logger.js';
 
 // ── Types ────────────────────────────────────────────────────────────────
 
@@ -572,6 +572,8 @@ export class GitHubAPIBackend implements StorageBackend {
       }
     } else if (!(this.rest.isTripped())) {
       await this.fetchDirectoryFromAPI(repoPath, opts, seen);
+    } else {
+      log.server.warn({ dir: repoPath, cause: 'circuit-breaker-open' }, 'listDirectory returning [] — circuit breaker open, may be false-empty (t/3300)');
     }
 
     // Merge the session overlay so files written this session are visible and
@@ -634,7 +636,11 @@ export class GitHubAPIBackend implements StorageBackend {
         `/repos/${creds.repo}/contents/${repoPath}${qRef}`);
       if (resp.ok && Array.isArray(resp.data)) {
         for (const e of resp.data as Array<{ name: string }>) seen.add(e.name);
+      } else if (!resp.ok) {
+        log.server.warn({ dir: repoPath, status: (resp as { status?: number }).status, cause: 'api-non-ok' }, 'listDirectory returning [] — GitHub API non-ok response, may be false-empty (t/3300)');
       }
+    } else {
+      log.server.warn({ dir: repoPath, cause: 'no-credentials' }, 'listDirectory returning [] — no GitHub credentials available, may be false-empty (t/3300)');
     }
   }
 


### PR DESCRIPTION
## Summary
- Adds `log.server.warn` (stdout → Log_s) at each of the 3 swallow sites in `GitHubAPIBackend.listDirectory` that silently return `[]` instead of throwing
- **`[]` contract unchanged** — zero cross-caller regression
- `listDirectoryStrict` (t/3296 A arm) coexists; `validateDataRoot` still needs the throwing variant

| Swallow site | Cause field |
|---|---|
| Circuit breaker tripped | `circuit-breaker-open` |
| No GitHub credentials | `no-credentials` |
| GitHub API non-ok response | `api-non-ok` |

Each WARN includes `{ dir, cause[, status] }` for structured log querying in Log_s.

## TL corrections applied (t/3300#2)
- Uses `log.server.warn` (stdout → Log_s), NOT `getGlobalRecorder().record()` (ring buffer / t/3110 trap)
- Test asserts against `log.server.warn` sink specifically

## Test plan
- [x] 4/4 `listDirectoryWarnFloor.test.ts` — all 3 WARN sites + happy-path no-WARN
- [x] 21/21 storage-adjacent tests green (`validateDataRoot`, `opedRunStore`, `dictionaryWarn`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)