### PR TITLE
feat(oped): Get-OpEdSource convert-only + structured shim failure contract (t/3307)

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -87,8 +87,8 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 ### Op-Ed Generation
 | Cmdlet | Use when |
 |--------|----------|
-| `Get-OpEdSource` | Fetch, convert (PDF/DOCX/HTML routing), and validate a source URL once — returns a SourcePrep object to pass to New-OpEd for one or multiple POVs (t/2586) |
-| `New-OpEd` | Generate a publication-ready op-ed in a POV camp voice, grounded in the project taxonomy; accepts -Topic, -Url (fetches internally via Get-OpEdSource), or -SourcePrep (pre-built prep object for multi-voice runs) |
+| `Get-OpEdSource` | Convert (PDF/DOCX/HTML, dispatched on Content-Type) and validate PRE-FETCHED source content — takes a temp-file path + content-type, returns a SourcePrep object for New-OpEd. Convert-only: the URL fetch moved to the shared Node fetcher (t/2586, t/3307) |
+| `New-OpEd` | Generate a publication-ready op-ed in a POV camp voice, grounded in the project taxonomy; accepts -Topic, -Url (CLI best-effort fetch then convert — desktop fetches via the hardened Node fetcher, t/3312), or -SourcePrep (pre-built prep object for multi-voice runs) |
 
 ### Sources & Ingestion
 | Cmdlet | Use when |

--- a/scripts/AITriad/Private/New-ActionableError.ps1
+++ b/scripts/AITriad/Private/New-ActionableError.ps1
@@ -38,26 +38,57 @@ function New-ActionableError {
         [Parameter(Mandatory)]
         [string[]]$NextSteps,
 
+        # Optional machine-readable failure category (e.g. 'ContentPathMissing'). When set it renders
+        # a `Type:` line AND is carried structurally on -AsErrorRecord's TargetObject so a subprocess
+        # shim can serialize it to a contract field without parsing the human message (t/3307).
+        [string]$ErrorType,
+
         [System.Management.Automation.ErrorRecord]$InnerError,
 
         [switch]$Throw,
 
-        [switch]$PassThru
+        [switch]$PassThru,
+
+        # Return a [System.Management.Automation.ErrorRecord] whose TargetObject is an ordered
+        # hashtable {ErrorType, Goal, Problem, Location, NextSteps}. Lets a catcher (the op-ed shim)
+        # emit the {ErrorType,Goal,Problem,NextSteps} wire contract from structured fields — never by
+        # regex-parsing the rendered string (which is the silent parse-fail class, t/3306#4). Backward
+        # compatible: existing default/-Throw/-PassThru callers are unaffected (t/3307).
+        [switch]$AsErrorRecord
     )
 
     $StepList = ($NextSteps | ForEach-Object { $i = [int]($NextSteps.IndexOf($_)) + 1; "   $i. $_" }) -join "`n"
     if ($InnerError) { $InnerDetail = "`n   Inner error: $($InnerError.Exception.Message)" } else { $InnerDetail = '' }
+    # Only emitted when -ErrorType is supplied, so pre-existing rendered output is byte-for-byte unchanged.
+    $TypeSegment = if ($ErrorType) { "  Type:     $ErrorType`n" } else { '' }
 
     $Message = @"
 
   Goal:     $Goal
   Error:    $Problem$InnerDetail
-  Location: $Location
+$($TypeSegment)  Location: $Location
   Resolve:
 $StepList
 "@
 
