### PR TITLE
fix(server): include decisions[] in attribution response (t/3323)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/attribution.test.ts
+++ b/taxonomy-editor/src/server/__tests__/attribution.test.ts
@@ -142,6 +142,15 @@ describe('POST /api/argument-network/attribution — server parity (t/3297)', ()
     expect((res._body.attributions as Record<string, { unattributed_reason?: string }>)['an-3'].unattributed_reason).toBe('no_embedding');
   });
 
+  it('t/3323: summary includes per-claim decisions[] (ExtractionTimelinePanel contract)', async () => {
+    const res = fakeRes();
+    await post(fakeReq(), res, { pov: 'accelerationist', claims: structuredClone(CLAIMS) });
+    const summary = res._body.summary as { decisions?: { claim_id: string }[] };
+    expect(Array.isArray(summary.decisions)).toBe(true);
+    expect(summary.decisions).toHaveLength(CLAIMS.length); // one decision per claim, incl. the no-embedding one
+    expect(summary.decisions!.map(d => d.claim_id)).toEqual(CLAIMS.map(c => c.id)); // order-preserving
+  });
+
   it('rejects an invalid pov with 400', async () => {
     const res = fakeRes();
     await post(fakeReq(), res, { pov: 'bogus', claims: [] });

--- a/taxonomy-editor/src/server/routes/attribution.ts
+++ b/taxonomy-editor/src/server/routes/attribution.ts
@@ -91,6 +91,9 @@ export function registerAttributionRoutes(r: Router, _ctx: ServerCtx): void {
           unattributed: summary.unattributed,
           missing_embedding: summary.missing_embedding,
           novel_argument: summary.novel_argument,
+          // t/3323: per-claim decisions feed the client's ExtractionTimelinePanel
+          // (attribution_decisions). Already computed on the ClaimAttributionResult — include, don't drop.
+          decisions: summary.decisions,
         },
       });
     } catch (err) {


### PR DESCRIPTION
## Summary (t/3323)

The `/api/argument-network/attribution` endpoint (t/3297) trimmed its response summary to the 4 counts and **dropped `decisions` (ClaimAttributionDecision[])**. The renderer's `attribution_decisions` feeds `ExtractionTimelinePanel` (per-claim timeline), so the omission would regress that panel once the client flips (caught by Rosetta, t/3316#2).

`computeClaimTaxonomyAttribution` already returns `decisions` on its `ClaimAttributionResult` — this is a **one-line include, no recompute**.

## Change
- `routes/attribution.ts` — add `decisions: summary.decisions` to the response summary.
- `__tests__/attribution.test.ts` — assert `summary.decisions` is an array, one entry per claim (incl. the no-embedding claim), order-preserving.

## Safety
- **Non-breaking / additive** — the endpoint is dormant (no client caller until t/3316 flips), so adding a field can't break anyone.
- Self-cert **/trivial-change** (additive field, single handler + its test, dormant surface).
- Electron handler mirror tracked in **t/3322** (must return the identical shape).

Verify: 10/10 attribution tests green (incl. the new decisions test), tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)