### PR TITLE
feat(debate): flip claim-attribution to POST /api/argument-network/attribution (t/3316)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
@@ -277,6 +277,9 @@ export const api: AppAPI = {
   // t/3258 (T3): packaged Electron has no embedded server, so this delegates to a main-process
   // handler that mirrors routes/relevantNodes.ts via the SAME shared lib (parity by construction).
   fetchRelevantNodes: (payload) => window.electronAPI.fetchRelevantNodes(payload),
+  // t/3316: packaged Electron has no server → delegates to a main handler (t/3322) computing
+  // attribution from the LOCAL corpus via the SAME pure fn (parity by construction, per-build).
+  fetchClaimAttribution: (payload) => window.electronAPI.computeAttribution(payload),
 
   // Debate sessions
   getDebateQuotaStatus: () => Promise.resolve({ allowed: true, resource: 'debates', current: 0, limit: Infinity }),

--- a/taxonomy-editor/src/renderer/bridge/types.ts
+++ b/taxonomy-editor/src/renderer/bridge/types.ts
@@ -115,6 +115,30 @@ export interface FetchRelevantNodesPayload {
   };
 }
 
+// t/3316 (t/3297 client half): per-claim taxonomy attribution moved server/main-side — the debate
+// client stops assembling the corpus for attribution (the last synthetic-corpus fetch). Both
+// transports call the SAME pure fn (computeClaimTaxonomyAttribution) — web server-side, electron
+// main-side — so the result is parity-identical by construction.
+import type { ClaimAttributionResult as _ClaimAttributionResult } from '@lib/debate/argumentNetwork/attribution';
+import type { ClaimTaxonomyAttribution as _ClaimTaxonomyAttribution } from '@lib/debate/types';
+
+/** Payload for `fetchClaimAttribution` (t/3316). The client sends the newly-extracted AN claims (id +
+ *  embeddings); the server/main derives the same-POV candidate corpus itself. Field-for-field identical
+ *  to the attribution route's body (routes/attribution.ts). */
+export interface FetchClaimAttributionPayload {
+  /** Speaker POV file key: accelerationist | safetyist | skeptic. */
+  pov: string;
+  claims: { id: string; embedding?: number[]; attribution_embedding?: number[] }[];
+  topN?: number;
+}
+
+/** Response: per-claim attribution (applied verbatim to each AN node's `claim_taxonomy_attribution`) +
+ *  the diagnostics summary — the 4 counts AND `decisions[]` (drives ExtractionTimelinePanel, t/3316#2). */
+export interface ClaimAttributionResponse {
+  attributions: Record<string, _ClaimTaxonomyAttribution>;
+  summary: _ClaimAttributionResult;
+}
+
 import type { OpEdSet, OpEdSetSummary, PovKey } from '../../../../lib/oped/types';
 import type { BriefPreset, ExportJobState, ExportErrorCode, BriefArtifactName } from '../../../../lib/brief/types';
 