-    if ($PassThru) {
+    if ($AsErrorRecord) {
+        $exc = [System.Exception]::new($Message)
+        $targetData = [ordered]@{
+            ErrorType = $ErrorType
+            Goal      = $Goal
+            Problem   = $Problem
+            Location  = $Location
+            NextSteps = @($NextSteps)
+        }
+        $errorId = if ($ErrorType) { "ActionableError:$ErrorType" } else { 'ActionableError' }
+        # Pass the structured payload as the constructor's targetObject arg — ErrorRecord.TargetObject
+        # is read-only after construction, so it cannot be assigned afterward.
+        $rec = [System.Management.Automation.ErrorRecord]::new(
+            $exc, $errorId,
+            [System.Management.Automation.ErrorCategory]::NotSpecified, $targetData)
+        return $rec
+    }
+    elseif ($PassThru) {
         return $Message
     }
     elseif ($Throw) {

--- a/scripts/AITriad/Public/Get-OpEdSource.ps1
+++ b/scripts/AITriad/Public/Get-OpEdSource.ps1
@@ -4,18 +4,27 @@
 function Get-OpEdSource {
     <#
     .SYNOPSIS
-        Fetches, converts, and validates a source URL for op-ed generation — once for all POVs.
+        Converts and validates PRE-FETCHED source content for op-ed generation — once for all POVs.
     .DESCRIPTION
-        Fetches the URL, detects its format (PDF / DOCX / HTML) from the Content-Type header and
-        URL extension, routes to the appropriate converter (ConvertFrom-Pdf, ConvertFrom-Docx, or
-        ConvertFrom-Html), applies a fail-loud readability gate, truncates to the prompt budget,
-        and returns a prep object that New-OpEd (or the server) can pass to multiple per-POV
-        drafts without re-fetching or re-converting.
+        Convert-only (t/3307). The URL fetch moved to the shared SSRF-guarded Node fetcher
+        (lib/url-fetch) after the .NET/PowerShell HTTP client fingerprint was WAF-blocked (403) on
+        hosts Node fetches at 200 (t/3306). The caller (the op-ed Node orchestrator, or New-OpEd's
+        CLI path) fetches the bytes, writes them to a temp file, and passes the path + content-type
+        here. This cmdlet reads the file, routes to the converter keyed on -ContentType (authoritative,
+        never the filename extension — a .html-named PDF must still convert as a PDF, t/3306#4),
+        applies a fail-loud readability gate, truncates to the prompt budget, and returns a prep
+        object that New-OpEd (or the server) reuses across per-POV drafts without re-converting.
 
-        SourceBrief is populated by New-OpEd after the comprehension pass; it is null here.
-    .PARAMETER Url
-        The URL to fetch. PDF and DOCX are written to a temp file before conversion; HTML is
-        passed as a string.
+        The caller owns the temp file lifecycle (creates + deletes it); this cmdlet never fetches,
+        writes, or deletes it. SourceBrief is populated by New-OpEd after the comprehension pass.
+    .PARAMETER ContentPath
+        Path to the pre-fetched source bytes on disk (a temp file the caller owns).
+    .PARAMETER ContentType
+        The source Content-Type (authoritative dispatch): 'application/pdf' → PDF,
+        '…wordprocessingml…' → DOCX, text/* or empty → HTML.
+    .PARAMETER SourceUrl
+        Optional originating URL — used as the HTML base for relative-link resolution and recorded
+        on the returned object for provenance. Not fetched.
     .PARAMETER MaxChars
         Maximum characters of extracted Markdown to retain for the prompt budget. Default 12000.
     .PARAMETER MinReadableWords
@@ -24,11 +33,12 @@ function Get-OpEdSource {
     .PARAMETER MinAlphaDensity
         Minimum ratio of alpha-words to total whitespace-split tokens. Default 0.60.
     .EXAMPLE
-        $Prep = Get-OpEdSource -Url 'https://example.com/report.pdf'
+        $Prep = Get-OpEdSource -ContentPath $Temp -ContentType 'application/pdf' -SourceUrl $Url
         New-OpEd -SourcePrep $Prep -Pov safetyist
     .OUTPUTS
-        PSCustomObject with: Url, SourceMarkdown, SourceFormat, SourceExtractionTool,
-        ReadableWords, ReadableRatio, CharsTotal, CharsUsed, Truncated, Excerpt, SourceBrief.
+        PSCustomObject with: SourceUrl, ContentType, SourceMarkdown, SourceFormat,
+        SourceExtractionTool, ReadableWords, ReadableRatio, CharsTotal, CharsUsed, Truncated,
+        Excerpt, ContentHash, FetchedAt, SourceBrief.
     .LINK
         New-OpEd
     #>
@@ -37,7 +47,13 @@ function Get-OpEdSource {
     param(
         [Parameter(Mandatory, Position = 0)]
         [ValidateNotNullOrEmpty()]
-        [string]$Url,
+        [string]$ContentPath,
+
+        [Parameter(Mandatory, Position = 1)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ContentType,
+
+        [string]$SourceUrl = '',
 
         [ValidateRange(1000, 100000)]
         [int]$MaxChars = 12000,
@@ -51,83 +67,87 @@ function Get-OpEdSource {
 
     Set-StrictMode -Version Latest
 
-    # ── Fetch ────────────────────────────────────────────────────────────────
-    try {
-        $Resp = Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 60
-    } catch {
-        throw (New-ActionableError -PassThru `
-            -Goal "Fetch source URL for op-ed generation" `
-            -Problem "Could not fetch '$Url': $($_.Exception.Message)" `
+    # ── Validate the pre-fetched content file ─────────────────────────────────
+    if (-not (Test-Path -LiteralPath $ContentPath -PathType Leaf)) {
+        throw (New-ActionableError -AsErrorRecord -ErrorType 'ContentPathMissing' `
+            -Goal 'Convert pre-fetched source content for op-ed generation' `
+            -Problem "Content file not found: '$ContentPath'. Get-OpEdSource is convert-only — the caller must fetch the source and write it to this path first." `
             -Location 'Get-OpEdSource' `
             -NextSteps @(
-                'Confirm the URL is reachable and publicly accessible',
+                'Confirm the Node fetcher wrote the temp file before invoking the converter',
                 'Supply material via -Topic text in New-OpEd instead'
             ))
     }
 
-    # ── Detect format ────────────────────────────────────────────────────────
-    $ContentType = [string]($Resp.Headers['Content-Type'] ?? '')
-    $Extension   = [System.IO.Path]::GetExtension(([uri]$Url).LocalPath).ToLower()
-
-    $Format        = 'html'
+    # ── Detect format from ContentType (authoritative — NOT the file extension) ─
+    $Format         = 'html'
     $ExtractionTool = 'ConvertFrom-Html'
-    if ($ContentType -match 'application/pdf' -or $Extension -eq '.pdf') {
-        $Format        = 'pdf'
+    if ($ContentType -match 'application/pdf') {
+        $Format         = 'pdf'
         $ExtractionTool = 'ConvertFrom-Pdf'
-    } elseif ($ContentType -match 'vnd\.openxmlformats' -or $Extension -eq '.docx') {
-        $Format        = 'docx'
+    } elseif ($ContentType -match 'vnd\.openxmlformats' -or $ContentType -match 'msword') {
+        $Format         = 'docx'
         $ExtractionTool = 'ConvertFrom-Docx'
+    } elseif ($ContentType -match '^(image|audio|video)/' -or $ContentType -match 'application/octet-stream') {
+        # Clearly-binary, non-document content — fail with a precise cause rather than letting the
+        # readability gate report a misleading "not readable prose" for e.g. a PNG.
+        throw (New-ActionableError -AsErrorRecord -ErrorType 'UnsupportedContentType' `
+            -Goal 'Convert pre-fetched source content for op-ed generation' `
+            -Problem "Content-Type '$ContentType' is not a supported document format (PDF, DOCX, or HTML/text)." `
+            -Location 'Get-OpEdSource' `
+            -NextSteps @(
+                'Provide a PDF, DOCX, or HTML/text source',
+                'Supply material via -Topic text in New-OpEd instead'
+            ))
     }
 
-    Write-Verbose "Get-OpEdSource: format=$Format tool=$ExtractionTool"
+    Write-Verbose "Get-OpEdSource: contentType=$ContentType format=$Format tool=$ExtractionTool"
 
-    # ── Convert ──────────────────────────────────────────────────────────────
+    # ── Convert (reads the caller-owned temp file; never deletes it) ───────────
     $Markdown = ''
-    switch ($Format) {
-        'pdf' {
-            $TempFile = [System.IO.Path]::GetTempFileName() + '.pdf'
-            try {
-                [System.IO.File]::WriteAllBytes($TempFile, $Resp.Content)
-                $Markdown = Invoke-PdfConversion -Path $TempFile
-            } finally {
-                Remove-Item $TempFile -Force -ErrorAction SilentlyContinue
+    try {
+        switch ($Format) {
+            'pdf'  { $Markdown = Invoke-PdfConversion  -Path $ContentPath }
+            'docx' { $Markdown = Invoke-DocxConversion -Path $ContentPath }
+            default {
+                $Html     = [System.IO.File]::ReadAllText($ContentPath)
+                $HtmlArgs = @{ Html = $Html }
+                if ($SourceUrl) { $HtmlArgs['SourceUrl'] = $SourceUrl }
+                $Markdown = ConvertFrom-Html @HtmlArgs
             }
         }
-        'docx' {
-            $TempFile = [System.IO.Path]::GetTempFileName() + '.docx'
-            try {
-                [System.IO.File]::WriteAllBytes($TempFile, $Resp.Content)
-                $Markdown = Invoke-DocxConversion -Path $TempFile
-            } finally {
-                Remove-Item $TempFile -Force -ErrorAction SilentlyContinue
-            }
-        }
-        default {
-            $Markdown = ConvertFrom-Html -Html ([string]$Resp.Content) -SourceUrl $Url
-        }
+    } catch {
+        throw (New-ActionableError -AsErrorRecord -ErrorType 'ConversionFailed' `
+            -Goal "Extract text from the $Format source" `
+            -Problem "The $ExtractionTool converter failed: $($_.Exception.Message)" `
+            -Location 'Get-OpEdSource' `
+            -NextSteps @(
+                'Install a PDF extraction tool (markitdown, pdftotext, or mutool) for PDF sources',
+                'Confirm the fetched bytes are a valid document of the declared Content-Type',
+                'Supply material via -Topic text in New-OpEd instead'
+            ))
     }
     $Markdown = [string]$Markdown
 
-    # ── Readability gate ─────────────────────────────────────────────────────
-    # Splits on whitespace; counts tokens with >=3 letters as "readable words".
-    # A PDF piped through ConvertFrom-Html yields space-joined decimal byte values —
-    # zero alpha tokens, caught here before the prompt is built.
-    $Tokens      = @($Markdown -split '\s+' | Where-Object { $_ -ne '' })
-    $AlphaTokens = @($Tokens   | Where-Object { ($_ -replace '[^a-zA-Z]', '').Length -ge 3 })
+    # ── Readability gate ──────────────────────────────────────────────────────
+    # Splits on whitespace; counts tokens with >=3 letters as "readable words". A PDF whose bytes
+    # were mis-converted yields space-joined decimal byte values — zero alpha tokens, caught here.
+    $Tokens        = @($Markdown -split '\s+' | Where-Object { $_ -ne '' })
+    $AlphaTokens   = @($Tokens   | Where-Object { ($_ -replace '[^a-zA-Z]', '').Length -ge 3 })
     $ReadableWords = $AlphaTokens.Count
     $ReadableRatio = if ($Tokens.Count -gt 0) { [double]$AlphaTokens.Count / $Tokens.Count } else { 0.0 }
 
     if ($ReadableWords -lt $MinReadableWords -or $ReadableRatio -lt $MinAlphaDensity) {
-        throw (New-ActionableError -PassThru `
-            -Goal "Extract readable text from '$Url'" `
+        throw (New-ActionableError -AsErrorRecord -ErrorType 'InsufficientReadableText' `
+            -Goal 'Extract readable text from the source' `
             -Problem ("Source yielded only $ReadableWords readable word(s) " +
                 "(alpha-token ratio $([Math]::Round($ReadableRatio, 2))). " +
                 "Format detected: $Format. The content is not readable prose.") `
             -Location 'Get-OpEdSource' `
             -NextSteps @(
+                'Confirm the source is a document with readable text content',
                 'Install a PDF extraction tool (markitdown, pdftotext, or mutool) for PDF sources',
-                'Confirm the URL points to a document with readable text content',
-                'Pass -VoiceOnly to New-OpEd to skip source grounding and write from camp voice alone'
+                'Supply material via -Topic text in New-OpEd instead'
             ))
     }
 
@@ -142,18 +162,19 @@ function Get-OpEdSource {
     }
     $Excerpt = $Markdown.Substring(0, [Math]::Min(500, $Markdown.Length))
 
-    # ContentHash: sha256 of the full extracted text (before truncation).
-    # Cheap to compute now; the only key needed for any future cross-run cache.
+    # ContentHash: sha256 of the full extracted text (before truncation). The only key needed for
+    # any future cross-run cache.
     $Sha256 = [System.Security.Cryptography.SHA256]::Create()
     try {
-        $HashBytes = $Sha256.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($Markdown))
+        $HashBytes   = $Sha256.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($Markdown))
         $ContentHash = [System.BitConverter]::ToString($HashBytes).Replace('-', '').ToLowerInvariant()
     } finally {
         $Sha256.Dispose()
     }
 
     [PSCustomObject]@{
-        Url                  = $Url
+        SourceUrl            = $SourceUrl
+        ContentType          = $ContentType
         SourceMarkdown       = $SourceMarkdown
         SourceFormat         = $Format
         SourceExtractionTool = $ExtractionTool

--- a/scripts/AITriad/Public/New-OpEd.ps1
+++ b/scripts/AITriad/Public/New-OpEd.ps1
@@ -260,14 +260,55 @@ function New-OpEd {
         $Prep = $SourcePrep
     } elseif ($PSCmdlet.ParameterSetName -eq 'FromUrl') {
         Write-Verbose "Fetching + converting source material from $Url"
-        $Prep = Get-OpEdSource -Url $Url -Verbose:($VerbosePreference -ne 'SilentlyContinue')
+        # INTERIM CLI-only fetch (t/3312). Get-OpEdSource is convert-only (t/3307): the desktop/Electron
+        # path fetches via the shared SSRF-guarded Node fetcher, but the standalone CLI has no Node
+        # orchestrator, so it fetches here then hands the bytes to the converter. PowerShell's
+        # Invoke-WebRequest is WAF-fingerprint-blocked (403) on some hosts (Akamai .gov, t/3306) where
+        # the Node fetcher gets 200 — so CLI -Url is BEST-EFFORT until it migrates to the shared Node
+        # fetch-CLI under t/3312 (this cmdlet is on that consumer list).
+        $TempSource = $null
+        try {
+            $Resp = Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 60
+            $CT   = [string]($Resp.Headers['Content-Type'] ?? '')
+            # Persist the RAW bytes so binary sources (PDF/DOCX) stay intact; the converter reads them.
+            # Property-guarded access (StrictMode-safe): a real BasicHtmlWebResponseObject exposes
+            # RawContentStream; test doubles may not.
+            $TempSource = [System.IO.Path]::GetTempFileName()
+            $HasRaw = $Resp.PSObject.Properties['RawContentStream'] -and $null -ne $Resp.RawContentStream
+            $Bytes = if ($HasRaw) {
+                $Ms = [System.IO.MemoryStream]::new()
+                try { $Resp.RawContentStream.Position = 0; $Resp.RawContentStream.CopyTo($Ms); $Ms.ToArray() }
+                finally { $Ms.Dispose() }
+            } elseif ($Resp.PSObject.Properties['Content'] -and ($Resp.Content -is [byte[]])) {
+                $Resp.Content
+            } else {
+                [System.Text.Encoding]::UTF8.GetBytes([string]$Resp.Content)
+            }
+            [System.IO.File]::WriteAllBytes($TempSource, $Bytes)
+            $Prep = Get-OpEdSource -ContentPath $TempSource -ContentType $CT -SourceUrl $Url `
+                -Verbose:($VerbosePreference -ne 'SilentlyContinue')
+        } catch {
+            throw (New-ActionableError -PassThru `
+                -Goal 'Fetch + convert source URL for op-ed generation (CLI path)' `
+                -Problem "Could not fetch '$Url': $($_.Exception.Message)" `
+                -Location 'New-OpEd (FromUrl)' `
+                -NextSteps @(
+                    'This CLI fetch is WAF-limited (t/3312); the desktop app fetches via the hardened Node fetcher',
+                    'Confirm the URL is reachable and publicly accessible',
+                    'Supply material via -Topic text instead'
+                ))
+        } finally {
+            if ($TempSource -and (Test-Path -LiteralPath $TempSource)) {
+                Remove-Item -LiteralPath $TempSource -Force -ErrorAction SilentlyContinue
+            }
+        }
     }
 
     $SourceMaterial = '(no external source supplied — argue from the topic and general knowledge)'
     if ($null -ne $Prep) {
         $SourceMaterial = [string]$Prep.SourceMarkdown
         if (-not $PSBoundParameters.ContainsKey('Topic') -or [string]::IsNullOrWhiteSpace($Topic)) {
-            $Topic = "Write an op-ed responding to the source material below (from $($Prep.Url)). Choose the sharpest angle consistent with your camp's convictions."
+            $Topic = "Write an op-ed responding to the source material below (from $($Prep.SourceUrl)). Choose the sharpest angle consistent with your camp's convictions."
         }
     }
 

--- a/taxonomy-editor/src/main/ps/invoke-get-oped-source.ps1
+++ b/taxonomy-editor/src/main/ps/invoke-get-oped-source.ps1
@@ -1,43 +1,71 @@
 #Requires -Version 7
-# Stage-A shim: fetch + convert + readability gate for one URL.
-# Called once per create-oped-set; SourcePrep is threaded into each voice spawn.
-# Reads JSON stdin: { "Url": "<url>" }
-# Writes JSON lines to stdout:
-#   {"type":"result","data":{...SourcePrep fields...}}
-# Throws (exit 1) if Get-OpEdSource's readability gate trips or any error occurs.
+# Stage-A shim: CONVERT pre-fetched source content + readability gate (t/3307). The URL FETCH moved to
+# the shared SSRF-guarded Node fetcher (t/3306); this shim receives a temp-file PATH + content-type,
+# never a URL, and never fetches. The CALLER owns the temp file (creates + deletes it).
+#
+# Reads JSON stdin:  { "ContentPath": "<path>", "ContentType": "<mime>", "SourceUrl": "<url?>" }
+# Writes stdout (success): {"type":"result","data":{...SourcePrep fields; content b64 via _b64Fields}}
+# Writes stderr (failure): {"ErrorType","Goal","Problem","NextSteps"}  then exits 1   (locked t/3306#4)
+#
+# Contract note: the emit field names here are asserted by the shared round-trip test
+# tests/OpEdShimTransport.Tests.ps1 against the parse side (opedShimTransport.ts) — keep them in sync.
 param()
 $ErrorActionPreference = 'Stop'
 
-$raw = [Console]::In.ReadToEnd()
-$p   = $raw | ConvertFrom-Json
+try {
+    $raw = [Console]::In.ReadToEnd()
+    $p   = $raw | ConvertFrom-Json
 
-$repoRoot = $PSScriptRoot
-for ($i = 0; $i -lt 4; $i++) { $repoRoot = Split-Path -Parent $repoRoot }
-$modulePath = Join-Path $repoRoot 'scripts' 'AITriad' 'AITriad.psd1'
-Import-Module $modulePath -Force -ErrorAction Stop
+    $repoRoot = $PSScriptRoot
+    for ($i = 0; $i -lt 4; $i++) { $repoRoot = Split-Path -Parent $repoRoot }
+    $modulePath = Join-Path $repoRoot 'scripts' 'AITriad' 'AITriad.psd1'
+    Import-Module $modulePath -Force -ErrorAction Stop
 
-$prep = Get-OpEdSource -Url ([string]$p.Url)
+    $sourceUrl = if ($p.PSObject.Properties['SourceUrl']) { [string]$p.SourceUrl } else { '' }
+    $prep = Get-OpEdSource -ContentPath ([string]$p.ContentPath) `
+        -ContentType ([string]$p.ContentType) -SourceUrl $sourceUrl
 
-# Base64-encode the fetched arbitrary-web-content fields BEFORE ConvertTo-Json, so it only ever
-# serializes safe ASCII for them. PS ConvertTo-Json emits INVALID JSON for some real article HTML
-# (a bare unescaped `"` inside the value), which the handler then can't parse (t/2928). The handler
-# base64-decodes anything listed in `_b64Fields`.
-#
-# ANY future $prep field carrying fetched / arbitrary web content MUST be added to this list.
-# (Today only SourceMarkdown + Excerpt are content; SourceBrief is $null here — the New-OpEd
-# comprehension pass fills it downstream, not this shim.) Backstop if one is ever missed:
-# opedHandlers surfaces a LOUD ActionableError (parseShimLine), never a silent drop — so the worst
-# case is a diagnosable failure, not a recurrence of this once-invisible bug.
-$b64Fields = @()
-foreach ($f in @('SourceMarkdown', 'Excerpt')) {
-    $val = $prep.$f
-    if ($val -is [string] -and $val.Length -gt 0) {
-        $prep.$f = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($val))
-        $b64Fields += $f
+    # Base64-encode fetched arbitrary-web-content fields BEFORE ConvertTo-Json (t/2928 — PS emits
+    # INVALID JSON for some real content: a bare unescaped `"` inside the value). The handler
+    # base64-decodes anything listed in `_b64Fields`. ANY future $prep field carrying fetched /
+    # arbitrary content MUST be added to this list. Backstop: parseShimLine surfaces a LOUD
+    # ActionableError if a content field is ever missed, never a silent drop.
+    $b64Fields = @()
+    foreach ($f in @('SourceMarkdown', 'Excerpt')) {
+        $val = $prep.$f
+        if ($val -is [string] -and $val.Length -gt 0) {
+            $prep.$f = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($val))
+            $b64Fields += $f
+        }
     }
-}
-$prep | Add-Member -NotePropertyName '_b64Fields' -NotePropertyValue $b64Fields -Force
+    $prep | Add-Member -NotePropertyName '_b64Fields' -NotePropertyValue $b64Fields -Force
 
-$resultLine = [ordered]@{ type = 'result'; data = $prep } | ConvertTo-Json -Depth 10 -Compress
-[Console]::Out.WriteLine($resultLine)
-[Console]::Out.Flush()
+    $resultLine = [ordered]@{ type = 'result'; data = $prep } | ConvertTo-Json -Depth 10 -Compress
+    [Console]::Out.WriteLine($resultLine)
+    [Console]::Out.Flush()
+}
+catch {
+    # Emit the LOCKED failure contract (t/3306#4): {ErrorType,Goal,Problem,NextSteps} JSON on stderr,
+    # exit 1. Prefer the structured TargetObject from Get-OpEdSource's -AsErrorRecord (no message
+    # parsing — parsing the rendered string is the silent parse-fail class). Fall back to a generic
+    # classification for non-ActionableError failures (module import, malformed stdin).
+    $to = $_.TargetObject
+    if ($to -is [System.Collections.IDictionary] -and $to.Contains('ErrorType')) {
+        $err = [ordered]@{
+            ErrorType = [string]$to['ErrorType']
+            Goal      = [string]$to['Goal']
+            Problem   = [string]$to['Problem']
+            NextSteps = @($to['NextSteps'])
+        }
+    } else {
+        $err = [ordered]@{
+            ErrorType = 'Unknown'
+            Goal      = 'Convert pre-fetched source content for op-ed generation'
+            Problem   = [string]$_.Exception.Message
+            NextSteps = @('Verify the stdin payload (ContentPath, ContentType) and that the AITriad module loads')
+        }
+    }
+    [Console]::Error.WriteLine(($err | ConvertTo-Json -Depth 6 -Compress))
+    [Console]::Error.Flush()
+    exit 1
+}

--- a/tests/Get-OpEdSource.Tests.ps1
+++ b/tests/Get-OpEdSource.Tests.ps1
@@ -1,4 +1,4 @@
-# Tag: oped (t/2586)
+# Tag: oped (t/2586, t/3307)
 # Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 # Licensed under the MIT License. See LICENSE file in the project root.
 
@@ -6,11 +6,13 @@
 
 <#
 .SYNOPSIS
-    Unit tests for Get-OpEdSource (t/2586).
+    Unit tests for Get-OpEdSource — convert-only (t/3307).
 .DESCRIPTION
-    Mocks Invoke-WebRequest and the DocConverter cmdlets to verify format
-    detection, readability gate, truncation, and output shape without network
-    access or binary tools.
+    Get-OpEdSource no longer fetches (the URL fetch moved to the shared Node fetcher, t/3306). It
+    reads a caller-owned temp file, dispatches on -ContentType (authoritative, not the extension),
+    converts, applies the readability gate, and returns the prep object — or throws an ActionableError
+    whose TargetObject carries {ErrorType,Goal,Problem,Location,NextSteps} for the shim to serialize.
+    Mocks the DocConverter cmdlets so no binary tools / network are needed.
 #>
 
 BeforeAll {
@@ -32,27 +34,39 @@ BeforeAll {
         'building continuous learning adaptation resilience measurement metrics ' +
         'impact assessment reporting accountability frameworks enforcement ' +
         'mechanisms remediation pathways and meaningful public participation. '
-    ) * 2  # repeat to ensure well above 100 words
+    ) * 2
+
+    # Create a temp file with given bytes/text; tracked for cleanup. Returns the path.
+    $script:TempFiles = [System.Collections.Generic.List[string]]::new()
+    function script:New-SourceTemp {
+        param([string]$Text = 'placeholder', [string]$Extension = '.dat')
+        $path = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(),
+            "opedsrc-$([System.Guid]::NewGuid().ToString('n'))$Extension")
+        [System.IO.File]::WriteAllText($path, $Text)
+        $script:TempFiles.Add($path)
+        return $path
+    }
 }
 
-Describe 'Get-OpEdSource' -Tag 'oped' {
+AfterAll {
+    foreach ($f in $script:TempFiles) {
+        if (Test-Path -LiteralPath $f) { Remove-Item -LiteralPath $f -Force -ErrorAction SilentlyContinue }
+    }
+}
 
-    Context 'HTML source (default)' {
+Describe 'Get-OpEdSource (convert-only)' -Tag 'oped' {
+
+    Context 'HTML source (default dispatch)' {
         BeforeEach {
-            Mock Invoke-WebRequest -ModuleName AITriad {
-                [PSCustomObject]@{
-                    Content    = "<html><body><p>$($script:ReadableText)</p></body></html>"
-                    Headers    = @{ 'Content-Type' = 'text/html; charset=utf-8' }
-                    StatusCode = 200
-                }
-            }
             Mock ConvertFrom-Html -ModuleName AITriad { $script:ReadableText }
+            $script:HtmlPath = script:New-SourceTemp -Text "<html><body><p>$($script:ReadableText)</p></body></html>" -Extension '.html'
         }
 
         It 'Returns a prep object with required fields' {
-            $Prep = Get-OpEdSource -Url 'https://example.com/article.html'
-            $Prep | Should -Not -BeNullOrEmpty
-            $Prep.Url                  | Should -Be 'https://example.com/article.html'
+            $Prep = Get-OpEdSource -ContentPath $script:HtmlPath -ContentType 'text/html; charset=utf-8' -SourceUrl 'https://example.com/article.html'
+            $Prep                      | Should -Not -BeNullOrEmpty
+            $Prep.SourceUrl            | Should -Be 'https://example.com/article.html'
+            $Prep.ContentType          | Should -Be 'text/html; charset=utf-8'
             $Prep.SourceMarkdown       | Should -Not -BeNullOrEmpty
             $Prep.SourceFormat         | Should -Be 'html'
             $Prep.SourceExtractionTool | Should -Be 'ConvertFrom-Html'
@@ -68,179 +82,142 @@ Describe 'Get-OpEdSource' -Tag 'oped' {
         }
 
         It 'ContentHash is deterministic for the same content' {
-            $P1 = Get-OpEdSource -Url 'https://example.com/a.html'
-            $P2 = Get-OpEdSource -Url 'https://example.com/a.html'
+            $P1 = Get-OpEdSource -ContentPath $script:HtmlPath -ContentType 'text/html'
+            $P2 = Get-OpEdSource -ContentPath $script:HtmlPath -ContentType 'text/html'
             $P1.ContentHash | Should -Be $P2.ContentHash
         }
 
         It 'FetchedAt is a valid ISO 8601 timestamp' {
-            $Prep = Get-OpEdSource -Url 'https://example.com/article.html'
+            $Prep = Get-OpEdSource -ContentPath $script:HtmlPath -ContentType 'text/html'
             { [System.DateTime]::Parse($Prep.FetchedAt) } | Should -Not -Throw
         }
+
+        It 'Treats empty ContentType as HTML' {
+            $Prep = Get-OpEdSource -ContentPath $script:HtmlPath -ContentType ' '
+            $Prep.SourceFormat | Should -Be 'html'
+        }
     }
 
-    Context 'PDF source — content-type detection' {
+    Context 'ContentType is authoritative over the filename extension (t/3306#4)' {
         BeforeEach {
-            Mock Invoke-WebRequest -ModuleName AITriad {
-                [PSCustomObject]@{
-                    Content    = [byte[]]@(0x25, 0x50, 0x44, 0x46)
-                    Headers    = @{ 'Content-Type' = 'application/pdf' }
-                    StatusCode = 200
-                }
-            }
             $script:PdfConvCalled = $false
             Mock Invoke-PdfConversion -ModuleName AITriad { $script:PdfConvCalled = $true; $script:ReadableText }
+            Mock ConvertFrom-Html    -ModuleName AITriad { throw 'ConvertFrom-Html must NOT be called for a PDF content-type' }
+            # File named .html but the bytes are a PDF — ContentType must win.
+            $script:MisnamedPath = script:New-SourceTemp -Text 'dummy' -Extension '.html'
         }
 
-        It 'Routes to ConvertFrom-Pdf when Content-Type is application/pdf' {
-            $Prep = Get-OpEdSource -Url 'https://example.com/report'
+        It 'Routes a .html-named file to the PDF converter when ContentType is application/pdf' {
+            $Prep = Get-OpEdSource -ContentPath $script:MisnamedPath -ContentType 'application/pdf'
             $Prep.SourceFormat         | Should -Be 'pdf'
             $Prep.SourceExtractionTool | Should -Be 'ConvertFrom-Pdf'
-            $script:PdfConvCalled      | Should -BeTrue -Because 'Invoke-PdfConversion must be called for PDF routing'
+            $script:PdfConvCalled      | Should -BeTrue -Because 'dispatch keys on ContentType, not the .html extension'
         }
     }
 
-    Context 'PDF source — URL extension detection' {
+    Context 'DOCX dispatch by ContentType' {
         BeforeEach {
-            Mock Invoke-WebRequest -ModuleName AITriad {
-                [PSCustomObject]@{
-                    Content    = [byte[]]@(0x25, 0x50, 0x44, 0x46)
-                    Headers    = @{ 'Content-Type' = 'application/octet-stream' }
-                    StatusCode = 200
-                }
-            }
-            $script:PdfConvCalled = $false
-            Mock Invoke-PdfConversion -ModuleName AITriad { $script:PdfConvCalled = $true; $script:ReadableText }
-        }
-
-        It 'Routes to ConvertFrom-Pdf when URL ends in .pdf' {
-            $Prep = Get-OpEdSource -Url 'https://example.com/report.pdf'
-            $Prep.SourceFormat    | Should -Be 'pdf'
-            $script:PdfConvCalled | Should -BeTrue -Because 'Invoke-PdfConversion must be called for .pdf extension routing'
-        }
-    }
-
-    Context 'DOCX source — URL extension detection' {
-        BeforeEach {
-            Mock Invoke-WebRequest -ModuleName AITriad {
-                [PSCustomObject]@{
-                    Content    = [byte[]]@(0x50, 0x4B, 0x03, 0x04)
-                    Headers    = @{ 'Content-Type' = 'application/octet-stream' }
-                    StatusCode = 200
-                }
-            }
             $script:DocxConvCalled = $false
             Mock Invoke-DocxConversion -ModuleName AITriad { $script:DocxConvCalled = $true; $script:ReadableText }
+            $script:DocxPath = script:New-SourceTemp -Text 'dummy' -Extension '.bin'
         }
 
-        It 'Routes to ConvertFrom-Docx when URL ends in .docx' {
-            $Prep = Get-OpEdSource -Url 'https://example.com/brief.docx'
+        It 'Routes to ConvertFrom-Docx for the wordprocessingml content-type' {
+            $Prep = Get-OpEdSource -ContentPath $script:DocxPath -ContentType 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
             $Prep.SourceFormat          | Should -Be 'docx'
             $Prep.SourceExtractionTool  | Should -Be 'ConvertFrom-Docx'
-            $script:DocxConvCalled      | Should -BeTrue -Because 'Invoke-DocxConversion must be called for .docx extension routing'
+            $script:DocxConvCalled      | Should -BeTrue
         }
     }
 
-    Context 'Readability gate — PDF bytes through HTML converter (the 2/10 incident)' {
-        BeforeEach {
-            Mock Invoke-WebRequest -ModuleName AITriad {
-                [PSCustomObject]@{
-                    Content    = [byte[]]@(0x25, 0x50, 0x44, 0x46)
-                    Headers    = @{ 'Content-Type' = 'text/html' }  # wrong Content-Type
-                    StatusCode = 200
-                }
-            }
-            # Simulate what ConvertFrom-Html actually returns for PDF bytes:
-            # space-separated decimal byte values — zero alpha tokens.
-            Mock ConvertFrom-Html -ModuleName AITriad {
-                '37 80 68 70 45 49 46 48 10 37 226 227 207 211'
-            }
-        }
-
-        It 'Throws ActionableError when extracted text has no readable words' {
-            { Get-OpEdSource -Url 'https://example.com/report.pdf' } | Should -Throw
-        }
-
-        It 'Error message names the format and readable word count' {
-            try {
-                Get-OpEdSource -Url 'https://example.com/report.pdf'
-            } catch {
-                $_.Exception.Message | Should -Match 'readable word'
-            }
+    Context 'ContentPathMissing' {
+        It 'Throws with ErrorType ContentPathMissing when the file does not exist' {
+            $err = $null
+            try { Get-OpEdSource -ContentPath (Join-Path ([System.IO.Path]::GetTempPath()) 'does-not-exist-xyz.dat') -ContentType 'application/pdf' }
+            catch { $err = $_ }
+            $err | Should -Not -BeNullOrEmpty
+            $err.TargetObject.ErrorType | Should -Be 'ContentPathMissing'
+            $err.TargetObject.NextSteps | Should -Not -BeNullOrEmpty
         }
     }
 
-    Context 'Readability gate — MinReadableWords threshold' {
-        BeforeEach {
-            Mock Invoke-WebRequest -ModuleName AITriad {
-                [PSCustomObject]@{
-                    Content    = '<p>ok</p>'
-                    Headers    = @{ 'Content-Type' = 'text/html' }
-                    StatusCode = 200
-                }
-            }
-            # Returns 3 readable words — below the default threshold of 100
-            Mock ConvertFrom-Html -ModuleName AITriad { 'Artificial intelligence policy' }
+    Context 'UnsupportedContentType' {
+        It 'Throws with ErrorType UnsupportedContentType for a binary image' {
+            $path = script:New-SourceTemp -Text 'binary' -Extension '.png'
+            $err = $null
+            try { Get-OpEdSource -ContentPath $path -ContentType 'image/png' } catch { $err = $_ }
+            $err.TargetObject.ErrorType | Should -Be 'UnsupportedContentType'
+        }
+    }
+
+    Context 'ConversionFailed' {
+        It 'Throws with ErrorType ConversionFailed when the converter throws' {
+            Mock Invoke-PdfConversion -ModuleName AITriad { throw 'pdftotext not found' }
+            $path = script:New-SourceTemp -Text 'dummy' -Extension '.pdf'
+            $err = $null
+            try { Get-OpEdSource -ContentPath $path -ContentType 'application/pdf' } catch { $err = $_ }
+            $err.TargetObject.ErrorType | Should -Be 'ConversionFailed'
+        }
+    }
+
+    Context 'Readability gate' {
+        It 'Throws InsufficientReadableText when extracted text is byte-garbage (the 2/10 incident)' {
+            # Simulate a mis-converted PDF: space-joined decimal byte values, zero alpha tokens.
+            Mock ConvertFrom-Html -ModuleName AITriad { '37 80 68 70 45 49 46 48 10 37 226 227 207 211' }
+            $path = script:New-SourceTemp -Text 'garbage' -Extension '.html'
+            $err = $null
+            try { Get-OpEdSource -ContentPath $path -ContentType 'text/html' } catch { $err = $_ }
+            $err.TargetObject.ErrorType | Should -Be 'InsufficientReadableText'
+            $err.Exception.Message      | Should -Match 'readable word'
         }
 
         It 'Throws when readable word count is below MinReadableWords' {
-            { Get-OpEdSource -Url 'https://example.com/stub.html' } | Should -Throw
+            Mock ConvertFrom-Html -ModuleName AITriad { 'Artificial intelligence policy' }
+            $path = script:New-SourceTemp -Text 'stub' -Extension '.html'
+            { Get-OpEdSource -ContentPath $path -ContentType 'text/html' } | Should -Throw
         }
 
         It 'Passes when MinReadableWords is lowered to match' {
-            $Prep = Get-OpEdSource -Url 'https://example.com/stub.html' -MinReadableWords 2
+            Mock ConvertFrom-Html -ModuleName AITriad { 'Artificial intelligence policy' }
+            $path = script:New-SourceTemp -Text 'stub' -Extension '.html'
+            $Prep = Get-OpEdSource -ContentPath $path -ContentType 'text/html' -MinReadableWords 2 -MinAlphaDensity 0.5
             $Prep.ReadableWords | Should -BeGreaterOrEqual 2
         }
     }
 
     Context 'Truncation' {
         BeforeEach {
-            # Build text well over 2000 chars with enough readable words
             $script:LongText = $script:ReadableText * 10
-            Mock Invoke-WebRequest -ModuleName AITriad {
-                [PSCustomObject]@{
-                    Content    = "<p>$($script:LongText)</p>"
-                    Headers    = @{ 'Content-Type' = 'text/html' }
-                    StatusCode = 200
-                }
-            }
             Mock ConvertFrom-Html -ModuleName AITriad { $script:LongText }
+            $script:LongPath = script:New-SourceTemp -Text 'long' -Extension '.html'
         }
 
         It 'Truncates SourceMarkdown to MaxChars and sets Truncated=true' {
-            $Prep = Get-OpEdSource -Url 'https://example.com/long.html' -MaxChars 1000
-            $Prep.Truncated         | Should -Be $true
-            $Prep.CharsUsed         | Should -Be 1000
-            $Prep.SourceMarkdown.Length | Should -BeLessOrEqual 1030  # 1000 + truncation notice
-            $Prep.CharsTotal        | Should -BeGreaterThan 1000
+            $Prep = Get-OpEdSource -ContentPath $script:LongPath -ContentType 'text/html' -MaxChars 1000
+            $Prep.Truncated             | Should -Be $true
+            $Prep.CharsUsed             | Should -Be 1000
+            $Prep.SourceMarkdown.Length | Should -BeLessOrEqual 1030
+            $Prep.CharsTotal            | Should -BeGreaterThan 1000
         }
 
         It 'ContentHash reflects the full untruncated text regardless of MaxChars' {
-            $Prep1 = Get-OpEdSource -Url 'https://example.com/long.html' -MaxChars 1000
-            $Prep2 = Get-OpEdSource -Url 'https://example.com/long.html' -MaxChars 2000
-            $Prep1.ContentHash | Should -Be $Prep2.ContentHash
-        }
-    }
-
-    Context 'Network failure' {
-        BeforeEach {
-            Mock Invoke-WebRequest -ModuleName AITriad {
-                throw [System.Net.WebException]::new('Connection refused')
-            }
-        }
-
-        It 'Throws ActionableError when the URL is unreachable' {
-            { Get-OpEdSource -Url 'https://unreachable.example.com/' } | Should -Throw
+            $P1 = Get-OpEdSource -ContentPath $script:LongPath -ContentType 'text/html' -MaxChars 1000
+            $P2 = Get-OpEdSource -ContentPath $script:LongPath -ContentType 'text/html' -MaxChars 2000
+            $P1.ContentHash | Should -Be $P2.ContentHash
         }
     }
 
     Context 'Parameter validation' {
-        It 'Rejects empty Url' {
-            { Get-OpEdSource -Url '' } | Should -Throw
+        It 'Rejects empty ContentPath' {
+            { Get-OpEdSource -ContentPath '' -ContentType 'text/html' } | Should -Throw
         }
-
+        It 'Rejects empty ContentType' {
+            $path = script:New-SourceTemp -Text 'x' -Extension '.html'
+            { Get-OpEdSource -ContentPath $path -ContentType '' } | Should -Throw
+        }
         It 'Rejects MaxChars below minimum (1000)' {
-            { Get-OpEdSource -Url 'https://example.com/' -MaxChars 999 } | Should -Throw
+            $path = script:New-SourceTemp -Text 'x' -Extension '.html'
+            { Get-OpEdSource -ContentPath $path -ContentType 'text/html' -MaxChars 999 } | Should -Throw
         }
     }
 }

--- a/tests/New-ActionableError.Tests.ps1
+++ b/tests/New-ActionableError.Tests.ps1
@@ -1,0 +1,67 @@
+# Tag: erroring (t/3307)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Tests for New-ActionableError's -ErrorType and -AsErrorRecord options (t/3307).
+.DESCRIPTION
+    -ErrorType and -AsErrorRecord are optional/backward-compatible additions so a subprocess shim can
+    serialize a structured failure ({ErrorType,Goal,Problem,NextSteps}) WITHOUT parsing the rendered
+    human message. Verifies structured propagation via TargetObject, the rendered Type: line, and that
+    pre-existing default/-PassThru/-Throw behavior is unchanged. New-ActionableError is private, so
+    exercised via InModuleScope.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'New-ActionableError -AsErrorRecord / -ErrorType' -Tag 'erroring' {
+
+    It '-AsErrorRecord returns an ErrorRecord whose TargetObject carries the structured fields' {
+        $rec = InModuleScope AITriad {
+            New-ActionableError -AsErrorRecord -ErrorType 'ContentPathMissing' `
+                -Goal 'G' -Problem 'P' -Location 'L' -NextSteps @('one', 'two')
+        }
+        $rec        | Should -BeOfType [System.Management.Automation.ErrorRecord]
+        $to = $rec.TargetObject
+        $to.ErrorType | Should -Be 'ContentPathMissing'
+        $to.Goal      | Should -Be 'G'
+        $to.Problem   | Should -Be 'P'
+        $to.Location  | Should -Be 'L'
+        @($to.NextSteps).Count | Should -Be 2
+        $rec.FullyQualifiedErrorId | Should -Match 'ContentPathMissing'
+    }
+
+    It '-ErrorType renders a Type: line in the -PassThru message' {
+        $msg = InModuleScope AITriad {
+            New-ActionableError -PassThru -ErrorType 'ConversionFailed' `
+                -Goal 'G' -Problem 'P' -Location 'L' -NextSteps @('x')
+        }
+        $msg | Should -Match 'Type:\s+ConversionFailed'
+    }
+
+    It 'omits the Type: line when -ErrorType is not supplied (backward compatible)' {
+        $msg = InModuleScope AITriad {
+            New-ActionableError -PassThru -Goal 'G' -Problem 'P' -Location 'L' -NextSteps @('x')
+        }
+        $msg | Should -Not -Match 'Type:'
+        # Rendered labels unchanged (t/2952): Goal/Error/Location/Resolve.
+        $msg | Should -Match 'Goal:'
+        $msg | Should -Match 'Error:'
+        $msg | Should -Match 'Location:'
+        $msg | Should -Match 'Resolve:'
+    }
+
+    It 'still throws the rendered string with -Throw (unchanged path)' {
+        {
+            InModuleScope AITriad {
+                New-ActionableError -Throw -Goal 'G' -Problem 'boom' -Location 'L' -NextSteps @('x')
+            }
+        } | Should -Throw -ExpectedMessage '*boom*'
+    }
+}

--- a/tests/OpEdShimTransport.Tests.ps1
+++ b/tests/OpEdShimTransport.Tests.ps1
@@ -64,3 +64,55 @@ Describe 'invoke-get-oped-source shim — base64 content transport (t/2928)' {
         $parsed.data.ReadableWords | Should -Be 640
     }
 }
+
+# ── Locked cross-role wire contract (t/3306#4, t/3307) ────────────────────────────────────────────
+# The shim (invoke-get-oped-source.ps1) EMIT side must use the exact field names the TS parse side
+# (opedShimTransport.ts) reads. TL's non-negotiable guard: assert the exact field names on emit here;
+# the TS test (opedShimTransport.test.ts) asserts the same names on parse. Success carries
+# SourceMarkdown; failure carries EXACTLY {ErrorType, Goal, Problem, NextSteps} on stderr.
+Describe 'op-ed shim ↔ handler LOCKED wire contract (t/3307)' {
+    BeforeAll {
+        $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+        Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+    }
+
+    It 'success result carries the SourceMarkdown field name' {
+        $prep = [PSCustomObject]@{ SourceMarkdown = 'body'; Excerpt = 'lead'; SourceFormat = 'html' }
+        $line = [ordered]@{ type = 'result'; data = $prep } | ConvertTo-Json -Depth 10 -Compress
+        $parsed = $line | ConvertFrom-Json
+        $parsed.type                                    | Should -Be 'result'
+        $parsed.data.PSObject.Properties.Name           | Should -Contain 'SourceMarkdown'
+    }
+
+    It 'failure serialization emits EXACTLY {ErrorType,Goal,Problem,NextSteps} from the structured TargetObject' {
+        # Build the real structured error Get-OpEdSource throws, then replicate the shim catch verbatim.
+        $rec = InModuleScope AITriad {
+            New-ActionableError -AsErrorRecord -ErrorType 'ContentPathMissing' `
+                -Goal 'Convert pre-fetched source content for op-ed generation' `
+                -Problem "Content file not found: 'x'" `
+                -Location 'Get-OpEdSource' `
+                -NextSteps @('Confirm the fetcher wrote the temp file', 'Supply -Topic text instead')
+        }
+        $to = $rec.TargetObject
+        $to | Should -BeOfType [System.Collections.IDictionary]
+
+        # Verbatim mirror of the shim's catch-block serialization.
+        $err = [ordered]@{
+            ErrorType = [string]$to['ErrorType']
+            Goal      = [string]$to['Goal']
+            Problem   = [string]$to['Problem']
+            NextSteps = @($to['NextSteps'])
+        }
+        $json   = $err | ConvertTo-Json -Depth 6 -Compress
+        $parsed = $json | ConvertFrom-Json
+
+        # EXACT field-name set — no more, no less (a drift here = the silent parse-fail class).
+        $names = @($parsed.PSObject.Properties.Name | Sort-Object)
+        $names | Should -Be @('ErrorType', 'Goal', 'NextSteps', 'Problem')
+
+        $parsed.ErrorType | Should -Be 'ContentPathMissing'
+        $parsed.Goal      | Should -Be 'Convert pre-fetched source content for op-ed generation'
+        $parsed.Problem   | Should -Match 'Content file not found'
+        @($parsed.NextSteps).Count | Should -Be 2
+    }
+}


### PR DESCRIPTION
## t/3307 — Get-OpEdSource convert-only + structured shim failure contract

Implements the PowerShell half of the op-ed fetch/convert split (TL ruling t/3306#2, gate t/3307#3).

### Changes
- **Get-OpEdSource → convert-only**: `-ContentPath` + `-ContentType` (authoritative dispatch, not the extension) + optional `-SourceUrl`. Drops `Invoke-WebRequest` (the WAF-fingerprint 403 root cause, t/3306). Caller owns the temp file.
- **Shim** `invoke-get-oped-source.ps1`: stdin `{ContentPath,ContentType,SourceUrl?}` → success envelope with `SourceMarkdown` (base64, t/2928 preserved) / stderr `{ErrorType,Goal,Problem,NextSteps}` + exit 1 on failure.
- **New-ActionableError**: `-ErrorType` + `-AsErrorRecord` (optional, backward-compat) → structured failures serialize from `ErrorRecord.TargetObject`, never by parsing the human message.
- **New-OpEd `-Url`**: best-effort CLI fetch preserved (WAF-limited interim, migrates to the Node fetch-CLI under t/3312).
- Catalog updated.

### Cross-role contract (locked, t/3306#4)
INPUT `{ContentPath,ContentType}` → SUCCESS `{SourceMarkdown}` → FAILURE stderr `{ErrorType,Goal,Problem,NextSteps}`. Guarded by the round-trip test in `tests/OpEdShimTransport.Tests.ps1` (exact field names).

### ⚠️ Joint landing — DRAFT until #1940
The new shim stdin (`{ContentPath,ContentType}`) is incompatible with the pre-#1940 opedHandlers (`{Url}`). Per TL (t/3307#3) this lands **jointly with ElectronMain #1940 at the GV**. Do not self-merge alone.

### Tests
60 green: convert-only ContentType dispatch (incl. `.html`-named PDF), the four ErrorType classifications, New-ActionableError options + backward-compat, and the shim↔handler wire-contract guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
