### PR TITLE
feat(url-fetch): add fetch-url-cli.mjs node CLI over fetchUrlForPromptBinary (t/3324)

### DIFF
--- a/lib/url-fetch/fetch-url-cli.mjs
+++ b/lib/url-fetch/fetch-url-cli.mjs
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Standalone CLI over the SSRF-guarded binary fetcher (t/3324, TL contract t/3310#1). PS-standalone
+// cmdlets (Import-AITriadDocument, Repair-PovLineage, Get-OpEdSource) can't call the Node function,
+// so they invoke this:
+//
+//   node lib/url-fetch/fetch-url-cli.mjs <url> --out <file> [--max-bytes N] [--timeout-ms N]
+//
+// It writes the response bytes to --out and prints ONE line of JSON to stdout:
+//   { status, contentType, finalUrl, error, bodySnippet }
+//     status      : 200 on success; the HTTP code on an http-error; null on a transport failure
+//                   (ssrf-blocked / timeout / too-large / too-many-redirects / network).
+//     contentType : the response Content-Type on success, else null.
+//     finalUrl    : the post-redirect URL on success, else null.
+//     error       : null on success; the failure reason string otherwise.
+//     bodySnippet : first ~1KB of the body decoded utf-8 (PS soft-404 liveness heuristic — a 200
+//                   whose body is an error page), else null. Lossy for binary; a heuristic only.
+// Exit code: 0 on success, 1 on any failure (incl. usage errors). PS can branch on either the exit
+// code or the parsed JSON. Runs under plain `node` type-stripping — the fetcher's eager imports are
+// node builtins only (the sanitizer is lazy in the text path, which this CLI never invokes).
+//
+// The fetcher enforces every SSRF/redirect/timeout/maxBytes guard; this CLI adds no network logic.
+import { writeFileSync } from 'node:fs';
+import { fetchUrlForPromptBinary } from './fetchUrlForPrompt.ts';
+
+const SNIPPET_BYTES = 1024;
+
+/** Parse `<url> --out <file> [--max-bytes N] [--timeout-ms N]`. Throws on missing/invalid args. */
+export function parseArgs(argv) {
+  let url;
+  const opts = {};
+  let out;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--out') { out = argv[++i]; }
+    else if (a === '--max-bytes') { opts.maxBytes = Number(argv[++i]); }
+    else if (a === '--timeout-ms') { opts.timeoutMs = Number(argv[++i]); }
+    else if (a.startsWith('--')) { throw new Error(`unknown flag ${a}`); }
+    else if (url === undefined) { url = a; }
+    else { throw new Error(`unexpected argument ${a}`); }
+  }
+  if (!url) throw new Error('missing <url>');
+  if (!out) throw new Error('missing --out <file>');
+  if (opts.maxBytes !== undefined && !Number.isFinite(opts.maxBytes)) throw new Error('--max-bytes must be a number');
+  if (opts.timeoutMs !== undefined && !Number.isFinite(opts.timeoutMs)) throw new Error('--timeout-ms must be a number');
+  return { url, out, opts };
+}
+
+/** Map a UrlFetchBinaryResult to the CLI's { exitCode, json } (pure — unit-tested). */
+export function buildOutput(result) {
+  if (result.ok) {
+    return {
+      exitCode: 0,
+      json: {
+        status: 200,
+        contentType: result.contentType,
+        finalUrl: result.finalUrl,
+        error: null,
+        bodySnippet: result.bytes.subarray(0, SNIPPET_BYTES).toString('utf-8'),
+      },
+    };
+  }
+  return {
+    exitCode: 1,
+    json: {
+      status: result.status ?? null,   // present only on http-error
+      contentType: null,
+      finalUrl: null,
+      error: result.reason,
+      bodySnippet: null,
+    },
+  };
+}
+
+function emit(json, exitCode) {
+  process.stdout.write(JSON.stringify(json) + '\n');
+  process.exitCode = exitCode;
+}
+
+async function main(argv) {
+  let parsed;
+  try {
+    parsed = parseArgs(argv);
+  } catch (e) {
+    emit({ status: null, contentType: null, finalUrl: null, error: `usage: ${e.message}`, bodySnippet: null }, 1);
+    return;
+  }
+  const result = await fetchUrlForPromptBinary(parsed.url, parsed.opts);
+  const { exitCode, json } = buildOutput(result);
+  if (result.ok) writeFileSync(parsed.out, result.bytes);
+  emit(json, exitCode);
+}
+
+// Run only when invoked directly (not when a test imports parseArgs/buildOutput).
+if (process.argv[1] && process.argv[1].replace(/\\/g, '/').endsWith('/url-fetch/fetch-url-cli.mjs')) {
+  await main(process.argv.slice(2));
+}