@@ -339,6 +363,11 @@ export interface AppAPI {
   // Electron → IPC → a main handler mirroring routes/relevantNodes.ts (packaged Electron has no
   // embedded server). Only per-session state crosses the wire; the corpus is assembled server/main-side.
   fetchRelevantNodes: (payload: FetchRelevantNodesPayload) => Promise<RelevantTaxonomyResult>;
+  // t/3316 (t/3297 client half): server/main-side per-claim taxonomy attribution — the debate client
+  // stops assembling the corpus for attribution. Both transports run the SAME pure fn
+  // (computeClaimTaxonomyAttribution). Web → REST POST /api/argument-network/attribution; Electron →
+  // IPC → a main handler (window.electronAPI.computeAttribution, t/3322) computing from the LOCAL corpus.
+  fetchClaimAttribution: (payload: FetchClaimAttributionPayload) => Promise<ClaimAttributionResponse>;
   nliClassify: (pairs: Array<{ text_a: string; text_b: string }>) => Promise<{
     results: Array<{
       nli_label: string;

--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -993,10 +993,10 @@ const rawApi: AppAPI = {
 
   // Embeddings & NLI
   computeEmbeddings: (texts, ids) => computeEmbeddingsChunked(post, texts, ids), // ≤EMBEDDINGS_MAX_BATCH sequential chunks so an oversized batch can't blow the 50s server timeout (t/3072)
-  // Web transport: server embed backend has no DirectML GPU-OOM mode → nothing goes stale → always [] (t/2060 staleNodeIds contract).
-  updateNodeEmbeddings: (nodes) => post('/api/embeddings/update-nodes', { nodes }).then(() => ({ staleNodeIds: [] as string[] })),
+  updateNodeEmbeddings: (nodes) => post('/api/embeddings/update-nodes', { nodes }).then(() => ({ staleNodeIds: [] as string[] })), // Web: server embed backend has no GPU-OOM mode → nothing stale → always [] (t/2060).
   computeQueryEmbedding: (text) => post('/api/embeddings/query', { text }),
-  fetchRelevantNodes: (payload) => post('/api/taxonomy/relevant-nodes', payload), // t/3258 (T3): EXACT path (no trailing slash/query) — anon free-tier gate is exact-match, else anon debates 403 (TL t/3284#2)
+  fetchRelevantNodes: (payload) => post('/api/taxonomy/relevant-nodes', payload), // t/3258 (T3): EXACT path — anon free-tier gate is exact-match (TL t/3284#2)
+  fetchClaimAttribution: (payload) => post('/api/argument-network/attribution', payload), // t/3316 (t/3297 client half): server-side per-claim attribution
   nliClassify: (pairs) => post('/api/nli/classify', { pairs }),
 
   // Source evidence

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/argumentNetwork.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/argumentNetwork.ts
@@ -19,7 +19,6 @@ import {
   extractClaimsPrompt,
   classifyClaimsPrompt,
   processExtractedClaims,
-  computeClaimTaxonomyAttribution,
   updateUnansweredLedger,
 } from '../../../prompts/argumentNetwork';
 import { trace, newCallId, TraceEventName } from '../../../lib/trace';
@@ -42,7 +41,6 @@ import type { GroundingCitation } from '../../../bridge/types';
 import { pushWarning, recordDiagnostic } from './diagnostics';
 import { getConfiguredModel } from './modelConfig';
 import { buildFactCheckPrompt } from './prompts';
-import { loadSyntheticVectors, mergeSyntheticVectors } from './taxonomyContext';
 import { phaseGuardedSet } from './generation';
 
 /** Maximum number of turn embeddings to retain (enough for recycling detection). */
@@ -321,63 +319,24 @@ async function computeTaxonomyAttribution(newNodes: NewAnNode[], speaker: Speake
       const speakerPov = POVER_INFO[speaker as Exclude<SpeakerId, 'user'>]?.pov;
       if (speakerPov) {
         try {
-          const taxState = useTaxonomyStore.getState();
-          const povFile = taxState[speakerPov as keyof typeof taxState] as { nodes: { id: string; category: string; label: string; description: string }[] } | null;
-          const povNodes = povFile?.nodes ?? [];
-          const allPovNodeIds = new Set(povNodes.map((n) => n.id));
-
-          // Ensure we have embeddings for POV nodes — load from embeddings.json via IPC
-          let embCache = taxState.embeddingCache;
-          if (embCache.size === 0 || !povNodes.some(n => embCache.has(n.id))) {
-            const { ids, texts } = taxState.buildEmbeddingTexts(new Set(), new Set());
-            if (ids.length > 0) {
-              const { vectors } = await api.computeEmbeddings(texts, ids);
-              embCache = new Map<string, number[]>();
-              for (let i = 0; i < ids.length; i++) {
-                if (vectors[i]?.length > 0) embCache.set(ids[i], vectors[i]);
-              }
-              useTaxonomyStore.setState({ embeddingCache: embCache, embeddingDirty: false });
-            }
+          // t/3316 (t/3297 client half): attribution moved server/main-side — POST the newly-extracted
+          // claims (id + embeddings) instead of assembling the corpus locally. The server/main runs the
+          // SAME pure fn (computeClaimTaxonomyAttribution) over the shared corpus → parity by construction;
+          // fixes the anon degradation (endpoint is free-tier gated) + drops the last synthetic-corpus fetch.
+          const { attributions, summary } = await api.fetchClaimAttribution({
+            pov: speakerPov,
+            claims: newNodes.map(n => ({ id: n.id, embedding: n.embedding, attribution_embedding: n.attribution_embedding })),
+          });
+          // Re-apply per-claim attribution verbatim to each AN node (mirrors the old in-place mutation).
+          for (const node of newNodes) {
+            const attr = attributions[node.id];
+            if (attr) node.claim_taxonomy_attribution = attr;
           }
-
-          // Build nodeEmbeddings from embeddingCache — add pov from node ID prefix
-          const baseNodeEmbeddings: Record<string, { pov: string; vector: number[] }> = {};
-          const povMap: Record<string, string> = { acc: 'accelerationist', saf: 'safetyist', skp: 'skeptic' };
-          for (const [nodeId, vector] of embCache) {
-            const prefix = nodeId.split('-')[0];
-            const pov = povMap[prefix];
-            if (pov && vector.length > 0) {
-              baseNodeEmbeddings[nodeId] = { pov, vector };
-            }
-          }
-
-          // Merge synthetic multi-vector embeddings when available
-          const synVecs = await loadSyntheticVectors();
-          if (!synVecs) {
-            // t/3298 (t/3297 c-floor): loadSyntheticVectors returned null — the synthetic-embeddings
-            // corpus GET is auth-gated (t/3259), so it 403s for ANON debates → the synthetic
-            // multi-vector merge is DROPPED and claim attribution runs on BASE embeddings only. Make
-            // this degradation observable HERE (Fallback-Path Logging) with a specific WARN + marker,
-            // rather than letting it be inferred from downstream attribution quality or swallowed by
-            // the generic catch below. (Structural fix = the t/3297 (a)-spike, ServerAPI.)
-            getGlobalRecorder()?.record({
-              type: 'system.error', debate_id: debate.id, component: 'debate-store', level: 'warn',
-              message: 'Claim attribution degraded — synthetic-vector merge dropped (synthetic corpus unavailable; likely the anon corpus-gate 403, t/3259). Attribution runs on base embeddings only.',
-              data: { fallback: 'synthetic-merge-skipped', cause: 'synthetic-vectors-null', base_node_count: Object.keys(baseNodeEmbeddings).length },
-            });
-          }
-          const nodeEmbeddings = synVecs
-            ? mergeSyntheticVectors(baseNodeEmbeddings, synVecs)
-            : baseNodeEmbeddings;
-
-          const attrResult = computeClaimTaxonomyAttribution(
-            newNodes, speakerPov, nodeEmbeddings, allPovNodeIds,
-          );
-          extractionTrace.attribution_attributed = attrResult.attributed;
-          extractionTrace.attribution_unattributed = attrResult.unattributed;
-          extractionTrace.attribution_missing_embedding = attrResult.missing_embedding;
-          extractionTrace.attribution_novel_argument = attrResult.novel_argument;
-          extractionTrace.attribution_decisions = attrResult.decisions;
+          extractionTrace.attribution_attributed = summary.attributed;
+          extractionTrace.attribution_unattributed = summary.unattributed;
+          extractionTrace.attribution_missing_embedding = summary.missing_embedding;
+          extractionTrace.attribution_novel_argument = summary.novel_argument;
+          extractionTrace.attribution_decisions = summary.decisions;
         } catch (e) {
           getGlobalRecorder()?.record({ type: 'system.error', debate_id: debate.id, component: 'debate-store', level: 'warn', message: 'Claim taxonomy attribution failed', error: { name: (e as Error).name ?? 'Error', message: String(e), stack: (e as Error).stack } });
           // Attribution failure never blocks extraction

--- a/taxonomy-editor/src/renderer/types/electron.d.ts
+++ b/taxonomy-editor/src/renderer/types/electron.d.ts
@@ -5,7 +5,7 @@ import type { Organization, OrganizationEdge } from '@lib/organizations/types';
 import type { EntityDetail, EntitySummary, EntityListQuery } from '@lib/entities/types';
 import type { ContainerMentions } from '@lib/entities/mentionTypes';
 import type { EdgesFile } from '@lib/debate/taxonomyTypes';
-import type { UserPreferences, BriefExportRequest, BriefExportJobView, BriefExportRecord, FetchRelevantNodesPayload, RelevantTaxonomyResult } from '../bridge/types';
+import type { UserPreferences, BriefExportRequest, BriefExportJobView, BriefExportRecord, FetchRelevantNodesPayload, RelevantTaxonomyResult, FetchClaimAttributionPayload, ClaimAttributionResponse } from '../bridge/types';
 import type { BriefArtifactName } from '@lib/brief/types';
 
 export interface ElectronAPI {
@@ -135,6 +135,9 @@ export interface ElectronAPI {
   // mirrors routes/relevantNodes.ts via the shared lib (parity by construction). Contract shared with
   // the web transport through bridge/types.ts.
   fetchRelevantNodes: (payload: FetchRelevantNodesPayload) => Promise<RelevantTaxonomyResult>;
+  // t/3316: the renderer's view of the main-process attribution handler ElectronMain implements (t/3322)
+  // — computes from the LOCAL corpus via the same pure fn. Contract shared with web via bridge/types.ts.
+  computeAttribution: (payload: FetchClaimAttributionPayload) => Promise<ClaimAttributionResponse>;
   nliClassify: (pairs: Array<{ text_a: string; text_b: string }>) => Promise<{ results: Array<{ nli_label: string; nli_entailment: number; nli_neutral: number; nli_contradiction: number; margin: number }> }>;
 
   // Debate sessions


### PR DESCRIPTION
Client half of **t/3297** — the structural fix for anon-attribution degradation (supersedes the t/3298 c-floor WARN) + drops the last synthetic-corpus fetch from the debate client. Mirrors the T3 relevant-nodes flip (t/3258); ServerAPI ruled option **A** (full dual-build, p/528#69).

## Renderer half (this PR)
- **Bridge trio:** `types.ts` (`FetchClaimAttributionPayload` + `ClaimAttributionResponse` + `AppAPI.fetchClaimAttribution`), `web-bridge` (POST `/api/argument-network/attribution`), `electron-bridge` (→ `window.electronAPI.computeAttribution`), `electron.d.ts`.
- **`argumentNetwork.ts` flip:** one bridge call replaces the local corpus build + synthetic merge + `computeClaimTaxonomyAttribution`; applies `attributions[node.id]` verbatim; maps `summary` (incl. `decisions[]`) → `extractionTrace.attribution_*`; **keeps the non-blocking catch**. Drops the now-dead imports.
- **`decisions[]`** flows through to `ExtractionTimelinePanel` — the contract gap I caught (t/3316#2), fixed server-side in **PR #1955**.
- **Kept** `loadSyntheticVectors` + the synthetic-embeddings bridge path (the t/3165 test's `buildNodeEmbeddingMap` still uses it — same call as t/3258).

## JOINT-GV — must land together
- **PR #1955** (ServerAPI): adds `decisions` to the endpoint response.
- **t/3322** (ElectronMain): the `computeAttribution` IPC handler (LOCAL corpus).
- **This PR** (renderer). `appapi-completeness` requires all transports; mis-ordering crashes Electron debates. **Electron-first**, manual `--match-head-commit`, never `--auto` (t/3318).

## Verify
renderer-tsc clean · eslint 0 errors · appapi-completeness + full useDebateStore suite **284 pass**.

Self-cert /add-bridge-method (T3 precedent t/3258). Parity by construction (same pure fn). Draft — held for #1955 + t/3322.