### PR TITLE
refactor(oped): restore stranded t/3307 consolidation (Get-OpEdSourceFromUrl + round-trip test)

### DIFF
--- a/scripts/AITriad/Private/Get-OpEdSourceFromUrl.ps1
+++ b/scripts/AITriad/Private/Get-OpEdSourceFromUrl.ps1
@@ -1,0 +1,85 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+#
+# CLI convenience: best-effort PS fetch → temp file → convert-only Get-OpEdSource, so `New-OpEd -Url`
+# keeps working from the command line after Get-OpEdSource became convert-only (t/3307).
+#
+# WAF-limited interim (t/3312): PowerShell's Invoke-WebRequest client fingerprint is blocked by some
+# WAFs (Akamai .gov/news PDFs will 403 it) — the same WAF-fingerprint fetch class the Electron op-ed
+# path already avoids by fetching via Node (fetchUrlForPromptBinary) and calling the convert-only
+# shim. This helper is the ONE remaining PS-side external URL fetch; it migrates to the shared Node
+# fetch-CLI entrypoint when that lands under t/3312. Kept for now so the CLI is not broken. Because it
+# is a t/3312 class-member, it is intentionally localized here (one entry point) rather than inlined
+# into New-OpEd, so the migration and any WAF-fetch prevention guard have a single site to target.
+#
+# Dot-sourced by AITriad.psm1 — do NOT export.
+
+function Get-OpEdSourceFromUrl {
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Url,
+
+        [ValidateRange(1000, 100000)]
+        [int]$MaxChars = 12000,
+
+        [ValidateRange(1, 10000)]
+        [int]$MinReadableWords = 100,
+
+        [ValidateRange(0.0, 1.0)]
+        [double]$MinAlphaDensity = 0.60
+    )
+
+    Set-StrictMode -Version Latest
+
+    try {
+        $Resp = Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 60
+    } catch {
+        throw (New-ActionableError -PassThru `
+            -ErrorType 'FetchFailed' `
+            -Goal 'Fetch source URL for op-ed generation' `
+            -Problem "Could not fetch '$Url': $($_.Exception.Message)" `
+            -Location 'Get-OpEdSourceFromUrl' `
+            -NextSteps @(
+                'Confirm the URL is reachable and publicly accessible',
+                'This CLI fetch is WAF-limited (Akamai .gov/news PDFs may 403 the PowerShell client); use the Electron op-ed path or supply -Topic text in New-OpEd instead'
+            ))
+    }
+
+    # Content-Type is authoritative for the convert step; fall back to the URL extension only when the
+    # server omitted it. Get-OpEdSource dispatches on ContentType, so the temp-file extension is advisory.
+    $ContentType = [string]($Resp.Headers['Content-Type'] ?? '')
+    if ([string]::IsNullOrWhiteSpace($ContentType)) {
+        $UrlExt = [System.IO.Path]::GetExtension(([uri]$Url).LocalPath).ToLowerInvariant()
+        $ContentType = switch ($UrlExt) {
+            '.pdf'  { 'application/pdf' }
+            '.docx' { 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' }
+            default { 'text/html' }
+        }
+    }
+
+    $TempExt = if ($ContentType -match 'pdf') { '.pdf' } elseif ($ContentType -match 'wordprocessingml') { '.docx' } else { '.html' }
+    $TempFile = [System.IO.Path]::GetTempFileName() + $TempExt
+    try {
+        # Persist RAW bytes so binary sources (PDF/DOCX) stay intact. Prefer RawContentStream — for a
+        # binary body $Resp.Content is a decoded string that corrupts the bytes. Property-guarded for
+        # StrictMode + test doubles that lack RawContentStream.
+        $HasRaw = $Resp.PSObject.Properties['RawContentStream'] -and $null -ne $Resp.RawContentStream
+        $Bytes = if ($HasRaw) {
+            $Ms = [System.IO.MemoryStream]::new()
+            try { $Resp.RawContentStream.Position = 0; $Resp.RawContentStream.CopyTo($Ms); $Ms.ToArray() }
+            finally { $Ms.Dispose() }
+        } elseif ($Resp.PSObject.Properties['Content'] -and ($Resp.Content -is [byte[]])) {
+            $Resp.Content
+        } else {
+            [System.Text.Encoding]::UTF8.GetBytes([string]$Resp.Content)
+        }
+        [System.IO.File]::WriteAllBytes($TempFile, $Bytes)
+        Get-OpEdSource -ContentPath $TempFile -ContentType $ContentType -SourceUrl $Url `
+            -MaxChars $MaxChars -MinReadableWords $MinReadableWords -MinAlphaDensity $MinAlphaDensity
+    } finally {
+        Remove-Item -LiteralPath $TempFile -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/scripts/AITriad/Public/New-OpEd.ps1
+++ b/scripts/AITriad/Public/New-OpEd.ps1
@@ -260,48 +260,10 @@ function New-OpEd {
         $Prep = $SourcePrep
     } elseif ($PSCmdlet.ParameterSetName -eq 'FromUrl') {
         Write-Verbose "Fetching + converting source material from $Url"
-        # INTERIM CLI-only fetch (t/3312). Get-OpEdSource is convert-only (t/3307): the desktop/Electron
-        # path fetches via the shared SSRF-guarded Node fetcher, but the standalone CLI has no Node
-        # orchestrator, so it fetches here then hands the bytes to the converter. PowerShell's
-        # Invoke-WebRequest is WAF-fingerprint-blocked (403) on some hosts (Akamai .gov, t/3306) where
-        # the Node fetcher gets 200 — so CLI -Url is BEST-EFFORT until it migrates to the shared Node
-        # fetch-CLI under t/3312 (this cmdlet is on that consumer list).
-        $TempSource = $null
-        try {
-            $Resp = Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 60
-            $CT   = [string]($Resp.Headers['Content-Type'] ?? '')
-            # Persist the RAW bytes so binary sources (PDF/DOCX) stay intact; the converter reads them.
-            # Property-guarded access (StrictMode-safe): a real BasicHtmlWebResponseObject exposes
-            # RawContentStream; test doubles may not.
-            $TempSource = [System.IO.Path]::GetTempFileName()
-            $HasRaw = $Resp.PSObject.Properties['RawContentStream'] -and $null -ne $Resp.RawContentStream
-            $Bytes = if ($HasRaw) {
-                $Ms = [System.IO.MemoryStream]::new()
-                try { $Resp.RawContentStream.Position = 0; $Resp.RawContentStream.CopyTo($Ms); $Ms.ToArray() }
-                finally { $Ms.Dispose() }
-            } elseif ($Resp.PSObject.Properties['Content'] -and ($Resp.Content -is [byte[]])) {
-                $Resp.Content
-            } else {
-                [System.Text.Encoding]::UTF8.GetBytes([string]$Resp.Content)
-            }
-            [System.IO.File]::WriteAllBytes($TempSource, $Bytes)
-            $Prep = Get-OpEdSource -ContentPath $TempSource -ContentType $CT -SourceUrl $Url `
-                -Verbose:($VerbosePreference -ne 'SilentlyContinue')
-        } catch {
-            throw (New-ActionableError -PassThru `
-                -Goal 'Fetch + convert source URL for op-ed generation (CLI path)' `
-                -Problem "Could not fetch '$Url': $($_.Exception.Message)" `
-                -Location 'New-OpEd (FromUrl)' `
-                -NextSteps @(
-                    'This CLI fetch is WAF-limited (t/3312); the desktop app fetches via the hardened Node fetcher',
-                    'Confirm the URL is reachable and publicly accessible',
-                    'Supply material via -Topic text instead'
-                ))
-        } finally {
-            if ($TempSource -and (Test-Path -LiteralPath $TempSource)) {
-                Remove-Item -LiteralPath $TempSource -Force -ErrorAction SilentlyContinue
-            }
-        }
+        # Get-OpEdSource is convert-only (t/3307); the CLI's best-effort fetch lives in the localized
+        # Private helper Get-OpEdSourceFromUrl (WAF-limited interim, migrates to the shared Node
+        # fetch-CLI under t/3312 — one entry point for the migration + any WAF-fetch prevention guard).
+        $Prep = Get-OpEdSourceFromUrl -Url $Url -Verbose:($VerbosePreference -ne 'SilentlyContinue')
     }
 
     $SourceMaterial = '(no external source supplied — argue from the topic and general knowledge)'

--- a/taxonomy-editor/src/main/ps/invoke-get-oped-source.ps1
+++ b/taxonomy-editor/src/main/ps/invoke-get-oped-source.ps1
@@ -55,14 +55,16 @@ catch {
             ErrorType = [string]$to['ErrorType']
             Goal      = [string]$to['Goal']
             Problem   = [string]$to['Problem']
-            NextSteps = @($to['NextSteps'])
+            # [string[]] forces a JSON array even for a single element (PS collapses 1-element arrays to
+            # a scalar) — opedHandlers does Array.isArray(NextSteps).
+            NextSteps = [string[]]@($to['NextSteps'])
         }
     } else {
         $err = [ordered]@{
             ErrorType = 'Unknown'
             Goal      = 'Convert pre-fetched source content for op-ed generation'
             Problem   = [string]$_.Exception.Message
-            NextSteps = @('Verify the stdin payload (ContentPath, ContentType) and that the AITriad module loads')
+            NextSteps = [string[]]@('Verify the stdin payload (ContentPath, ContentType) and that the AITriad module loads')
         }
     }
     [Console]::Error.WriteLine(($err | ConvertTo-Json -Depth 6 -Compress))

--- a/tests/OpEdShimTransport.Tests.ps1
+++ b/tests/OpEdShimTransport.Tests.ps1
@@ -63,56 +63,76 @@ Describe 'invoke-get-oped-source shim — base64 content transport (t/2928)' {
         $parsed = $script:Json | ConvertFrom-Json
         $parsed.data.ReadableWords | Should -Be 640
     }
+
+    It 'success line carries the locked SourceMarkdown field name under data (contract t/3306#4)' {
+        $parsed = $script:Json | ConvertFrom-Json
+        $parsed.type | Should -Be 'result'
+        $parsed.data.PSObject.Properties.Name | Should -Contain 'SourceMarkdown'
+    }
 }
 
-# ── Locked cross-role wire contract (t/3306#4, t/3307) ────────────────────────────────────────────
-# The shim (invoke-get-oped-source.ps1) EMIT side must use the exact field names the TS parse side
-# (opedShimTransport.ts) reads. TL's non-negotiable guard: assert the exact field names on emit here;
-# the TS test (opedShimTransport.test.ts) asserts the same names on parse. Success carries
-# SourceMarkdown; failure carries EXACTLY {ErrorType, Goal, Problem, NextSteps} on stderr.
-Describe 'op-ed shim ↔ handler LOCKED wire contract (t/3307)' {
+# ─────────────────────────────────────────────────────────────────────────────
+# Convert-only failure-transport round-trip (t/3306/t/3307).
+#
+# The producer/consumer split (PowerShell authors the shim serialization; ElectronMain owns the
+# opedHandlers parse) is only safe if the field names match EXACTLY. The locked failure contract
+# (t/3306#4) is: PS emits `{ ErrorType, Goal, Problem, NextSteps }` as the LAST stderr line + exit 1;
+# opedHandlers JSON.parses that last line and reads Problem (string) / Goal / NextSteps (array).
+# These tests fail if either side renames a field.
+# ─────────────────────────────────────────────────────────────────────────────
+Describe 'invoke-get-oped-source shim — structured failure transport round-trip (t/3307)' {
     BeforeAll {
-        $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
-        Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+        $script:RepoRoot = Split-Path -Parent $PSScriptRoot
+        $script:ShimPath = Join-Path $script:RepoRoot 'taxonomy-editor' 'src' 'main' 'ps' 'invoke-get-oped-source.ps1'
     }
 
-    It 'success result carries the SourceMarkdown field name' {
-        $prep = [PSCustomObject]@{ SourceMarkdown = 'body'; Excerpt = 'lead'; SourceFormat = 'html' }
-        $line = [ordered]@{ type = 'result'; data = $prep } | ConvertTo-Json -Depth 10 -Compress
-        $parsed = $line | ConvertFrom-Json
-        $parsed.type                                    | Should -Be 'result'
-        $parsed.data.PSObject.Properties.Name           | Should -Contain 'SourceMarkdown'
+    It 'end-to-end: emits the exact failure field names as the last stderr line and exits 1' {
+        # ContentPathMissing needs no converter — exercises the real Get-OpEdSource structured throw
+        # → real shim serialization → real field names (the definitive rename guard, both sides).
+        $missing = Join-Path ([System.IO.Path]::GetTempPath()) ('nope-' + [guid]::NewGuid() + '.pdf')
+        $stdin = [ordered]@{ ContentPath = $missing; ContentType = 'application/pdf' } | ConvertTo-Json -Compress
+        $errFile = [System.IO.Path]::GetTempFileName()
+        try {
+            $stdin | pwsh -NoProfile -NonInteractive -File $script:ShimPath 2>$errFile | Out-Null
+            $code = $LASTEXITCODE
+            $stderr = Get-Content -LiteralPath $errFile -Raw
+
+            $code | Should -Be 1 -Because 'a convert failure must exit non-zero'
+            $lines = @($stderr -split "`r?`n" | Where-Object { $_.Trim() -ne '' })
+            $lines.Count | Should -BeGreaterThan 0 -Because 'the shim must write a structured failure line to stderr'
+            $lastLine = $lines[-1].Trim()
+
+            $parsed = $lastLine | ConvertFrom-Json   # must be valid JSON (opedHandlers JSON.parses it)
+            $names = $parsed.PSObject.Properties.Name
+            $names | Should -Contain 'ErrorType'
+            $names | Should -Contain 'Goal'
+            $names | Should -Contain 'Problem'
+            $names | Should -Contain 'NextSteps'
+            # Exact-set guard (no extra / renamed fields) — folds in #1947's original assertion so a
+            # NEW field on either side also fails, not just a rename.
+            @($names | Sort-Object) | Should -Be @('ErrorType', 'Goal', 'NextSteps', 'Problem')
+            $parsed.ErrorType | Should -Be 'ContentPathMissing'
+            $parsed.Problem   | Should -BeOfType [string]
+            $parsed.NextSteps -is [array] | Should -BeTrue -Because 'opedHandlers does Array.isArray(parsed.NextSteps)'
+        } finally {
+            Remove-Item -LiteralPath $errFile -Force -ErrorAction SilentlyContinue
+        }
     }
 
-    It 'failure serialization emits EXACTLY {ErrorType,Goal,Problem,NextSteps} from the structured TargetObject' {
-        # Build the real structured error Get-OpEdSource throws, then replicate the shim catch verbatim.
-        $rec = InModuleScope AITriad {
-            New-ActionableError -AsErrorRecord -ErrorType 'ContentPathMissing' `
-                -Goal 'Convert pre-fetched source content for op-ed generation' `
-                -Problem "Content file not found: 'x'" `
-                -Location 'Get-OpEdSource' `
-                -NextSteps @('Confirm the fetcher wrote the temp file', 'Supply -Topic text instead')
+    It 'serializes NextSteps as a JSON array even with a single element (Array.isArray guard)' {
+        # Mirror the shim catch serialization on a single-element NextSteps — the classic PS
+        # single-element-array-collapses-to-scalar gotcha would silently break opedHandlers' array read.
+        $payload = [PSCustomObject]@{ ErrorType = 'X'; Goal = 'g'; Problem = 'p'; NextSteps = [string[]]@('only one') }
+        $out = [ordered]@{
+            ErrorType = [string]$payload.ErrorType
+            Goal      = [string]$payload.Goal
+            Problem   = [string]$payload.Problem
+            NextSteps = [string[]]@($payload.NextSteps)
         }
-        $to = $rec.TargetObject
-        $to | Should -BeOfType [System.Collections.IDictionary]
-
-        # Verbatim mirror of the shim's catch-block serialization.
-        $err = [ordered]@{
-            ErrorType = [string]$to['ErrorType']
-            Goal      = [string]$to['Goal']
-            Problem   = [string]$to['Problem']
-            NextSteps = @($to['NextSteps'])
-        }
-        $json   = $err | ConvertTo-Json -Depth 6 -Compress
-        $parsed = $json | ConvertFrom-Json
-
-        # EXACT field-name set — no more, no less (a drift here = the silent parse-fail class).
-        $names = @($parsed.PSObject.Properties.Name | Sort-Object)
-        $names | Should -Be @('ErrorType', 'Goal', 'NextSteps', 'Problem')
-
-        $parsed.ErrorType | Should -Be 'ContentPathMissing'
-        $parsed.Goal      | Should -Be 'Convert pre-fetched source content for op-ed generation'
-        $parsed.Problem   | Should -Match 'Content file not found'
-        @($parsed.NextSteps).Count | Should -Be 2
+        $json = $out | ConvertTo-Json -Depth 5 -Compress
+        $json | Should -Match '"NextSteps":\['
+        $reparsed = $json | ConvertFrom-Json
+        @($reparsed.NextSteps).Count | Should -Be 1
+        $reparsed.NextSteps -is [array] | Should -BeTrue
     }
 }


### PR DESCRIPTION
## Restore stranded t/3307 consolidation

#1947 **auto-merged at its first commit** (squash `ca3d80b7`) before the consolidation could land, stranding it off the merged head. This re-lands it — a cherry-pick of the reviewed #1947 `407f6bab` delta onto main.

### Content (already reviewed — TL gate t/3307#3, PS2 p/191, ElectronMain shim review)
- `Private/Get-OpEdSourceFromUrl.ps1` — CLI best-effort fetch localized to one t/3312 migration site (from #1948), with the stronger `RawContentStream` binary read (PDF/DOCX over the CLI).
- `New-OpEd` FromUrl delegates to it (removes the inline fetch).
- `tests/OpEdShimTransport.Tests.ps1` — end-to-end subprocess round-trip (spawns the shim, asserts stderr `{ErrorType,Goal,Problem,NextSteps}` + exit 1 + NextSteps-array) + the exact-set guard.
- Shim `NextSteps` → `[string[]]` (single-element list stays a JSON array; opedHandlers `Array.isArray`).

**Independent of #1940** — the wire contract is unchanged (already on main via #1947). 48 tests green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
