### PR TITLE
feat(oped): Get-OpEdSource convert-only + structured failure transpor…

### DIFF
--- a/scripts/AITriad/Private/Get-OpEdSourceFromUrl.ps1
+++ b/scripts/AITriad/Private/Get-OpEdSourceFromUrl.ps1
@@ -1,0 +1,77 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+#
+# CLI convenience: best-effort PS fetch → temp file → convert-only Get-OpEdSource, so `New-OpEd -Url`
+# keeps working from the command line after Get-OpEdSource became convert-only (t/3307).
+#
+# WAF-limited interim (t/3312): PowerShell's Invoke-WebRequest client fingerprint is blocked by some
+# WAFs (Akamai .gov/news PDFs will 403 it) — the same WAF-fingerprint fetch class the Electron op-ed
+# path already avoids by fetching via Node (fetchUrlForPromptBinary) and calling the convert-only
+# shim. This helper is the ONE remaining PS-side external URL fetch; it migrates to the shared Node
+# fetch-CLI entrypoint when that lands under t/3312. Kept for now so the CLI is not broken. Because it
+# is a t/3312 class-member, it is intentionally localized here (one entry point) rather than inlined
+# into New-OpEd, so the migration and any WAF-fetch prevention guard have a single site to target.
+#
+# Dot-sourced by AITriad.psm1 — do NOT export.
+
+function Get-OpEdSourceFromUrl {
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Url,
+
+        [ValidateRange(1000, 100000)]
+        [int]$MaxChars = 12000,
+
+        [ValidateRange(1, 10000)]
+        [int]$MinReadableWords = 100,
+
+        [ValidateRange(0.0, 1.0)]
+        [double]$MinAlphaDensity = 0.60
+    )
+
+    Set-StrictMode -Version Latest
+
+    try {
+        $Resp = Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 60
+    } catch {
+        throw (New-ActionableError -PassThru `
+            -ErrorType 'FetchFailed' `
+            -Goal 'Fetch source URL for op-ed generation' `
+            -Problem "Could not fetch '$Url': $($_.Exception.Message)" `
+            -Location 'Get-OpEdSourceFromUrl' `
+            -NextSteps @(
+                'Confirm the URL is reachable and publicly accessible',
+                'This CLI fetch is WAF-limited (Akamai .gov/news PDFs may 403 the PowerShell client); use the Electron op-ed path or supply -Topic text in New-OpEd instead'
+            ))
+    }
+
+    # Content-Type is authoritative for the convert step; fall back to the URL extension only when the
+    # server omitted it. Get-OpEdSource dispatches on ContentType, so the temp-file extension is advisory.
+    $ContentType = [string]($Resp.Headers['Content-Type'] ?? '')
+    if ([string]::IsNullOrWhiteSpace($ContentType)) {
+        $UrlExt = [System.IO.Path]::GetExtension(([uri]$Url).LocalPath).ToLowerInvariant()
+        $ContentType = switch ($UrlExt) {
+            '.pdf'  { 'application/pdf' }
+            '.docx' { 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' }
+            default { 'text/html' }
+        }
+    }
+
+    $TempExt = if ($ContentType -match 'pdf') { '.pdf' } elseif ($ContentType -match 'wordprocessingml') { '.docx' } else { '.html' }
+    $TempFile = [System.IO.Path]::GetTempFileName() + $TempExt
+    try {
+        $Bytes = if ($Resp.Content -is [byte[]]) {
+            $Resp.Content
+        } else {
+            [System.Text.Encoding]::UTF8.GetBytes([string]$Resp.Content)
+        }
+        [System.IO.File]::WriteAllBytes($TempFile, $Bytes)
+        Get-OpEdSource -ContentPath $TempFile -ContentType $ContentType -SourceUrl $Url `
+            -MaxChars $MaxChars -MinReadableWords $MinReadableWords -MinAlphaDensity $MinAlphaDensity
+    } finally {
+        Remove-Item -LiteralPath $TempFile -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/scripts/AITriad/Private/New-ActionableError.ps1
+++ b/scripts/AITriad/Private/New-ActionableError.ps1
@@ -38,6 +38,11 @@ function New-ActionableError {
         [Parameter(Mandatory)]
         [string[]]$NextSteps,
 
+        # Optional machine-readable error category (e.g. 'InsufficientReadableText'). Additive and
+        # backward-compatible: when absent the rendered message is unchanged for the existing callers;
+        # when set it renders a `Type:` line so callers/shims can classify the failure (t/3307).
+        [string]$ErrorType,
+
         [System.Management.Automation.ErrorRecord]$InnerError,
 
         [switch]$Throw,
@@ -47,11 +52,17 @@ function New-ActionableError {
 
     $StepList = ($NextSteps | ForEach-Object { $i = [int]($NextSteps.IndexOf($_)) + 1; "   $i. $_" }) -join "`n"
     if ($InnerError) { $InnerDetail = "`n   Inner error: $($InnerError.Exception.Message)" } else { $InnerDetail = '' }
+    # Only rendered when -ErrorType is supplied — keeps output byte-identical for the 40+ callers that don't.
+    if ($PSBoundParameters.ContainsKey('ErrorType') -and -not [string]::IsNullOrEmpty($ErrorType)) {
+        $TypeLine = "`n  Type:     $ErrorType"
+    } else {
+        $TypeLine = ''
+    }
 
     $Message = @"
 
   Goal:     $Goal
-  Error:    $Problem$InnerDetail
+  Error:    $Problem$InnerDetail$TypeLine
   Location: $Location
   Resolve:
 $StepList

--- a/scripts/AITriad/Public/Get-OpEdSource.ps1
+++ b/scripts/AITriad/Public/Get-OpEdSource.ps1
@@ -4,18 +4,35 @@
 function Get-OpEdSource {
     <#
     .SYNOPSIS
-        Fetches, converts, and validates a source URL for op-ed generation — once for all POVs.
+        Converts and validates pre-fetched source content for op-ed generation — once for all POVs.
     .DESCRIPTION
-        Fetches the URL, detects its format (PDF / DOCX / HTML) from the Content-Type header and
-        URL extension, routes to the appropriate converter (ConvertFrom-Pdf, ConvertFrom-Docx, or
-        ConvertFrom-Html), applies a fail-loud readability gate, truncates to the prompt budget,
-        and returns a prep object that New-OpEd (or the server) can pass to multiple per-POV
-        drafts without re-fetching or re-converting.
+        CONVERT-ONLY (t/3306/t/3307). The bytes have already been fetched (by the Node
+        fetchUrlForPromptBinary path for the Electron op-ed flow, or by Get-OpEdSourceFromUrl for
+        the CLI) and written to a temp file. This cmdlet reads that file, dispatches on the
+        authoritative Content-Type (NOT the file extension), routes to the appropriate converter
+        (Invoke-PdfConversion / Invoke-DocxConversion / ConvertFrom-Html), applies a fail-loud
+        readability gate, truncates to the prompt budget, and returns a prep object that New-OpEd
+        (or the server) can pass to multiple per-POV drafts without re-converting.
+
+        It never fetches — routing external URL fetches through one hardened Node fetcher is what
+        fixes the WAF-fingerprint 403 that blocked the old PowerShell Invoke-WebRequest path (the
+        senate.gov/Akamai case) and consolidates SSRF hardening in one place.
+
+        On failure it throws an ActionableError whose TargetObject carries a structured
+        { ErrorType, Goal, Problem, NextSteps } payload, so the Stage-A shim can serialize the real
+        cause to the handler instead of collapsing to a generic exit-code-1 (t/3306). ErrorType is
+        one of: ContentPathMissing, UnsupportedContentType, ConversionFailed, InsufficientReadableText.
 
         SourceBrief is populated by New-OpEd after the comprehension pass; it is null here.
-    .PARAMETER Url
-        The URL to fetch. PDF and DOCX are written to a temp file before conversion; HTML is
-        passed as a string.
+    .PARAMETER ContentPath
+        Path to the temp file holding the already-fetched source bytes. Read directly; never fetched.
+    .PARAMETER ContentType
+        The authoritative MIME type from the fetch (e.g. 'application/pdf', 'text/html'). Conversion
+        dispatch keys off THIS, not the file extension — a content-type→extension guess can be wrong
+        (a `.html`-named PDF would mis-convert), so the temp-file extension is advisory only.
+    .PARAMETER SourceUrl
+        Optional informational URL: used as the HTML base URL for resolving relative links and passed
+        through onto the returned object's provenance field. Not fetched.
     .PARAMETER MaxChars
         Maximum characters of extracted Markdown to retain for the prompt budget. Default 12000.
     .PARAMETER MinReadableWords
@@ -24,11 +41,12 @@ function Get-OpEdSource {
     .PARAMETER MinAlphaDensity
         Minimum ratio of alpha-words to total whitespace-split tokens. Default 0.60.
     .EXAMPLE
-        $Prep = Get-OpEdSource -Url 'https://example.com/report.pdf'
+        $Prep = Get-OpEdSource -ContentPath $Temp -ContentType 'application/pdf' -SourceUrl $Url
         New-OpEd -SourcePrep $Prep -Pov safetyist
     .OUTPUTS
-        PSCustomObject with: Url, SourceMarkdown, SourceFormat, SourceExtractionTool,
-        ReadableWords, ReadableRatio, CharsTotal, CharsUsed, Truncated, Excerpt, SourceBrief.
+        PSCustomObject with: SourceUrl, ContentType, SourceMarkdown, SourceFormat,
+        SourceExtractionTool, ReadableWords, ReadableRatio, CharsTotal, CharsUsed, Truncated,
+        Excerpt, ContentHash, FetchedAt, SourceBrief.
     .LINK
         New-OpEd
     #>
@@ -37,7 +55,13 @@ function Get-OpEdSource {
     param(
         [Parameter(Mandatory, Position = 0)]
         [ValidateNotNullOrEmpty()]
-        [string]$Url,
+        [string]$ContentPath,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ContentType,
+
+        [string]$SourceUrl = '',
 
         [ValidateRange(1000, 100000)]
         [int]$MaxChars = 12000,
@@ -51,60 +75,83 @@ function Get-OpEdSource {
 
     Set-StrictMode -Version Latest
 
-    # ── Fetch ────────────────────────────────────────────────────────────────
-    try {
-        $Resp = Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 60
-    } catch {
-        throw (New-ActionableError -PassThru `
-            -Goal "Fetch source URL for op-ed generation" `
-            -Problem "Could not fetch '$Url': $($_.Exception.Message)" `
-            -Location 'Get-OpEdSource' `
+    # Throws an ActionableError whose TargetObject carries the structured { ErrorType, Goal, Problem,
+    # NextSteps } the Stage-A shim serializes to the handler (t/3306 contract). CLI callers still see
+    # the human-rendered message on $_.Exception.Message.
+    function New-ConvertError {
+        param(
+            [Parameter(Mandatory)][string]$ErrorType,
+            [Parameter(Mandatory)][string]$Goal,
+            [Parameter(Mandatory)][string]$Problem,
+            [Parameter(Mandatory)][string[]]$NextSteps
+        )
+        $Rendered = New-ActionableError -PassThru -ErrorType $ErrorType `
+            -Goal $Goal -Problem $Problem -Location 'Get-OpEdSource' -NextSteps $NextSteps
+        $Payload = [PSCustomObject]@{
+            ErrorType = $ErrorType
+            Goal      = $Goal
+            Problem   = $Problem
+            NextSteps = [string[]]@($NextSteps)
+        }
+        $Record = [System.Management.Automation.ErrorRecord]::new(
+            [System.Exception]::new($Rendered),
+            "GetOpEdSource.$ErrorType",
+            [System.Management.Automation.ErrorCategory]::InvalidData,
+            $Payload)
+        throw $Record
+    }
+
+    # ── Validate the pre-fetched content file ────────────────────────────────
+    if (-not (Test-Path -LiteralPath $ContentPath -PathType Leaf)) {
+        New-ConvertError -ErrorType 'ContentPathMissing' `
+            -Goal 'Convert pre-fetched source content for op-ed generation' `
+            -Problem "The content file was not found or is not readable: '$ContentPath'" `
             -NextSteps @(
-                'Confirm the URL is reachable and publicly accessible',
+                'This is an internal handoff error — the fetched bytes should have been written to a temp file before Get-OpEdSource ran',
+                'Retry the op-ed source fetch, or supply material via -Topic text in New-OpEd instead'
+            )
+    }
+
+    # ── Dispatch on Content-Type (authoritative; extension is advisory) ──────
+    $Ct = $ContentType.ToLowerInvariant()
+    if ($Ct -match 'application/pdf' -or $Ct -match '(^|[^a-z])pdf([^a-z]|$)') {
+        $Format = 'pdf'; $ExtractionTool = 'ConvertFrom-Pdf'
+    } elseif ($Ct -match 'wordprocessingml' -or $Ct -match 'application/msword') {
+        $Format = 'docx'; $ExtractionTool = 'ConvertFrom-Docx'
+    } elseif ($Ct -match 'html' -or $Ct -match 'xml' -or $Ct -match '^text/') {
+        $Format = 'html'; $ExtractionTool = 'ConvertFrom-Html'
+    } else {
+        New-ConvertError -ErrorType 'UnsupportedContentType' `
+            -Goal 'Convert pre-fetched source content for op-ed generation' `
+            -Problem "Content-Type '$ContentType' is not a supported op-ed source format (expected PDF, DOCX, or HTML/text)." `
+            -NextSteps @(
+                'Supply a URL whose content is a PDF, DOCX, or HTML/text document',
                 'Supply material via -Topic text in New-OpEd instead'
-            ))
+            )
     }
 
-    # ── Detect format ────────────────────────────────────────────────────────
-    $ContentType = [string]($Resp.Headers['Content-Type'] ?? '')
-    $Extension   = [System.IO.Path]::GetExtension(([uri]$Url).LocalPath).ToLower()
+    Write-Verbose "Get-OpEdSource: contentType='$ContentType' format=$Format tool=$ExtractionTool"
 
-    $Format        = 'html'
-    $ExtractionTool = 'ConvertFrom-Html'
-    if ($ContentType -match 'application/pdf' -or $Extension -eq '.pdf') {
-        $Format        = 'pdf'
-        $ExtractionTool = 'ConvertFrom-Pdf'
-    } elseif ($ContentType -match 'vnd\.openxmlformats' -or $Extension -eq '.docx') {
-        $Format        = 'docx'
-        $ExtractionTool = 'ConvertFrom-Docx'
-    }
-
-    Write-Verbose "Get-OpEdSource: format=$Format tool=$ExtractionTool"
-
-    # ── Convert ──────────────────────────────────────────────────────────────
+    # ── Convert (read directly from the pre-fetched temp file) ───────────────
     $Markdown = ''
-    switch ($Format) {
-        'pdf' {
-            $TempFile = [System.IO.Path]::GetTempFileName() + '.pdf'
-            try {
-                [System.IO.File]::WriteAllBytes($TempFile, $Resp.Content)
-                $Markdown = Invoke-PdfConversion -Path $TempFile
-            } finally {
-                Remove-Item $TempFile -Force -ErrorAction SilentlyContinue
+    try {
+        switch ($Format) {
+            'pdf'  { $Markdown = Invoke-PdfConversion -Path $ContentPath }
+            'docx' { $Markdown = Invoke-DocxConversion -Path $ContentPath }
+            default {
+                $Html = Get-Content -LiteralPath $ContentPath -Raw -Encoding UTF8
+                $Markdown = ConvertFrom-Html -Html ([string]$Html) -SourceUrl $SourceUrl
             }
         }
-        'docx' {
-            $TempFile = [System.IO.Path]::GetTempFileName() + '.docx'
-            try {
-                [System.IO.File]::WriteAllBytes($TempFile, $Resp.Content)
-                $Markdown = Invoke-DocxConversion -Path $TempFile
-            } finally {
-                Remove-Item $TempFile -Force -ErrorAction SilentlyContinue
-            }
-        }
-        default {
-            $Markdown = ConvertFrom-Html -Html ([string]$Resp.Content) -SourceUrl $Url
-        }
+    } catch {
+        New-ConvertError -ErrorType 'ConversionFailed' `
+            -Goal "Extract readable text from the $Format source" `
+            -Problem "The $ExtractionTool conversion failed: $($_.Exception.Message)" `
+            -NextSteps @(
+                'Install the required extraction tool (markitdown, pdftotext, or mutool for PDF; pandoc for HTML) and retry',
+                'Confirm the source is a valid, non-corrupt document',
+                'Supply material via -Topic text in New-OpEd instead'
+            )
     }
     $Markdown = [string]$Markdown
 
@@ -118,17 +165,16 @@ function Get-OpEdSource {
     $ReadableRatio = if ($Tokens.Count -gt 0) { [double]$AlphaTokens.Count / $Tokens.Count } else { 0.0 }
 
     if ($ReadableWords -lt $MinReadableWords -or $ReadableRatio -lt $MinAlphaDensity) {
-        throw (New-ActionableError -PassThru `
-            -Goal "Extract readable text from '$Url'" `
+        New-ConvertError -ErrorType 'InsufficientReadableText' `
+            -Goal 'Extract readable text from the op-ed source' `
             -Problem ("Source yielded only $ReadableWords readable word(s) " +
                 "(alpha-token ratio $([Math]::Round($ReadableRatio, 2))). " +
                 "Format detected: $Format. The content is not readable prose.") `
-            -Location 'Get-OpEdSource' `
             -NextSteps @(
                 'Install a PDF extraction tool (markitdown, pdftotext, or mutool) for PDF sources',
                 'Confirm the URL points to a document with readable text content',
-                'Pass -VoiceOnly to New-OpEd to skip source grounding and write from camp voice alone'
-            ))
+                'Supply material via -Topic text in New-OpEd instead, or pass -VoiceOnly to skip source grounding'
+            )
     }
 
     # ── Truncate to prompt budget ─────────────────────────────────────────────
@@ -153,7 +199,8 @@ function Get-OpEdSource {
     }
 
     [PSCustomObject]@{
-        Url                  = $Url
+        SourceUrl            = $SourceUrl
+        ContentType          = $ContentType
         SourceMarkdown       = $SourceMarkdown
         SourceFormat         = $Format
         SourceExtractionTool = $ExtractionTool

--- a/scripts/AITriad/Public/New-OpEd.ps1
+++ b/scripts/AITriad/Public/New-OpEd.ps1
@@ -43,9 +43,12 @@ function New-OpEd {
         default 'FromTopic' parameter set; optional alongside -Url to steer the
         angle of a fetched source.
     .PARAMETER Url
-        A web page to use as source material. Fetched and converted to Markdown
-        via Get-OpEdSource (with format detection and readability gate), then
-        handed to the model as factual grounding. Mandatory in 'FromUrl'.
+        A web page to use as source material. Fetched (best-effort, from the CLI)
+        and converted to Markdown via Get-OpEdSourceFromUrl → Get-OpEdSource (with
+        Content-Type dispatch and readability gate), then handed to the model as
+        factual grounding. Mandatory in 'FromUrl'. NOTE: the CLI fetch is WAF-limited
+        (some Akamai .gov/news PDFs will 403 the PowerShell client); the Electron
+        op-ed path fetches via Node instead. Migrates to a Node fetch-CLI under t/3312.
     .PARAMETER SourcePrep
         A pre-built SourcePrep object from Get-OpEdSource. Use this in the
         multi-POV orchestrated path so the fetch/convert/gate work happens once
@@ -260,14 +263,19 @@ function New-OpEd {
         $Prep = $SourcePrep
     } elseif ($PSCmdlet.ParameterSetName -eq 'FromUrl') {
         Write-Verbose "Fetching + converting source material from $Url"
-        $Prep = Get-OpEdSource -Url $Url -Verbose:($VerbosePreference -ne 'SilentlyContinue')
+        # Get-OpEdSource is convert-only (t/3307); the CLI's best-effort fetch lives in
+        # Get-OpEdSourceFromUrl (WAF-limited interim, migrates to the Node fetch-CLI under t/3312).
+        # The Electron op-ed path never uses this — it fetches via Node and calls the convert-only shim.
+        $Prep = Get-OpEdSourceFromUrl -Url $Url -Verbose:($VerbosePreference -ne 'SilentlyContinue')
     }
 
     $SourceMaterial = '(no external source supplied — argue from the topic and general knowledge)'
     if ($null -ne $Prep) {
         $SourceMaterial = [string]$Prep.SourceMarkdown
         if (-not $PSBoundParameters.ContainsKey('Topic') -or [string]::IsNullOrWhiteSpace($Topic)) {
-            $Topic = "Write an op-ed responding to the source material below (from $($Prep.Url)). Choose the sharpest angle consistent with your camp's convictions."
+            # Prep provenance is SourceUrl (convert-only rename, t/3307); guard for older prep objects.
+            $SrcRef = if ($Prep.PSObject.Properties.Name -contains 'SourceUrl') { [string]$Prep.SourceUrl } else { '' }
+            $Topic = "Write an op-ed responding to the source material below (from $SrcRef). Choose the sharpest angle consistent with your camp's convictions."
         }
     }
 

--- a/taxonomy-editor/src/main/ps/invoke-get-oped-source.ps1
+++ b/taxonomy-editor/src/main/ps/invoke-get-oped-source.ps1
@@ -1,43 +1,88 @@
 #Requires -Version 7
-# Stage-A shim: fetch + convert + readability gate for one URL.
-# Called once per create-oped-set; SourcePrep is threaded into each voice spawn.
-# Reads JSON stdin: { "Url": "<url>" }
-# Writes JSON lines to stdout:
-#   {"type":"result","data":{...SourcePrep fields...}}
-# Throws (exit 1) if Get-OpEdSource's readability gate trips or any error occurs.
+# Stage-A shim: CONVERT-ONLY (t/3306/t/3307). The bytes are fetched by Node (fetchUrlForPromptBinary,
+# bypassing the PS/WAF fingerprint 403) and written to a temp file; this shim converts + readability-
+# gates that pre-fetched file. Called once per create-oped-set; SourcePrep threads into each voice spawn.
+#
+# Reads JSON stdin: { "ContentPath": "<temp-file>", "ContentType": "<mime>", "SourceUrl": "<url?>" }
+#   (ContentType is authoritative for dispatch; the temp-file extension is advisory. SourceUrl optional.)
+# stdout success (unchanged transport, t/2928):
+#   {"type":"result","data":{...SourcePrep..., SourceMarkdown/Excerpt base64-encoded, "_b64Fields":[...]}}
+# stderr failure: a single JSON line { "ErrorType","Goal","Problem","NextSteps" } as the LAST stderr
+#   line, then exit 1 — so opedHandlers threads the real cause instead of a generic exit-code-1 (t/3306).
+#
+# File owned by ElectronMain (taxonomy-editor/src/main/ps); the PS serialization block is authored by
+# PowerShell for contract coherence (it serializes a PS ActionableError + the t/2928 base64), and the
+# EXACT field names on both sides are guarded by the shared round-trip test OpEdShimTransport.Tests.ps1.
 param()
 $ErrorActionPreference = 'Stop'
 
-$raw = [Console]::In.ReadToEnd()
-$p   = $raw | ConvertFrom-Json
+try {
+    $raw = [Console]::In.ReadToEnd()
+    $p   = $raw | ConvertFrom-Json
 
-$repoRoot = $PSScriptRoot
-for ($i = 0; $i -lt 4; $i++) { $repoRoot = Split-Path -Parent $repoRoot }
-$modulePath = Join-Path $repoRoot 'scripts' 'AITriad' 'AITriad.psd1'
-Import-Module $modulePath -Force -ErrorAction Stop
+    $repoRoot = $PSScriptRoot
+    for ($i = 0; $i -lt 4; $i++) { $repoRoot = Split-Path -Parent $repoRoot }
+    $modulePath = Join-Path $repoRoot 'scripts' 'AITriad' 'AITriad.psd1'
+    Import-Module $modulePath -Force -ErrorAction Stop
 
-$prep = Get-OpEdSource -Url ([string]$p.Url)
+    # Contract: { ContentPath, ContentType, SourceUrl? }. SourceUrl is optional/informational —
+    # the handler does not send it today, so guard its access under Set-StrictMode.
+    $sourceUrl = if ($p.PSObject.Properties['SourceUrl']) { [string]$p.SourceUrl } else { '' }
+    $prep = Get-OpEdSource -ContentPath ([string]$p.ContentPath) -ContentType ([string]$p.ContentType) -SourceUrl $sourceUrl
 
-# Base64-encode the fetched arbitrary-web-content fields BEFORE ConvertTo-Json, so it only ever
-# serializes safe ASCII for them. PS ConvertTo-Json emits INVALID JSON for some real article HTML
-# (a bare unescaped `"` inside the value), which the handler then can't parse (t/2928). The handler
-# base64-decodes anything listed in `_b64Fields`.
-#
-# ANY future $prep field carrying fetched / arbitrary web content MUST be added to this list.
-# (Today only SourceMarkdown + Excerpt are content; SourceBrief is $null here — the New-OpEd
-# comprehension pass fills it downstream, not this shim.) Backstop if one is ever missed:
-# opedHandlers surfaces a LOUD ActionableError (parseShimLine), never a silent drop — so the worst
-# case is a diagnosable failure, not a recurrence of this once-invisible bug.
-$b64Fields = @()
-foreach ($f in @('SourceMarkdown', 'Excerpt')) {
-    $val = $prep.$f
-    if ($val -is [string] -and $val.Length -gt 0) {
-        $prep.$f = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($val))
-        $b64Fields += $f
+    # Base64-encode the fetched arbitrary-web-content fields BEFORE ConvertTo-Json, so it only ever
+    # serializes safe ASCII for them. PS ConvertTo-Json emits INVALID JSON for some real article HTML
+    # (a bare unescaped `"` inside the value), which the handler then can't parse (t/2928). The handler
+    # base64-decodes anything listed in `_b64Fields`.
+    #
+    # ANY future $prep field carrying fetched / arbitrary web content MUST be added to this list.
+    # (Today only SourceMarkdown + Excerpt are content; SourceBrief is $null here — the New-OpEd
+    # comprehension pass fills it downstream, not this shim.) Backstop if one is ever missed:
+    # opedHandlers surfaces a LOUD ActionableError (parseShimLine), never a silent drop — so the worst
+    # case is a diagnosable failure, not a recurrence of this once-invisible bug.
+    $b64Fields = @()
+    foreach ($f in @('SourceMarkdown', 'Excerpt')) {
+        $val = $prep.$f
+        if ($val -is [string] -and $val.Length -gt 0) {
+            $prep.$f = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($val))
+            $b64Fields += $f
+        }
     }
-}
-$prep | Add-Member -NotePropertyName '_b64Fields' -NotePropertyValue $b64Fields -Force
+    $prep | Add-Member -NotePropertyName '_b64Fields' -NotePropertyValue $b64Fields -Force
 
-$resultLine = [ordered]@{ type = 'result'; data = $prep } | ConvertTo-Json -Depth 10 -Compress
-[Console]::Out.WriteLine($resultLine)
-[Console]::Out.Flush()
+    $resultLine = [ordered]@{ type = 'result'; data = $prep } | ConvertTo-Json -Depth 10 -Compress
+    [Console]::Out.WriteLine($resultLine)
+    [Console]::Out.Flush()
+}
+catch {
+    # Serialize the structured failure as the LAST stderr line, then exit 1. Get-OpEdSource attaches a
+    # { ErrorType, Goal, Problem, NextSteps } payload to the ErrorRecord's TargetObject; any other
+    # failure (bad stdin, module import) is synthesized so the handler still gets structure, never a
+    # bare exit code. Writing our JSON last + exit (not re-throw) keeps PS's own error rendering from
+    # trailing after it — the handler reads the final stderr line.
+    $err = $_
+    $payload = $err.TargetObject
+    if ($null -ne $payload -and
+        ($payload.PSObject.Properties.Name -contains 'ErrorType') -and
+        ($payload.PSObject.Properties.Name -contains 'Problem')) {
+        $out = [ordered]@{
+            ErrorType = [string]$payload.ErrorType
+            Goal      = [string]$payload.Goal
+            Problem   = [string]$payload.Problem
+            NextSteps = [string[]]@($payload.NextSteps)
+        }
+    } else {
+        $out = [ordered]@{
+            ErrorType = 'ConvertShimFailure'
+            Goal      = 'Convert op-ed source'
+            Problem   = [string]$err.Exception.Message
+            NextSteps = [string[]]@(
+                'Check the Get-OpEdSource stderr output',
+                'Confirm the ContentPath temp file exists and the ContentType is a PDF, DOCX, or HTML/text type'
+            )
+        }
+    }
+    [Console]::Error.WriteLine(($out | ConvertTo-Json -Depth 5 -Compress))
+    [Console]::Error.Flush()
+    exit 1
+}

--- a/tests/Get-OpEdSource.Tests.ps1
+++ b/tests/Get-OpEdSource.Tests.ps1
@@ -1,4 +1,4 @@
-# Tag: oped (t/2586)
+# Tag: oped (t/2586, t/3307)
 # Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 # Licensed under the MIT License. See LICENSE file in the project root.
 
@@ -6,11 +6,14 @@
 
 <#
 .SYNOPSIS
-    Unit tests for Get-OpEdSource (t/2586).
+    Unit tests for Get-OpEdSource — convert-only (t/3307).
 .DESCRIPTION
-    Mocks Invoke-WebRequest and the DocConverter cmdlets to verify format
-    detection, readability gate, truncation, and output shape without network
-    access or binary tools.
+    Get-OpEdSource no longer fetches; it converts pre-fetched content from a temp file, dispatching
+    on the authoritative Content-Type (NOT the extension). These tests mock the DocConverter cmdlets
+    and write real temp files to verify Content-Type dispatch, the enumerated failure ErrorTypes
+    (ContentPathMissing / UnsupportedContentType / ConversionFailed / InsufficientReadableText carried
+    on the thrown ErrorRecord's TargetObject), the readability gate, truncation, and output shape —
+    without network access or binary tools.
 #>
 
 BeforeAll {
@@ -33,26 +36,31 @@ BeforeAll {
         'impact assessment reporting accountability frameworks enforcement ' +
         'mechanisms remediation pathways and meaningful public participation. '
     ) * 2  # repeat to ensure well above 100 words
+
+    # Create a real temp file with the given bytes/text and return its path (dispatch is on
+    # ContentType, so the extension here is deliberately arbitrary).
+    function New-ContentFile {
+        param([string]$Text = 'placeholder', [string]$Extension = '.tmp')
+        $Path = [System.IO.Path]::GetTempFileName() + $Extension
+        [System.IO.File]::WriteAllText($Path, $Text)
+        return $Path
+    }
 }
 
-Describe 'Get-OpEdSource' -Tag 'oped' {
+Describe 'Get-OpEdSource (convert-only)' -Tag 'oped' {
 
-    Context 'HTML source (default)' {
+    Context 'HTML source' {
         BeforeEach {
-            Mock Invoke-WebRequest -ModuleName AITriad {
-                [PSCustomObject]@{
-                    Content    = "<html><body><p>$($script:ReadableText)</p></body></html>"
-                    Headers    = @{ 'Content-Type' = 'text/html; charset=utf-8' }
-                    StatusCode = 200
-                }
-            }
+            $script:HtmlFile = New-ContentFile -Text '<html><body><p>hi</p></body></html>' -Extension '.html'
             Mock ConvertFrom-Html -ModuleName AITriad { $script:ReadableText }
         }
+        AfterEach { Remove-Item -LiteralPath $script:HtmlFile -Force -ErrorAction SilentlyContinue }
 
-        It 'Returns a prep object with required fields' {
-            $Prep = Get-OpEdSource -Url 'https://example.com/article.html'
-            $Prep | Should -Not -BeNullOrEmpty
-            $Prep.Url                  | Should -Be 'https://example.com/article.html'
+        It 'Returns a prep object with the convert-only fields' {
+            $Prep = Get-OpEdSource -ContentPath $script:HtmlFile -ContentType 'text/html; charset=utf-8' -SourceUrl 'https://example.com/article'
+            $Prep                      | Should -Not -BeNullOrEmpty
+            $Prep.SourceUrl            | Should -Be 'https://example.com/article'
+            $Prep.ContentType          | Should -Be 'text/html; charset=utf-8'
             $Prep.SourceMarkdown       | Should -Not -BeNullOrEmpty
             $Prep.SourceFormat         | Should -Be 'html'
             $Prep.SourceExtractionTool | Should -Be 'ConvertFrom-Html'
@@ -67,180 +75,136 @@ Describe 'Get-OpEdSource' -Tag 'oped' {
             $Prep.SourceBrief          | Should -BeNullOrEmpty
         }
 
-        It 'ContentHash is deterministic for the same content' {
-            $P1 = Get-OpEdSource -Url 'https://example.com/a.html'
-            $P2 = Get-OpEdSource -Url 'https://example.com/a.html'
+        It 'Does NOT expose a Url property (renamed to SourceUrl in convert-only)' {
+            $Prep = Get-OpEdSource -ContentPath $script:HtmlFile -ContentType 'text/html'
+            $Prep.PSObject.Properties.Name | Should -Not -Contain 'Url'
+            $Prep.PSObject.Properties.Name | Should -Contain 'SourceUrl'
+        }
+
+        It 'ContentHash is deterministic for the same converted text' {
+            $P1 = Get-OpEdSource -ContentPath $script:HtmlFile -ContentType 'text/html'
+            $P2 = Get-OpEdSource -ContentPath $script:HtmlFile -ContentType 'text/html'
             $P1.ContentHash | Should -Be $P2.ContentHash
         }
-
-        It 'FetchedAt is a valid ISO 8601 timestamp' {
-            $Prep = Get-OpEdSource -Url 'https://example.com/article.html'
-            { [System.DateTime]::Parse($Prep.FetchedAt) } | Should -Not -Throw
-        }
     }
 
-    Context 'PDF source — content-type detection' {
-        BeforeEach {
-            Mock Invoke-WebRequest -ModuleName AITriad {
-                [PSCustomObject]@{
-                    Content    = [byte[]]@(0x25, 0x50, 0x44, 0x46)
-                    Headers    = @{ 'Content-Type' = 'application/pdf' }
-                    StatusCode = 200
-                }
-            }
-            $script:PdfConvCalled = $false
-            Mock Invoke-PdfConversion -ModuleName AITriad { $script:PdfConvCalled = $true; $script:ReadableText }
-        }
-
-        It 'Routes to ConvertFrom-Pdf when Content-Type is application/pdf' {
-            $Prep = Get-OpEdSource -Url 'https://example.com/report'
-            $Prep.SourceFormat         | Should -Be 'pdf'
-            $Prep.SourceExtractionTool | Should -Be 'ConvertFrom-Pdf'
-            $script:PdfConvCalled      | Should -BeTrue -Because 'Invoke-PdfConversion must be called for PDF routing'
-        }
-    }
-
-    Context 'PDF source — URL extension detection' {
-        BeforeEach {
-            Mock Invoke-WebRequest -ModuleName AITriad {
-                [PSCustomObject]@{
-                    Content    = [byte[]]@(0x25, 0x50, 0x44, 0x46)
-                    Headers    = @{ 'Content-Type' = 'application/octet-stream' }
-                    StatusCode = 200
-                }
-            }
-            $script:PdfConvCalled = $false
-            Mock Invoke-PdfConversion -ModuleName AITriad { $script:PdfConvCalled = $true; $script:ReadableText }
-        }
-
-        It 'Routes to ConvertFrom-Pdf when URL ends in .pdf' {
-            $Prep = Get-OpEdSource -Url 'https://example.com/report.pdf'
-            $Prep.SourceFormat    | Should -Be 'pdf'
-            $script:PdfConvCalled | Should -BeTrue -Because 'Invoke-PdfConversion must be called for .pdf extension routing'
-        }
-    }
-
-    Context 'DOCX source — URL extension detection' {
-        BeforeEach {
-            Mock Invoke-WebRequest -ModuleName AITriad {
-                [PSCustomObject]@{
-                    Content    = [byte[]]@(0x50, 0x4B, 0x03, 0x04)
-                    Headers    = @{ 'Content-Type' = 'application/octet-stream' }
-                    StatusCode = 200
-                }
-            }
-            $script:DocxConvCalled = $false
-            Mock Invoke-DocxConversion -ModuleName AITriad { $script:DocxConvCalled = $true; $script:ReadableText }
-        }
-
-        It 'Routes to ConvertFrom-Docx when URL ends in .docx' {
-            $Prep = Get-OpEdSource -Url 'https://example.com/brief.docx'
-            $Prep.SourceFormat          | Should -Be 'docx'
-            $Prep.SourceExtractionTool  | Should -Be 'ConvertFrom-Docx'
-            $script:DocxConvCalled      | Should -BeTrue -Because 'Invoke-DocxConversion must be called for .docx extension routing'
-        }
-    }
-
-    Context 'Readability gate — PDF bytes through HTML converter (the 2/10 incident)' {
-        BeforeEach {
-            Mock Invoke-WebRequest -ModuleName AITriad {
-                [PSCustomObject]@{
-                    Content    = [byte[]]@(0x25, 0x50, 0x44, 0x46)
-                    Headers    = @{ 'Content-Type' = 'text/html' }  # wrong Content-Type
-                    StatusCode = 200
-                }
-            }
-            # Simulate what ConvertFrom-Html actually returns for PDF bytes:
-            # space-separated decimal byte values — zero alpha tokens.
-            Mock ConvertFrom-Html -ModuleName AITriad {
-                '37 80 68 70 45 49 46 48 10 37 226 227 207 211'
-            }
-        }
-
-        It 'Throws ActionableError when extracted text has no readable words' {
-            { Get-OpEdSource -Url 'https://example.com/report.pdf' } | Should -Throw
-        }
-
-        It 'Error message names the format and readable word count' {
+    Context 'Content-Type dispatch is authoritative (not the file extension)' {
+        It 'Routes to ConvertFrom-Pdf when ContentType is application/pdf even if the temp file is named .html' {
+            $File = New-ContentFile -Text 'ignored' -Extension '.html'   # deliberately mis-named
             try {
-                Get-OpEdSource -Url 'https://example.com/report.pdf'
-            } catch {
-                $_.Exception.Message | Should -Match 'readable word'
-            }
+                $called = $false
+                Mock Invoke-PdfConversion -ModuleName AITriad { $script:PdfCalled = $true; $script:ReadableText }
+                $script:PdfCalled = $false
+                $Prep = Get-OpEdSource -ContentPath $File -ContentType 'application/pdf'
+                $Prep.SourceFormat         | Should -Be 'pdf'
+                $Prep.SourceExtractionTool | Should -Be 'ConvertFrom-Pdf'
+                $script:PdfCalled          | Should -BeTrue -Because 'ContentType application/pdf must dispatch to the PDF converter regardless of the .html temp name'
+            } finally { Remove-Item -LiteralPath $File -Force -ErrorAction SilentlyContinue }
+        }
+
+        It 'Routes to ConvertFrom-Docx when ContentType is wordprocessingml even if the temp file is named .pdf' {
+            $File = New-ContentFile -Text 'ignored' -Extension '.pdf'    # deliberately mis-named
+            try {
+                Mock Invoke-DocxConversion -ModuleName AITriad { $script:DocxCalled = $true; $script:ReadableText }
+                $script:DocxCalled = $false
+                $Prep = Get-OpEdSource -ContentPath $File -ContentType 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+                $Prep.SourceFormat         | Should -Be 'docx'
+                $Prep.SourceExtractionTool | Should -Be 'ConvertFrom-Docx'
+                $script:DocxCalled         | Should -BeTrue
+            } finally { Remove-Item -LiteralPath $File -Force -ErrorAction SilentlyContinue }
         }
     }
 
-    Context 'Readability gate — MinReadableWords threshold' {
+    Context 'Failure: ContentPathMissing' {
+        It 'Throws with ErrorType ContentPathMissing on a non-existent ContentPath' {
+            $Missing = Join-Path ([System.IO.Path]::GetTempPath()) ('nope-' + [guid]::NewGuid() + '.pdf')
+            $err = $null
+            try { Get-OpEdSource -ContentPath $Missing -ContentType 'application/pdf' } catch { $err = $_ }
+            $err                        | Should -Not -BeNullOrEmpty
+            $err.TargetObject.ErrorType | Should -Be 'ContentPathMissing'
+            $err.TargetObject.Problem   | Should -Match 'not found or is not readable'
+        }
+    }
+
+    Context 'Failure: UnsupportedContentType' {
+        It 'Throws with ErrorType UnsupportedContentType for a non-document Content-Type' {
+            $File = New-ContentFile -Extension '.bin'
+            try {
+                $err = $null
+                try { Get-OpEdSource -ContentPath $File -ContentType 'image/png' } catch { $err = $_ }
+                $err                        | Should -Not -BeNullOrEmpty
+                $err.TargetObject.ErrorType | Should -Be 'UnsupportedContentType'
+            } finally { Remove-Item -LiteralPath $File -Force -ErrorAction SilentlyContinue }
+        }
+    }
+
+    Context 'Failure: ConversionFailed' {
+        It 'Throws with ErrorType ConversionFailed when the converter throws' {
+            $File = New-ContentFile -Extension '.pdf'
+            try {
+                Mock Invoke-PdfConversion -ModuleName AITriad { throw 'pdftotext not found' }
+                $err = $null
+                try { Get-OpEdSource -ContentPath $File -ContentType 'application/pdf' } catch { $err = $_ }
+                $err                        | Should -Not -BeNullOrEmpty
+                $err.TargetObject.ErrorType | Should -Be 'ConversionFailed'
+            } finally { Remove-Item -LiteralPath $File -Force -ErrorAction SilentlyContinue }
+        }
+    }
+
+    Context 'Failure: InsufficientReadableText (readability gate)' {
         BeforeEach {
-            Mock Invoke-WebRequest -ModuleName AITriad {
-                [PSCustomObject]@{
-                    Content    = '<p>ok</p>'
-                    Headers    = @{ 'Content-Type' = 'text/html' }
-                    StatusCode = 200
-                }
-            }
-            # Returns 3 readable words — below the default threshold of 100
-            Mock ConvertFrom-Html -ModuleName AITriad { 'Artificial intelligence policy' }
+            $script:StubFile = New-ContentFile -Extension '.html'
+            # Simulate PDF-bytes-through-HTML: space-separated decimal byte values — zero alpha tokens.
+            Mock ConvertFrom-Html -ModuleName AITriad { '37 80 68 70 45 49 46 48 10 37 226 227 207 211' }
         }
+        AfterEach { Remove-Item -LiteralPath $script:StubFile -Force -ErrorAction SilentlyContinue }
 
-        It 'Throws when readable word count is below MinReadableWords' {
-            { Get-OpEdSource -Url 'https://example.com/stub.html' } | Should -Throw
-        }
-
-        It 'Passes when MinReadableWords is lowered to match' {
-            $Prep = Get-OpEdSource -Url 'https://example.com/stub.html' -MinReadableWords 2
-            $Prep.ReadableWords | Should -BeGreaterOrEqual 2
+        It 'Throws with ErrorType InsufficientReadableText and keeps the -Topic-text next-step' {
+            $err = $null
+            try { Get-OpEdSource -ContentPath $script:StubFile -ContentType 'text/html' } catch { $err = $_ }
+            $err                          | Should -Not -BeNullOrEmpty
+            $err.TargetObject.ErrorType   | Should -Be 'InsufficientReadableText'
+            $err.Exception.Message        | Should -Match 'readable word'
+            ($err.TargetObject.NextSteps -join ' ') | Should -Match '-Topic text'
         }
     }
 
     Context 'Truncation' {
         BeforeEach {
-            # Build text well over 2000 chars with enough readable words
+            $script:LongFile = New-ContentFile -Extension '.html'
             $script:LongText = $script:ReadableText * 10
-            Mock Invoke-WebRequest -ModuleName AITriad {
-                [PSCustomObject]@{
-                    Content    = "<p>$($script:LongText)</p>"
-                    Headers    = @{ 'Content-Type' = 'text/html' }
-                    StatusCode = 200
-                }
-            }
             Mock ConvertFrom-Html -ModuleName AITriad { $script:LongText }
         }
+        AfterEach { Remove-Item -LiteralPath $script:LongFile -Force -ErrorAction SilentlyContinue }
 
         It 'Truncates SourceMarkdown to MaxChars and sets Truncated=true' {
-            $Prep = Get-OpEdSource -Url 'https://example.com/long.html' -MaxChars 1000
-            $Prep.Truncated         | Should -Be $true
-            $Prep.CharsUsed         | Should -Be 1000
-            $Prep.SourceMarkdown.Length | Should -BeLessOrEqual 1030  # 1000 + truncation notice
-            $Prep.CharsTotal        | Should -BeGreaterThan 1000
+            $Prep = Get-OpEdSource -ContentPath $script:LongFile -ContentType 'text/html' -MaxChars 1000
+            $Prep.Truncated             | Should -Be $true
+            $Prep.CharsUsed             | Should -Be 1000
+            $Prep.SourceMarkdown.Length | Should -BeLessOrEqual 1030   # 1000 + truncation notice
+            $Prep.CharsTotal            | Should -BeGreaterThan 1000
         }
 
         It 'ContentHash reflects the full untruncated text regardless of MaxChars' {
-            $Prep1 = Get-OpEdSource -Url 'https://example.com/long.html' -MaxChars 1000
-            $Prep2 = Get-OpEdSource -Url 'https://example.com/long.html' -MaxChars 2000
-            $Prep1.ContentHash | Should -Be $Prep2.ContentHash
-        }
-    }
-
-    Context 'Network failure' {
-        BeforeEach {
-            Mock Invoke-WebRequest -ModuleName AITriad {
-                throw [System.Net.WebException]::new('Connection refused')
-            }
-        }
-
-        It 'Throws ActionableError when the URL is unreachable' {
-            { Get-OpEdSource -Url 'https://unreachable.example.com/' } | Should -Throw
+            $P1 = Get-OpEdSource -ContentPath $script:LongFile -ContentType 'text/html' -MaxChars 1000
+            $P2 = Get-OpEdSource -ContentPath $script:LongFile -ContentType 'text/html' -MaxChars 2000
+            $P1.ContentHash | Should -Be $P2.ContentHash
         }
     }
 
     Context 'Parameter validation' {
-        It 'Rejects empty Url' {
-            { Get-OpEdSource -Url '' } | Should -Throw
+        It 'Rejects empty ContentPath' {
+            { Get-OpEdSource -ContentPath '' -ContentType 'text/html' } | Should -Throw
         }
-
+        It 'Rejects empty ContentType' {
+            $File = New-ContentFile
+            try { { Get-OpEdSource -ContentPath $File -ContentType '' } | Should -Throw }
+            finally { Remove-Item -LiteralPath $File -Force -ErrorAction SilentlyContinue }
+        }
         It 'Rejects MaxChars below minimum (1000)' {
-            { Get-OpEdSource -Url 'https://example.com/' -MaxChars 999 } | Should -Throw
+            $File = New-ContentFile
+            try { { Get-OpEdSource -ContentPath $File -ContentType 'text/html' -MaxChars 999 } | Should -Throw }
+            finally { Remove-Item -LiteralPath $File -Force -ErrorAction SilentlyContinue }
         }
     }
 }

--- a/tests/New-ActionableError.ErrorType.Tests.ps1
+++ b/tests/New-ActionableError.ErrorType.Tests.ps1
@@ -1,0 +1,52 @@
+# Tag: error-handling (t/3307)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Coverage for the additive, optional -ErrorType parameter on New-ActionableError (t/3307).
+.DESCRIPTION
+    -ErrorType renders a `Type:` line ONLY when supplied, so the rendered message is byte-identical
+    for the 40+ existing callers that don't pass it. New-ActionableError is private (dot-sourced),
+    so it is exercised via InModuleScope.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'New-ActionableError -ErrorType (additive)' -Tag 'error-handling' {
+
+    It 'renders a Type: line when -ErrorType is supplied' {
+        InModuleScope AITriad {
+            $msg = New-ActionableError -PassThru -ErrorType 'InsufficientReadableText' `
+                -Goal 'g' -Problem 'p' -Location 'loc' -NextSteps @('do x')
+            $msg | Should -Match 'Type:\s+InsufficientReadableText'
+            # Ordering: Type sits between the Error and Location labels.
+            $msg | Should -Match '(?s)Error:.*Type:.*Location:'
+        }
+    }
+
+    It 'is byte-identical to the pre-existing render when -ErrorType is omitted (zero change for existing callers)' {
+        InModuleScope AITriad {
+            $msg = New-ActionableError -PassThru `
+                -Goal 'g' -Problem 'p' -Location 'loc' -NextSteps @('do x', 'do y')
+            $msg | Should -Not -Match 'Type:'
+            # Normalize line endings — CRLF vs LF is a file-encoding artifact, not a behavior change.
+            $norm = $msg -replace "`r`n", "`n"
+            $expected = "`n  Goal:     g`n  Error:    p`n  Location: loc`n  Resolve:`n   1. do x`n   2. do y"
+            $norm | Should -BeExactly $expected
+        }
+    }
+
+    It 'omits the Type: line when -ErrorType is the empty string' {
+        InModuleScope AITriad {
+            $msg = New-ActionableError -PassThru -ErrorType '' `
+                -Goal 'g' -Problem 'p' -Location 'loc' -NextSteps @('do x')
+            $msg | Should -Not -Match 'Type:'
+        }
+    }
+}

--- a/tests/OpEdShimTransport.Tests.ps1
+++ b/tests/OpEdShimTransport.Tests.ps1
@@ -63,4 +63,73 @@ Describe 'invoke-get-oped-source shim — base64 content transport (t/2928)' {
         $parsed = $script:Json | ConvertFrom-Json
         $parsed.data.ReadableWords | Should -Be 640
     }
+
+    It 'success line carries the locked SourceMarkdown field name under data (contract t/3306#4)' {
+        $parsed = $script:Json | ConvertFrom-Json
+        $parsed.type | Should -Be 'result'
+        $parsed.data.PSObject.Properties.Name | Should -Contain 'SourceMarkdown'
+    }
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Convert-only failure-transport round-trip (t/3306/t/3307).
+#
+# The producer/consumer split (PowerShell authors the shim serialization; ElectronMain owns the
+# opedHandlers parse) is only safe if the field names match EXACTLY. The locked failure contract
+# (t/3306#4) is: PS emits `{ ErrorType, Goal, Problem, NextSteps }` as the LAST stderr line + exit 1;
+# opedHandlers JSON.parses that last line and reads Problem (string) / Goal / NextSteps (array).
+# These tests fail if either side renames a field.
+# ─────────────────────────────────────────────────────────────────────────────
+Describe 'invoke-get-oped-source shim — structured failure transport round-trip (t/3307)' {
+    BeforeAll {
+        $script:RepoRoot = Split-Path -Parent $PSScriptRoot
+        $script:ShimPath = Join-Path $script:RepoRoot 'taxonomy-editor' 'src' 'main' 'ps' 'invoke-get-oped-source.ps1'
+    }
+
+    It 'end-to-end: emits the exact failure field names as the last stderr line and exits 1' {
+        # ContentPathMissing needs no converter — exercises the real Get-OpEdSource structured throw
+        # → real shim serialization → real field names (the definitive rename guard, both sides).
+        $missing = Join-Path ([System.IO.Path]::GetTempPath()) ('nope-' + [guid]::NewGuid() + '.pdf')
+        $stdin = [ordered]@{ ContentPath = $missing; ContentType = 'application/pdf' } | ConvertTo-Json -Compress
+        $errFile = [System.IO.Path]::GetTempFileName()
+        try {
+            $stdin | pwsh -NoProfile -NonInteractive -File $script:ShimPath 2>$errFile | Out-Null
+            $code = $LASTEXITCODE
+            $stderr = Get-Content -LiteralPath $errFile -Raw
+
+            $code | Should -Be 1 -Because 'a convert failure must exit non-zero'
+            $lines = @($stderr -split "`r?`n" | Where-Object { $_.Trim() -ne '' })
+            $lines.Count | Should -BeGreaterThan 0 -Because 'the shim must write a structured failure line to stderr'
+            $lastLine = $lines[-1].Trim()
+
+            $parsed = $lastLine | ConvertFrom-Json   # must be valid JSON (opedHandlers JSON.parses it)
+            $names = $parsed.PSObject.Properties.Name
+            $names | Should -Contain 'ErrorType'
+            $names | Should -Contain 'Goal'
+            $names | Should -Contain 'Problem'
+            $names | Should -Contain 'NextSteps'
+            $parsed.ErrorType | Should -Be 'ContentPathMissing'
+            $parsed.Problem   | Should -BeOfType [string]
+            $parsed.NextSteps -is [array] | Should -BeTrue -Because 'opedHandlers does Array.isArray(parsed.NextSteps)'
+        } finally {
+            Remove-Item -LiteralPath $errFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'serializes NextSteps as a JSON array even with a single element (Array.isArray guard)' {
+        # Mirror the shim catch serialization on a single-element NextSteps — the classic PS
+        # single-element-array-collapses-to-scalar gotcha would silently break opedHandlers' array read.
+        $payload = [PSCustomObject]@{ ErrorType = 'X'; Goal = 'g'; Problem = 'p'; NextSteps = [string[]]@('only one') }
+        $out = [ordered]@{
+            ErrorType = [string]$payload.ErrorType
+            Goal      = [string]$payload.Goal
+            Problem   = [string]$payload.Problem
+            NextSteps = [string[]]@($payload.NextSteps)
+        }
+        $json = $out | ConvertTo-Json -Depth 5 -Compress
+        $json | Should -Match '"NextSteps":\['
+        $reparsed = $json | ConvertFrom-Json
+        @($reparsed.NextSteps).Count | Should -Be 1
+        $reparsed.NextSteps -is [array] | Should -BeTrue
+    }
 }


### PR DESCRIPTION
## What

Makes `Get-OpEdSource` **convert-only** and routes op-ed Stage-A fetching out of PowerShell — the WAF-fingerprint 403 root cause (senate.gov/Akamai blocks the PS `Invoke-WebRequest` client fingerprint while Node's undici passes). Implements the PowerShell side of the LOCKED cross-role contract (t/3306#4) per the TL ruling (t/3307#3).

**Co-merges with ElectronMain #1940** (`t3306-oped-node-fetch`) — the two halves of the same interface. This PR is **draft** until ElectronMain reviews the shim serialization and the TL confirms the round-trip alignment at the joint gate verification.

## Changes

- **`Get-OpEdSource`** — drop `Invoke-WebRequest`; params `-ContentPath` / `-ContentType` / `-SourceUrl?`; **dispatch on Content-Type (authoritative, not the temp-file extension)**; enumerated failure `ErrorType`s (`ContentPathMissing` / `UnsupportedContentType` / `ConversionFailed` / `InsufficientReadableText`) carried as a structured `{ErrorType,Goal,Problem,NextSteps}` payload on the thrown `ErrorRecord`'s `TargetObject`; return object renames `Url`→`SourceUrl` + adds `ContentType`.
- **`New-ActionableError`** — optional, additive `-ErrorType` (renders a `Type:` line only when set → byte-identical output for the 40+ existing callers).
- **`Get-OpEdSourceFromUrl`** (new, `Private/`) — best-effort PS fetch→temp→convert so the `New-OpEd -Url` CLI keeps working; WAF-limited interim, localizes the one remaining PS external fetch as a **t/3312** class-member.
- **`New-OpEd`** — FromUrl path uses the helper; `$Prep.Url`→guarded `$Prep.SourceUrl`.
- **`invoke-get-oped-source.ps1`** (ElectronMain-owned; PS serialization authored here, ElectronMain reviews + owns the parse side) — new stdin `{ContentPath,ContentType,SourceUrl?}`, preserves the t/2928 base64/`_b64Fields` success transport, emits the structured failure JSON as the **last** stderr line + `exit 1`.

## Locked wire contract (t/3306#4) — matched verbatim against #1940

- stdin: `{ContentPath, ContentType}` (SourceUrl optional/informational — handler doesn't send it)
- success: `{type:"result", data:{… SourceMarkdown (base64) …}}`
- failure: `{ErrorType, Goal, Problem, NextSteps}` as the last stderr line

## Tests

- Rewrote `Get-OpEdSource.Tests.ps1` for convert-only: Content-Type dispatch (incl. a `.html`-named PDF proving extension is ignored), the four `ErrorType`s, readability gate, truncation. (14)
- Extended `OpEdShimTransport.Tests.ps1` with the **round-trip mismatch guard** — asserts the exact failure field names on emit AND parse, including a real end-to-end shim invocation (`pwsh -File` → structured stderr → parse), plus the single-element `NextSteps`-stays-an-array guard.
- Added `New-ActionableError.ErrorType.Tests.ps1` (render / omit / byte-identical).

Local: op-ed suite + round-trip + ErrorType all green (57). Full `./tests` sweep clean through the ~130 files that ran before the local 10-min cap — every `New-ActionableError` consumer green; the lone failure is the pre-existing live `Invoke-AIApi.Xai` token-count test (needs `XAI_API_KEY`, unrelated). CI runs the complete suite.

Closes t/3307 (co-merge with #1940).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
