### PR TITLE
infra(guard): block `gh pr merge --auto` on joint-gv-labeled PRs — extend t/3270 merge-guard (t/3318)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ The `pre-self-merge-verify` hook **blocks** a manual `gh pr merge` that omits `-
 - **Batch sequential same-feature work** onto one branch / one PR unless the diff exceeds ~400 lines, mixes concerns, or a peer needs an intermediate step on `main`.
 - **Merge promptly on green** — verify (above) and merge within ~15 min, or record the hold as a PR/ticket comment. An unmerged green PR with no recorded hold is drift.
 - **Gated PRs stay draft; never enable auto-merge on a gated PR.** A comment/design/`blocks` hold gives visibility but does **not** gate GitHub; only draft enforces. Un-draft only when the gate is verifiably clear (t/2603/#997).
+- **Co-merge / joint-GV PRs carry the `joint-gv` label; never `--auto` them.** When two+ PRs must land together (a locked cross-role contract) or a PR is gated on a joint TL Gate-Verification, label it `joint-gv`. Auto-merge fires the moment checks go green and merges the PR ALONE on whatever head is current — jumping the group and stranding reviewed work (t/3307: #1947 auto-merged without its ElectronMain pair, briefly breaking main). Merge these manually with `--match-head-commit` after the GV. The DevOps `auto-merge-jointgv-guard` (extends the t/3270 merge-guard: `operations/devops/merge-guard-predicate.mjs`) blocks `gh pr merge --auto` on a `joint-gv`-labeled PR; a normal `--match-head-commit` self-merge is unaffected (t/3318).
 
 ### Claim Before Implement (q/42)
 

--- a/operations/devops/merge-guard-predicate.mjs
+++ b/operations/devops/merge-guard-predicate.mjs
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
+import { execFileSync } from 'node:child_process'; // used only by the --jointgv CLI fetch shim
+
 /**
  * Pure command-string predicate for the pre-self-merge head-guard (t/3270, TL GV t/3270#2).
  *
@@ -40,13 +42,88 @@ export function mergeGuardVerdict(command) {
   return { block: true, reason: 'missing-match-head-commit' };
 }
 
-// CLI shim (t/3270#4, TL GV): the pre-self-merge-verify feedback rule invokes THIS module directly
-//   node <path>/merge-guard-predicate.mjs "<command>"
-// so the rule runs the exact logic the both-arms test proves — test == runtime. (A hand-copied
-// inline node -e would let a typo in the un-tested copy brick every merge or silently negate the
-// gate; TL's load-bearing fix.) Convention: BLOCK == write 'fire' to stdout; ALLOW == exit 0, no
-// stdout — the worktree-path-guard blocking contract. The endsWith guard makes this fire only on
-// direct invocation (any path form), never when imported by the test.
+/**
+ * Auto-merge-on-joint-GV guard (t/3318, TL gate design t/3318#1 — prevention for the t/3307 incident).
+ *
+ * FAILURE CLASS it closes: `gh pr merge --auto` was enabled on a PR that was part of a JOINT GV
+ * (co-merge group — #1947 had to land WITH ElectronMain #1940 per a locked cross-role contract).
+ * Auto-merge fired the moment #1947's checks went green and merged it ALONE on its pre-consolidation
+ * head — jumping the joint GV (main briefly broken) and stranding the reviewed consolidation. The
+ * "gated PRs stay draft / never --auto a gated PR" rule is a convention auto-merge does not honor.
+ *
+ * DESIGN (t/3247 split, per TL): key on a MARKER, not draft-ness — a *solo* draft legitimately uses
+ * --auto (TL recommends it). The hazard is the co-merge grouping. Marker = a `joint-gv` LABEL applied
+ * when a PR is in a co-merge group / gated on a joint TL-GV. This decision is a PURE predicate
+ * `(isAutoMerge ∧ isJointGvLabeled) → block`; the ONLY impure part is the label lookup, isolated in a
+ * fetch shim (kept out of the pure predicate so both arms stay unit-testable, t/2971). Unlike the
+ * t/3270 head-guard (which stays pure-string to avoid fail-open), this NEEDS PR-state I/O — so it
+ * fails CLOSED on a gh error (blocks --auto with a distinct "couldn't verify" message), because
+ * --auto-enable is rare + overridable and letting the t/3307 hazard through on a transient gh blip is
+ * the worse failure. `--match-head-commit` manual self-merge is entirely unaffected (no --auto).
+ */
+export function jointGvAutoMergeVerdict({ isAutoMerge, isJointGvLabeled } = {}) {
+  if (isAutoMerge && isJointGvLabeled) return { block: true, reason: 'auto-merge-on-joint-gv' };
+  if (isAutoMerge) return { block: false, reason: 'auto-merge-unlabeled-ok' };
+  return { block: false, reason: 'not-auto-merge' };
+}
+
+// Is this an auto-merge enable of a `gh pr merge`? (reuses the t/3270 --auto detection verbatim)
+export function isAutoMergeCommand(command) {
+  const cmd = command || '';
+  if (!/\bgh(?:\.exe)?\s+pr\s+merge\b/.test(cmd)) return false;
+  return /(?:^|\s)--auto(?:[=\s]|$)/.test(cmd);
+}
+
+// Extract the PR ref from a `gh pr merge <ref> …` command: a pull URL, else a numeric id, else null
+// (null → the caller lets `gh pr view` default to the current branch's PR). Only the leading ref
+// position is read, so a `--match-head-commit <sha>` value can't be mistaken for the ref (and --auto
+// commands can't carry that flag anyway — gh rejects the combination).
+export function parsePrRef(command) {
+  const cmd = command || '';
+  const url = cmd.match(/\bpr\s+merge\s+(\S*\/pull\/\d+)/);
+  if (url) return url[1];
+  const num = cmd.match(/\bpr\s+merge\s+(\d+)(?:\s|$)/);
+  if (num) return num[1];
+  return null;
+}
+
+// CLI shim (t/3270#4 / t/3318, TL GV): the feedback rules invoke THIS module directly so the rule
+// runs the exact logic the both-arms test proves — test == runtime. (A hand-copied inline node -e
+// would let a typo in the un-tested copy brick every merge or silently negate the gate; TL's
+// load-bearing fix.) Convention: BLOCK == write 'fire' to stdout; ALLOW == exit 0, no stdout — the
+// worktree-path-guard blocking contract. The endsWith guard makes this fire only on direct
+// invocation (any path form), never when imported by the test.
+//
+// Two modes, both feed the same 'fire' contract but from DIFFERENT rules (distinct remediation text):
+//   node <path>/merge-guard-predicate.mjs "<command>"              → t/3270 head-guard (pre-self-merge-verify)
+//   node <path>/merge-guard-predicate.mjs --jointgv "<command>"    → t/3318 auto-merge joint-GV guard
+// The head-guard path is byte-identical to before (its 13/13 test stays green); --auto is
+// 'auto-exempt' there, so the two guards never double-fire on one command.
 if (process.argv[1] && process.argv[1].replace(/\\/g, '/').endsWith('merge-guard-predicate.mjs')) {
-  if (mergeGuardVerdict(process.argv[2] || '').block) process.stdout.write('fire');
+  if (process.argv[2] === '--jointgv') {
+    const cmd = process.argv[3] || '';
+    if (isAutoMergeCommand(cmd)) {
+      // Fetch shim (the only impure part): look up the PR's labels. Fail CLOSED on a gh error (after
+      // one retry) — a joint-GV PR must not auto-merge, and an unverifiable label is treated as unsafe.
+      let labeled;
+      try {
+        const ref = parsePrRef(cmd);
+        const args = ['pr', 'view', ...(ref ? [ref] : []), '--json', 'labels', '-q', '.labels[].name'];
+        let out = '';
+        for (let attempt = 1; attempt <= 2; attempt++) {
+          try { out = execFileSync('gh', args, { encoding: 'utf8', timeout: 8000 }); break; }
+          catch (e) { if (attempt === 2) throw e; }
+        }
+        labeled = out.split(/\r?\n/).some((l) => l.trim() === 'joint-gv');
+      } catch {
+        process.stdout.write('fire'); // fail-closed: couldn't verify → block --auto
+        labeled = null;
+      }
+      if (labeled !== null && jointGvAutoMergeVerdict({ isAutoMerge: true, isJointGvLabeled: labeled }).block) {
+        process.stdout.write('fire');
+      }
+    }
+  } else if (mergeGuardVerdict(process.argv[2] || '').block) {
+    process.stdout.write('fire');
+  }
 }

--- a/operations/devops/merge-guard-predicate.test.mjs
+++ b/operations/devops/merge-guard-predicate.test.mjs
@@ -10,7 +10,12 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { mergeGuardVerdict } from './merge-guard-predicate.mjs';
+import {
+  mergeGuardVerdict,
+  jointGvAutoMergeVerdict,
+  isAutoMergeCommand,
+  parsePrRef,
+} from './merge-guard-predicate.mjs';
 
 const MODULE = fileURLToPath(new URL('./merge-guard-predicate.mjs', import.meta.url));
 // Invoke the module the SAME way the feedback rule does — proves runtime (CLI shim) == the tested
@@ -92,4 +97,64 @@ test('CLI shim: ALLOWs (no output) on a guarded merge — both flag forms', () =
 test('CLI shim: ALLOWs --auto (exempt) and non-merge commands', () => {
   assert.equal(runShim('gh pr merge 1901 --auto'), '');
   assert.equal(runShim('gh pr view 1901 --json headRefOid'), '');
+});
+
+// ── t/3318: auto-merge-on-joint-GV guard (TL gate design t/3318#1) ──
+// The pure predicate is the both-arms unit under test; the label lookup (fetch shim) is impure and
+// proven by the real fire-drill (labeled test PR + --auto → blocks). Here we prove the 4-combo truth
+// table + the command parsers, and the CLI --jointgv mode's gh-free early-exits.
+
+test('jointGv BLOCK arm: --auto + joint-gv label → block', () => {
+  const v = jointGvAutoMergeVerdict({ isAutoMerge: true, isJointGvLabeled: true });
+  assert.equal(v.block, true);
+  assert.equal(v.reason, 'auto-merge-on-joint-gv');
+});
+
+test('jointGv ALLOW arm: --auto + NOT labeled → allow (solo draft may auto-merge)', () => {
+  const v = jointGvAutoMergeVerdict({ isAutoMerge: true, isJointGvLabeled: false });
+  assert.equal(v.block, false);
+  assert.equal(v.reason, 'auto-merge-unlabeled-ok');
+});
+
+test('jointGv ALLOW arm: manual (no --auto) + joint-gv label → allow (manual co-merge is the intent)', () => {
+  const v = jointGvAutoMergeVerdict({ isAutoMerge: false, isJointGvLabeled: true });
+  assert.equal(v.block, false);
+  assert.equal(v.reason, 'not-auto-merge');
+});
+
+test('jointGv ALLOW arm: manual + not labeled → allow', () => {
+  const v = jointGvAutoMergeVerdict({ isAutoMerge: false, isJointGvLabeled: false });
+  assert.equal(v.block, false);
+  assert.equal(v.reason, 'not-auto-merge');
+});
+
+test('isAutoMergeCommand: true only for a `gh pr merge` carrying --auto', () => {
+  assert.equal(isAutoMergeCommand('gh pr merge 1947 --auto --squash'), true);
+  assert.equal(isAutoMergeCommand('gh pr merge 1947 --squash --auto'), true);
+  assert.equal(isAutoMergeCommand('gh.exe pr merge --auto'), true);
+  assert.equal(isAutoMergeCommand('gh pr merge 1947 --squash'), false); // manual
+  assert.equal(isAutoMergeCommand('gh pr view 1947 --json labels'), false); // not a merge
+  assert.equal(isAutoMergeCommand('gh pr merge 1947 --squash --auto-delete'), false); // not the --auto flag
+});
+
+test('parsePrRef: numeric id, pull URL, else null (→ current branch)', () => {
+  assert.equal(parsePrRef('gh pr merge 1947 --auto'), '1947');
+  assert.equal(parsePrRef('gh pr merge https://github.com/jpsnover/ai-triad-research/pull/1947 --auto'),
+    'https://github.com/jpsnover/ai-triad-research/pull/1947');
+  assert.equal(parsePrRef('gh pr merge --auto --squash'), null); // no ref → gh uses current branch
+  // a --match-head-commit value is never mistaken for the ref (leading-position only)
+  assert.equal(parsePrRef('gh pr merge --match-head-commit deadbeef --squash 1947'), null);
+});
+
+// CLI --jointgv mode: the gh-free early-exits are deterministic (no PR lookup performed).
+function runShimJointGv(command) {
+  return execFileSync(process.execPath, [MODULE, '--jointgv', command], { encoding: 'utf8' });
+}
+
+test('CLI --jointgv: no gh call + no fire on a MANUAL merge (not --auto)', () => {
+  assert.equal(runShimJointGv('gh pr merge 1947 --squash --match-head-commit abc'), '');
+});
+
+test('CLI --jointgv: no gh call + no fire on a non-merge command', () => {
+  assert.equal(runShimJointGv('gh pr view 1947 --json labels'), '');
 });


### PR DESCRIPTION
Prevention for t/3307: auto-merge was enabled on #1947 — part of a joint GV /
co-merge group with ElectronMain #1940 — and fired the moment its checks went
green, merging it ALONE on its pre-consolidation head (jumping the joint GV, briefly
breaking main, stranding the reviewed consolidation).

Per TL gate design (t/3318#1), extend the proven t/3270 merge-guard rather than build
new. Key on a `joint-gv` LABEL (not draft-ness — a solo draft may legitimately
--auto). The t/3247 split:
- pure predicate jointGvAutoMergeVerdict({isAutoMerge, isJointGvLabeled}) → block
- helpers isAutoMergeCommand(cmd), parsePrRef(cmd)
- CLI --jointgv mode: a fetch shim runs `gh pr view <ref> --json labels` (the only
  impure part) and feeds the predicate; emits 'fire' iff block. Fails CLOSED on a gh
  error after one retry (--auto-enable is rare + overridable; letting the t/3307
  hazard through on a transient blip is the worse failure).

The t/3270 default-mode path is byte-identical (its 13/13 stays green); --auto is
'auto-exempt' there so the two guards never double-fire.

Tests: 21/21 (13 existing + jointGv 4-combo truth table + parser cases + CLI
--jointgv gh-free early-exits). The gh-I/O fire path is proven by a real fire-drill
(labeled PR + --auto → fire), per the t/3247 force-the-fire-arm lesson.

Doc: `joint-gv` label convention + guard added to root AGENTS.md PR-Flow rules.

Ships as a type:context advisory rule (created separately); the type:block flip is a
separate GV step, mirroring the t/3270 sibling.

Co-Authored-By: DevOps (Orca) <main.operations-devops@ai-triad-research.orca.local>
Co-Authored-By: Tech Lead (Orca) <main.engineering-tech-lead@ai-triad-research.orca.local>
Co-Authored-By: PowerShell (Orca) <main.scripts@ai-triad-research.orca.local>