--- a/lib/url-fetch/fetch-url-cli.test.ts
+++ b/lib/url-fetch/fetch-url-cli.test.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// @vitest-environment node
+// Unit-tests the CLI's pure logic (arg parsing + result→JSON mapping) and a child_process smoke that
+// proves the CLI runs under plain `node` (the packaging goal: no build/tsx). The SSRF/fetch path
+// itself is covered by fetchUrlForPrompt.test.ts — this file guards only the CLI wrapper (t/3324).
+import { execFile } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { describe, expect, it } from 'vitest';
+import { parseArgs, buildOutput } from './fetch-url-cli.mjs';
+
+const CLI = fileURLToPath(new URL('./fetch-url-cli.mjs', import.meta.url));
+const run = promisify(execFile);
+
+describe('parseArgs', () => {
+  it('parses <url> --out <file>', () => {
+    expect(parseArgs(['https://x.test/', '--out', 'f.bin'])).toEqual({ url: 'https://x.test/', out: 'f.bin', opts: {} });
+  });
+  it('parses --max-bytes and --timeout-ms into opts', () => {
+    const r = parseArgs(['https://x.test/', '--out', 'f', '--max-bytes', '500', '--timeout-ms', '2000']);
+    expect(r.opts).toEqual({ maxBytes: 500, timeoutMs: 2000 });
+  });
+  it('throws on missing url', () => expect(() => parseArgs(['--out', 'f'])).toThrow(/missing <url>/));
+  it('throws on missing --out', () => expect(() => parseArgs(['https://x.test/'])).toThrow(/missing --out/));
+  it('throws on an unknown flag', () => expect(() => parseArgs(['https://x.test/', '--out', 'f', '--nope'])).toThrow(/unknown flag/));
+  it('throws on a non-numeric --max-bytes', () => expect(() => parseArgs(['u', '--out', 'f', '--max-bytes', 'abc'])).toThrow(/must be a number/));
+});
+
+describe('buildOutput', () => {
+  it('maps a success to status 200 + contentType + finalUrl + bodySnippet, exit 0', () => {
+    const { exitCode, json } = buildOutput({
+      ok: true, bytes: Buffer.from('%PDF-hello'), contentType: 'application/pdf', finalUrl: 'https://x.test/doc.pdf',
+    });
+    expect(exitCode).toBe(0);
+    expect(json).toEqual({
+      status: 200, contentType: 'application/pdf', finalUrl: 'https://x.test/doc.pdf', error: null, bodySnippet: '%PDF-hello',
+    });
+  });
+  it('truncates the bodySnippet to ~1KB', () => {
+    const { json } = buildOutput({ ok: true, bytes: Buffer.alloc(5000, 0x61), contentType: 'text/html', finalUrl: 'u' });
+    expect(json.bodySnippet.length).toBe(1024);
+  });
+  it('carries the HTTP status on an http-error, exit 1', () => {
+    const { exitCode, json } = buildOutput({ ok: false, reason: 'http-error', status: 403 });
+    expect(exitCode).toBe(1);
+    expect(json).toEqual({ status: 403, contentType: null, finalUrl: null, error: 'http-error', bodySnippet: null });
+  });
+  it('maps a transport failure to status null + error reason, exit 1', () => {
+    const { exitCode, json } = buildOutput({ ok: false, reason: 'ssrf-blocked' });
+    expect(exitCode).toBe(1);
+    expect(json).toEqual({ status: null, contentType: null, finalUrl: null, error: 'ssrf-blocked', bodySnippet: null });
+  });
+});
+
+describe('CLI process (plain node)', () => {
+  it('runs under plain `node` and reports a usage error (exit 1, parseable JSON)', async () => {
+    // Also the packaging proof: if the CLI could not import the .ts fetcher under plain node
+    // type-stripping, this would fail with ERR_MODULE_NOT_FOUND instead of our usage JSON.
+    await run('node', [CLI]).then(
+      () => { throw new Error('expected non-zero exit'); },
+      (err) => {
+        expect(err.code).toBe(1);
+        const out = JSON.parse(err.stdout);
+        expect(out.error).toMatch(/^usage: missing <url>/);
+        expect(out.status).toBeNull();
+      },
+    );
+  }, 15_000);
+});

