### PR TITLE
infra(azure): enable DATA_ROOT_VALIDATION_ENFORCE=1 on staging — gated promotion (t/3305)

### DIFF
--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -586,6 +586,12 @@ var stagingEnvOverrides = [
   { name: 'AI_TRIAD_STATE_ROOT', value: '/mnt/staging-state' }
   // github-api writes go to the staging branch, not main (t/2650 class-B isolation)
   { name: 'GITHUB_BRANCH',       value: 'staging' }
+  // t/3305: promote the data-root boot validation (t/3296) to HARD-FAIL on staging first —
+  // a misprovisioned data root crash-loops VISIBLY here (real backend + real creds) before we
+  // set this in prod baseEnv. Gated real-env-first (t/2683): staging proves the exit(1) path
+  // against the live github-api ref:'main' corpus, which validated CLEAN on the warn-only boot
+  // (rev staging-4826363, no "validation failed" WARN), so enforce mode boots green not looping.
+  { name: 'DATA_ROOT_VALIDATION_ENFORCE', value: '1' }
 ]
 // stagingBaseEnv = baseEnv with the isolation overrides applied.
 // filter() removes the baseEnv entries that stagingEnvOverrides supersedes.


### PR DESCRIPTION
Promote the t/3296 data-root boot validation to HARD-FAIL on staging first (real-env-first,
t/2683). A misprovisioned data root now crash-loops VISIBLY on staging (real github-api ref:'main'
backend + real creds) before we set ENFORCE=1 in prod baseEnv. The warm-only boot on staging rev
staging-4826363 validated CLEAN (no 'validation failed' WARN → taxonomy/+dictionary/ present), so
enforce mode boots green, not crash-looping. Prod flip is the next, separate step (owner-authorized).

Applied to the running staging app via az containerapp update --set-env-vars (in sync with this
bicep source-of-truth) since deploy-staging.yml only triggers on a container build.

Co-Authored-By: DevOps (Orca) <main.operations-devops@ai-triad-research.orca.local>
Co-Authored-By: ServerAPI (Orca) <main.taxonomy-editor-src-server@ai-triad-research.orca.local>