--- a/lib/url-fetch/fetchUrlForPrompt.ts
+++ b/lib/url-fetch/fetchUrlForPrompt.ts
@@ -37,7 +37,12 @@
 import { promises as dns } from 'node:dns';
 import * as http from 'node:http';
 import * as https from 'node:https';
-import { sanitizeText } from '../sanitize/contentSanitizerCore.js';
+// NOTE: `sanitizeText` is loaded LAZILY (dynamic import) inside the text path below — NOT eagerly here.
+// This keeps the module's eager runtime imports to node builtins only, so the standalone binary CLI
+// (`fetch-url-cli.mjs`, t/3324) can `import { fetchUrlForPromptBinary }` under plain `node`
+// type-stripping without pulling in the sanitizer's `.js`-specifier deps (decode-named-character-
+// reference etc.), which plain node cannot resolve. The binary path never sanitizes; the text path's
+// bundled/vitest callers resolve the dynamic import normally. Type-only imports below are erased.
 import type { UrlFetchOptions, UrlFetchResult, UrlFetchBinaryResult, UrlFetchFailureReason } from './types.js';
 
 const DEFAULT_MAX_BYTES = 1_572_864; // 1.5 MB
@@ -343,6 +348,9 @@ export async function fetchUrlForPrompt(
   } else {
     const extracted = isHtml ? htmlToText(body) : { text: body, title: undefined };
     title = extracted.title;
+    // Lazy import (see the top-of-file note): keeps the sanitizer out of the module's eager graph so
+    // the binary CLI stays plain-node-importable. Bundled/vitest callers resolve this normally.
+    const { sanitizeText } = await import('../sanitize/contentSanitizerCore.js');
     text = sanitizeText(extracted.text);
   }
 


### PR DESCRIPTION
CLI half of the Shared Lib fetch contract (TL ruling t/3310#1) — the interface-first prereq for the PS-standalone fetch surfaces (t/3307, t/3310, t/3313). t/3311 landed the function; PS cmdlets can't call a Node function, so they invoke this CLI.

## Contract (TL t/3310#1 + PS ask p/44#78)
```
node lib/url-fetch/fetch-url-cli.mjs <url> --out <file> [--max-bytes N] [--timeout-ms N]
```
→ writes response bytes to `--out`, prints one line of JSON to stdout:
`{ status, contentType, finalUrl, error, bodySnippet }`
- **status**: 200 on success / the HTTP code on http-error / null on transport failure (ssrf-blocked, timeout, too-large, too-many-redirects, network).
- **bodySnippet**: first ~1KB decoded utf-8 — PS soft-404 liveness heuristic (a 200 whose body is an error page), so PS needn't read `--out`.
- **error**: null on success, else the reason. Exit 0 on ok, 1 on any failure (incl. usage).

Reuses `fetchUrlForPromptBinary` — every SSRF/redirect/timeout/maxBytes guard, no new network logic.

## Packaging — plain `node`, no build/tsx
Plain node can't resolve the fetcher's one runtime non-builtin import (`sanitizeText`, a `.js`-specifier→`.ts`). Fix: made `sanitizeText` a **lazy dynamic import in the text path only** → the module's eager imports are node builtins, so the CLI imports `fetchUrlForPromptBinary` under plain-node type-stripping. Behavior-preserving for the text path (bundled/vitest callers resolve it; `vi.mock` intercepts it). **Not** an SSRF-logic change — the sanitizer is content-processing, not a transport guard.

## Verify
**48/48** — the full `fetchUrlForPrompt` suite passes **unchanged** (lazy-import regression guard) + 11 new CLI (parseArgs, buildOutput status/snippet/exit mapping, and a child_process smoke that also proves plain-node importability). Manually smoked `example.com` (status 200 + 559-byte file) and `127.0.0.1` (ssrf-blocked, exit 1). url-fetch tsc 0, eslint 0. No new dependency.

Closes t/3324; unblocks t/3307 + t/3310 + t/3313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
