### PR TITLE
feat(qbaf): fork-B semantic-opposition edges — classifier + numeric detector + enrich wiring (t/3302)

### DIFF
--- a/ai-usages.json
+++ b/ai-usages.json
@@ -550,6 +550,20 @@
       "qbaf"
     ]
   },
+  "enrichment.contradiction-classify": {
+    "description": "Fork-B semantic-opposition (t/3302): classify the logical relation (contradict|entail|neutral) of within-conflict assertion pairs. Per-conflict batch via invoke-contradiction-classifier.ps1; temperature pinned 0 for determinism. CALIBRATION-PROVISIONAL until CL scores the frozen golden (P>=0.85 / R>=0.50).",
+    "model": "gemini-3.5-flash-lite",
+    "temperature": 0,
+    "maxTokens": 2000,
+    "timeoutMs": 60000,
+    "jsonMode": true,
+    "messageTemplate": "{{prompt}}",
+    "tags": [
+      "enrichment",
+      "qbaf",
+      "fork-b"
+    ]
+  },
   "enrichment.logical-form-formalization": {
     "description": "Formalize one claim's proposition into a neo-Davidsonian first-order logical form (t/3126 schema, t/3215 pass). CL owns the schema + prompt (research/comp-linguist/docs/logical-form-schema.md); PowerShell's Invoke-LogicalFormPass renders logical-form-formalization.prompt per claim and runs this over claims carrying entity_refs[]. jsonMode WITHOUT responseSchema — the nested args[]/about[] object tripped Gemini structured-output HTTP 400s (same failure as enrichment.org-stance-extraction); the prompt enforces a single strict-JSON object and the pass parses + validates + grounds defensively. model/temperature are CALIBRATION-PROVISIONAL until CL's D3b formalization_accuracy run against the golden set.",
     "model": "claude-sonnet-4-6",

--- a/scripts/AITriad/Prompts/contradiction-classify.prompt
+++ b/scripts/AITriad/Prompts/contradiction-classify.prompt
@@ -1,0 +1,17 @@
+You classify the logical relation between pairs of factual assertions taken from ONE factual conflict — assertions that address the same underlying question. For each numbered pair, decide the relation between assertion A and assertion B.
+
+PAIRS:
+{{pairs_block}}
+
+Labels:
+- "contradict" = A and B cannot both be true: incompatible content on the same point (opposing magnitude / number / date, negation, mutually exclusive facts).
+- "entail"     = A and B assert the same thing in the same direction (agreement; one restates or is subsumed by the other).
+- "neutral"    = A and B concern different points, or the relation is indeterminate.
+
+Return ONLY this JSON (one object per pair id, EVERY id exactly once, no prose):
+{"results": [{"id": "<pair id>", "label": "contradict" | "entail" | "neutral", "confidence": 0.0}]}
+
+Rules:
+- Judge only the assertion texts. NEVER infer a contradiction from topical proximity alone.
+- Prefer "neutral" when uncertain.
+- "confidence" is your certainty in the chosen label, 0.0–1.0.

--- a/scripts/enrich_conflicts_qbaf.py
+++ b/scripts/enrich_conflicts_qbaf.py
@@ -381,10 +381,11 @@ def _run_qbaf_bridge_batch(batch):
     return [parsed]
 
 
-def enrich_conflict(conflict, node_meta):
+def enrich_conflict(conflict, node_meta, extra_edges=None):
     """Compute QBAF analysis for a single conflict and return the qbaf object.
 
-    Returns None if the conflict doesn't have enough instances for analysis.
+    extra_edges (fork-B semantic-opposition edges, t/3302) are merged after the stance-based edges,
+    deduped on (source, target). Returns None if the conflict has <2 instances.
     """
     instances = conflict.get("instances") or []
     if len(instances) < 2:
@@ -427,8 +428,19 @@ def enrich_conflict(conflict, node_meta):
             node_out["bdi_sub_scores"] = inst["bdi_sub_scores"]
         qbaf_nodes_output.append(node_out)
 
-    # Detect edges
+    # Detect edges (stance-based) + merge fork-B semantic edges (t/3302), deduped on (source,target).
     edges = _detect_edges(instances)
+    if extra_edges:
+        seen = set()
+        for e in edges:
+            seen.add((e["source"], e["target"]))
+            seen.add((e["target"], e["source"]))
+        for e in extra_edges:
+            key = (e["source"], e["target"])
+            if key not in seen:
+                edges.append(e)
+                seen.add(key)
+                seen.add((e["target"], e["source"]))
 
     if not edges:
         # No relationships detected — still useful to record base strengths
@@ -443,7 +455,8 @@ def enrich_conflict(conflict, node_meta):
             "iterations": 0,
         }
 
-    # Return pre-bridge data for batch processing
+    # Return pre-bridge data for batch processing. Provenance fields (detector/edge_origin/confidence)
+    # are persisted in edge_output for audit but stripped from the bridge input (whitelist in main).
     edge_output = []
     for e in edges:
         out = {
@@ -454,6 +467,9 @@ def enrich_conflict(conflict, node_meta):
         }
         if e.get("attack_type"):
             out["attack_type"] = e["attack_type"]
+        for prov in ("detector", "edge_origin", "confidence"):
+            if e.get(prov) is not None:
+                out[prov] = e[prov]
         edge_output.append(out)
 
     return {
@@ -463,6 +479,137 @@ def enrich_conflict(conflict, node_meta):
         "edges": edges,
         "edge_output": edge_output,
     }
+
+
+# ── Fork-B: semantic-opposition edge detection (t/3302, TL-approved seam t/3302#16) ───────
+# Within-conflict pairs with NO stance edge (the recall gap: 97% never attacked) are classified:
+# the deterministic numeric/temporal detector first (high precision), then the LLM contradiction
+# classifier for the rest via the file-based pwsh bridge. contradict->attack, entail->support.
+# Opt-in (--semantic-edges); owner runs the paid classification (--write). CL scores the golden.
+
+_CC_SHIM = _SCRIPT_DIR / "invoke-contradiction-classifier.ps1"
+
+
+def _collect_semantic_candidates(conflict):
+    """Within-conflict pairs that have NO stance-based edge. Same-doc pairs are skipped (duplicate
+    extractions) except debate: (independent agent positions, t/3214). Returns [{i,j,a,b}]."""
+    instances = conflict.get("instances") or []
+    if len(instances) < 2:
+        return []
+    existing = set()
+    for e in _detect_edges(instances):
+        existing.add((e["source"], e["target"]))
+        existing.add((e["target"], e["source"]))
+    cands = []
+    for i in range(len(instances)):
+        for j in range(i + 1, len(instances)):
+            if (f"inst-{i}", f"inst-{j}") in existing:
+                continue
+            a, b = instances[i], instances[j]
+            doc_a = str(a.get("doc_id") or "")
+            if a.get("doc_id") == b.get("doc_id") and not doc_a.startswith("debate:"):
+                continue
+            ta = str(a.get("assertion") or "").strip()
+            tb = str(b.get("assertion") or "").strip()
+            if ta and tb:
+                cands.append({"i": i, "j": j, "a": ta, "b": tb})
+    return cands
+
+
+def _mk_semantic_edge(i, j, detector, edge_type="attacks", confidence=None):
+    edge = {
+        "source": f"inst-{i}",
+        "target": f"inst-{j}",
+        "type": edge_type,
+        "weight": 0.6,
+        "detector": detector,      # 'numeric' | 'llm' — provenance for CL scoring + audit
+        "edge_origin": "semantic",
+    }
+    if edge_type == "attacks":
+        edge["attack_type"] = "rebut"
+    if confidence is not None:
+        edge["confidence"] = round(float(confidence), 4)
+    return edge
+
+
+def _run_cc_shim(batch_conflicts, mode="per-conflict", temperature=0.0):
+    """FILE-BASED bridge to invoke-contradiction-classifier.ps1 (pair texts via a temp-file PATH, NOT
+    inline — quotes/newlines shell-corruption hazard, TL t/3302#16). Returns {id: {label,confidence}}.
+    Fallback: any failure -> {} (no LLM edges) + WARN; never fabricates edges."""
+    import os
+    import tempfile
+    if not batch_conflicts:
+        return {}
+    tmp = None
+    try:
+        fd, tmp = tempfile.mkstemp(suffix=".json", prefix="cc-batch-")
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump({"conflicts": batch_conflicts}, fh, ensure_ascii=False)
+        result = subprocess.run(
+            ["pwsh", "-NoProfile", "-NonInteractive", "-File", str(_CC_SHIM),
+             "-InputPath", tmp, "-Mode", mode, "-Temperature", str(temperature)],
+            capture_output=True, text=True, timeout=600, cwd=str(_PROJECT_ROOT), env=_safe_env(),
+        )
+        if result.returncode != 0:
+            _log(f"  WARN: contradiction-classifier exited {result.returncode} "
+                 f"({result.stderr.strip()[:200]}) — 0 semantic LLM edges (fallback, t/3302).")
+            return {}
+        parsed = json.loads(result.stdout)
+        out = {}
+        for r in parsed.get("results", []):
+            out[str(r.get("id"))] = {"label": r.get("label"), "confidence": r.get("confidence", 0.0)}
+        return out
+    except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError) as exc:
+        _log(f"  WARN: contradiction-classifier failed ({exc}) — 0 semantic LLM edges (fallback, t/3302).")
+        return {}
+    finally:
+        if tmp and os.path.exists(tmp):
+            try:
+                os.remove(tmp)
+            except OSError:
+                pass
+
+
+def detect_semantic_edges(to_process, min_confidence=0.0, mode="per-conflict", cc_runner=None):
+    """Fork-B semantic edges (t/3302). Numeric/temporal detector first (high precision), then the LLM
+    classifier for the rest. Returns {conflict_index: [edge,...]}. cc_runner is injectable for tests."""
+    cc_runner = cc_runner or _run_cc_shim
+    edges_by_ci = {}
+    batch_conflicts = []
+    llm_pairs = {}  # pair-id -> (ci, i, j)
+
+    for ci, (_path, conflict) in enumerate(to_process):
+        cands = _collect_semantic_candidates(conflict)
+        if not cands:
+            continue
+        conflict_pairs = []
+        for c in cands:
+            if _detect_numeric_temporal_conflict(c["a"], c["b"]):
+                edges_by_ci.setdefault(ci, []).append(
+                    _mk_semantic_edge(c["i"], c["j"], "numeric", "attacks", 1.0))
+            else:
+                pid = f"{ci}:{c['i']}:{c['j']}"
+                conflict_pairs.append({"id": pid, "a": c["a"], "b": c["b"]})
+                llm_pairs[pid] = (ci, c["i"], c["j"])
+        if conflict_pairs:
+            batch_conflicts.append({"cid": str(conflict.get("claim_id") or ci), "pairs": conflict_pairs})
+
+    if batch_conflicts:
+        results = cc_runner(batch_conflicts, mode, 0.0)
+        for pid, (ci, i, j) in llm_pairs.items():
+            r = results.get(pid)
+            if not r:
+                continue
+            conf = float(r.get("confidence") or 0.0)
+            if conf < min_confidence:
+                continue
+            label = r.get("label")
+            if label == "contradict":
+                edges_by_ci.setdefault(ci, []).append(_mk_semantic_edge(i, j, "llm", "attacks", conf))
+            elif label == "entail":
+                edges_by_ci.setdefault(ci, []).append(_mk_semantic_edge(i, j, "llm", "supports", conf))
+            # neutral / unresolved / missing -> no edge
+    return edges_by_ci
 
 
 # Resolution margin floor (t/3151, CL neutrality ruling t/3151#2). computed_strength is DF-QuAD
@@ -537,6 +684,13 @@ def main():
                         help="Process a single conflict by claim_id")
     parser.add_argument("--force", action="store_true",
                         help="Recompute QBAF even if already present")
+    parser.add_argument("--semantic-edges", action="store_true",
+                        help="Fork-B (t/3302): add semantic-opposition edges for within-conflict "
+                             "pairs with no stance edge (numeric/temporal detector + LLM classifier)")
+    parser.add_argument("--semantic-min-confidence", type=float, default=0.0,
+                        help="Min LLM confidence to accept a semantic edge (calibrate from CL's P/R curve)")
+    parser.add_argument("--classify-mode", choices=["per-conflict", "per-pair"], default="per-conflict",
+                        help="LLM classify batching mode (per-conflict batch with per-pair fallback)")
     args = parser.parse_args()
 
     _log("=" * 60)
@@ -596,13 +750,25 @@ def main():
     # t/3302 observability — aggregate testedness tiers across this run (CL schema t/3302#2).
     tier_counts = {"all_prior": 0, "support_only": 0, "adversarial": 0}
 
+    # Fork-B semantic-opposition pre-pass (t/3302). Computes extra edges per conflict index BEFORE
+    # phase 1 so they merge into the same QBAF graph. Opt-in (--semantic-edges); the LLM path is
+    # paid so the owner runs it under --write.
+    semantic_by_ci = {}
+    if getattr(args, "semantic_edges", False):
+        _log(f"\n  Fork-B: detecting semantic-opposition edges (mode={args.classify_mode}, "
+             f"min_conf={args.semantic_min_confidence})...")
+        semantic_by_ci = detect_semantic_edges(
+            to_process, min_confidence=args.semantic_min_confidence, mode=args.classify_mode)
+        _n_sem = sum(len(v) for v in semantic_by_ci.values())
+        _log(f"  Fork-B: {_n_sem} semantic edge(s) across {len(semantic_by_ci)} conflict(s).")
+
     # Phase 1: build local graphs (no subprocess)
     pre_results = []  # (index, path, conflict, pre_data_or_qbaf)
     bridge_batch = []  # items needing bridge computation
     bridge_indices = []  # indices into pre_results for bridge items
 
     for i, (path, conflict) in enumerate(to_process):
-        pre = enrich_conflict(conflict, node_meta)
+        pre = enrich_conflict(conflict, node_meta, extra_edges=semantic_by_ci.get(i))
 
         if pre is None:
             pre_results.append((i, path, conflict, None))
@@ -612,8 +778,10 @@ def main():
             pre_results.append((i, path, conflict, pre))
             bridge_batch.append({
                 "nodes": pre["qbaf_nodes_input"],
+                # Whitelist ONLY the bridge's schema fields — strip attack_type + the fork-B provenance
+                # (detector/edge_origin/confidence), which the DF-QuAD bridge doesn't accept.
                 "edges": [
-                    {k: v for k, v in e.items() if k != "attack_type"}
+                    {"source": e["source"], "target": e["target"], "type": e["type"], "weight": e["weight"]}
                     for e in pre["edges"]
                 ],
             })

--- a/scripts/enrich_conflicts_qbaf.py
+++ b/scripts/enrich_conflicts_qbaf.py
@@ -541,20 +541,26 @@ def _run_cc_shim(batch_conflicts, mode="per-conflict", temperature=0.0):
     if not batch_conflicts:
         return {}
     tmp = None
+    out_tmp = None
     try:
         fd, tmp = tempfile.mkstemp(suffix=".json", prefix="cc-batch-")
         with os.fdopen(fd, "w", encoding="utf-8") as fh:
             json.dump({"conflicts": batch_conflicts}, fh, ensure_ascii=False)
+        # Results come back via a FILE (-OutPath), not stdout: the shim's Write-Warning fallback notices
+        # render onto stdout ahead of the JSON and break json.loads (t/3302 live-run failure).
+        out_fd, out_tmp = tempfile.mkstemp(suffix=".json", prefix="cc-out-")
+        os.close(out_fd)
         result = subprocess.run(
             ["pwsh", "-NoProfile", "-NonInteractive", "-File", str(_CC_SHIM),
-             "-InputPath", tmp, "-Mode", mode, "-Temperature", str(temperature)],
+             "-InputPath", tmp, "-Mode", mode, "-Temperature", str(temperature), "-OutPath", out_tmp],
             capture_output=True, text=True, timeout=600, cwd=str(_PROJECT_ROOT), env=_safe_env(),
         )
         if result.returncode != 0:
             _log(f"  WARN: contradiction-classifier exited {result.returncode} "
                  f"({result.stderr.strip()[:200]}) — 0 semantic LLM edges (fallback, t/3302).")
             return {}
-        parsed = json.loads(result.stdout)
+        with open(out_tmp, "r", encoding="utf-8") as fh:
+            parsed = json.loads(fh.read())
         out = {}
         for r in parsed.get("results", []):
             out[str(r.get("id"))] = {"label": r.get("label"), "confidence": r.get("confidence", 0.0)}
@@ -563,11 +569,12 @@ def _run_cc_shim(batch_conflicts, mode="per-conflict", temperature=0.0):
         _log(f"  WARN: contradiction-classifier failed ({exc}) — 0 semantic LLM edges (fallback, t/3302).")
         return {}
     finally:
-        if tmp and os.path.exists(tmp):
-            try:
-                os.remove(tmp)
-            except OSError:
-                pass
+        for _p in (tmp, out_tmp):
+            if _p and os.path.exists(_p):
+                try:
+                    os.remove(_p)
+                except OSError:
+                    pass
 
 
 def detect_semantic_edges(to_process, min_confidence=0.0, mode="per-conflict", cc_runner=None):

--- a/scripts/enrich_conflicts_qbaf.py
+++ b/scripts/enrich_conflicts_qbaf.py
@@ -20,6 +20,7 @@ Usage:
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 import time
@@ -193,6 +194,78 @@ def _detect_edges(instances):
                 })
 
     return edges
+
+
+# ── Fork-B: deterministic numeric/temporal contradiction detector (t/3302) ────────────────
+# TL's mandatory high-precision complement to the LLM classifier (the naive strawman caught 0/6).
+# Fires ONLY when two within-conflict assertions share a subject AND cite directly incompatible
+# quantities of the SAME kind (percentages, years, or bare numbers). Conservative by design — a miss
+# is fine (the LLM classifier / base prior covers it); a false attack CORRUPTS strength. CL scores
+# its precision/recall separately on the golden (edges carry detector='numeric').
+
+_CC_STOPWORDS = frozenset(
+    "the a an of to in on for and or but with by from as at is are was were be been being this that "
+    "these those it its their his her our your not no than then over under about into within will "
+    "would could should may might can has have had do does did more most less least very".split()
+)
+_CC_WORD_RE = re.compile(r"[a-z]{3,}")
+_CC_PCT_RE = re.compile(r"(\d+(?:\.\d+)?)\s*(?:%|percent|percentage points?|pp\b)", re.IGNORECASE)
+_CC_YEAR_RE = re.compile(r"\b(19\d{2}|20\d{2})\b")
+_CC_NUM_RE = re.compile(r"(?<![\w.])(\d+(?:\.\d+)?)")
+
+
+def _cc_content_words(text):
+    return {w for w in _CC_WORD_RE.findall((text or "").lower()) if w not in _CC_STOPWORDS}
+
+
+def _cc_percents(text):
+    return {round(float(m.group(1)), 3) for m in _CC_PCT_RE.finditer(text or "")}
+
+
+def _cc_years(text):
+    return {int(m.group(1)) for m in _CC_YEAR_RE.finditer(text or "")}
+
+
+def _cc_bare_numbers(text):
+    """Numbers that are neither a percentage value nor a 4-digit year."""
+    t = text or ""
+    pct_spans = [m.span(1) for m in _CC_PCT_RE.finditer(t)]
+    years = _cc_years(t)
+    out = set()
+    for m in _CC_NUM_RE.finditer(t):
+        if any(s <= m.start(1) < e for (s, e) in pct_spans):
+            continue
+        try:
+            f = float(m.group(1))
+        except ValueError:
+            continue
+        if f == int(f) and int(f) in years:
+            continue
+        out.add(round(f, 3))
+    return out
+
+
+def _detect_numeric_temporal_conflict(text_a, text_b):
+    """True iff A and B share a subject AND cite directly incompatible quantities of the same kind.
+
+    Conservative (high precision): requires >=3 shared content words, and a same-kind numeric set that
+    is non-empty on BOTH sides and disjoint (percentages, years, or bare numbers). Bare numbers demand
+    a stronger subject overlap (>=4) since they are the most ambiguous. Returns False on any doubt.
+    """
+    shared = _cc_content_words(text_a) & _cc_content_words(text_b)
+    if len(shared) < 3:
+        return False
+    pa, pb = _cc_percents(text_a), _cc_percents(text_b)
+    if pa and pb and pa.isdisjoint(pb):
+        return True
+    ya, yb = _cc_years(text_a), _cc_years(text_b)
+    if ya and yb and ya.isdisjoint(yb):
+        return True
+    if len(shared) >= 4:
+        na, nb = _cc_bare_numbers(text_a), _cc_bare_numbers(text_b)
+        if na and nb and na.isdisjoint(nb):
+            return True
+    return False
 
 
 def _qbaf_testedness(qbaf, instances):

--- a/scripts/invoke-contradiction-classifier.ps1
+++ b/scripts/invoke-contradiction-classifier.ps1
@@ -21,7 +21,12 @@ param(
     # dot-source with a missing-parameter error). main() validates it below.
     [string]$InputPath = '',
     [ValidateSet('per-conflict', 'per-pair')][string]$Mode = 'per-conflict',
-    [ValidateRange(0.0, 2.0)][double]$Temperature = 0.0
+    [ValidateRange(0.0, 2.0)][double]$Temperature = 0.0,
+    # When set, JSON results are written to this FILE instead of stdout. Callers should prefer this:
+    # PowerShell's Write-Warning fallback notices render onto the captured stdout stream ahead of the
+    # JSON line, corrupting a caller's ConvertFrom-Json/json.loads (t/3302 live-run failure). A file is
+    # the clean data channel; warnings stay on the console for the operator. Empty => stdout (legacy).
+    [string]$OutPath = ''
 )
 
 Set-StrictMode -Version Latest
@@ -119,6 +124,25 @@ function Convert-ContradictionPairs {
     return @($out)
 }
 
+function Write-CCResult {
+    <#
+    .SYNOPSIS
+        Emit the results object. When -OutPath is given, JSON goes to that FILE (the clean data channel);
+        otherwise to stdout (legacy). Callers should prefer -OutPath: PowerShell's Write-Warning fallback
+        notices render onto captured stdout ahead of the JSON and break a caller's parse (t/3302 live-run
+        failure). Pure apart from the single Set-Content write — dot-source unit-tested.
+    #>
+    [CmdletBinding()]
+    param([object[]]$Results, [string]$OutPath = '')
+    $json = [ordered]@{ results = @($Results) } | ConvertTo-Json -Depth 6 -Compress
+    if (-not [string]::IsNullOrWhiteSpace($OutPath)) {
+        Set-Content -LiteralPath $OutPath -Value $json -Encoding utf8
+    }
+    else {
+        $json | Write-Output
+    }
+}
+
 # ── main (skipped when dot-sourced for unit tests: $env:CC_CLASSIFIER_NOEXEC) ──
 if (-not $env:CC_CLASSIFIER_NOEXEC) {
     $ErrorActionPreference = 'Stop'
@@ -144,5 +168,5 @@ if (-not $env:CC_CLASSIFIER_NOEXEC) {
         }
     }
 
-    [ordered]@{ results = @($allResults) } | ConvertTo-Json -Depth 6 -Compress | Write-Output
+    Write-CCResult -Results @($allResults) -OutPath $OutPath
 }

--- a/scripts/invoke-contradiction-classifier.ps1
+++ b/scripts/invoke-contradiction-classifier.ps1
@@ -58,10 +58,14 @@ function Invoke-CCModel {
         $resp     = Invoke-AIByUsage -UsageId 'enrichment.contradiction-classify' `
             -Values @{ prompt = $rendered } -Override @{ temperature = $Temperature } -ErrorAction Stop
         if (-not $resp -or -not $resp.PSObject.Properties['Text'] -or [string]::IsNullOrWhiteSpace($resp.Text)) {
+            Write-Warning "contradiction-classify: backend returned no Text for $(@($Pairs).Count) pair(s) — check the model/key for usage 'enrichment.contradiction-classify'."
             return $null
         }
         $parsed = $resp.Text | ConvertFrom-Json -ErrorAction Stop
-        if (-not $parsed.PSObject.Properties['results']) { return $null }
+        if (-not $parsed.PSObject.Properties['results']) {
+            Write-Warning "contradiction-classify: backend Text was not the expected { results: [...] } JSON."
+            return $null
+        }
         $map = @{}
         foreach ($r in @($parsed.results)) {
             # Positive guard (no `continue`): a `continue` inside a function escapes to Pester's
@@ -77,6 +81,9 @@ function Invoke-CCModel {
         return $map
     }
     catch {
+        # Log the WHY (project rule: log every fallback path + reason). The underlying exception here is
+        # usually a missing/invalid key or an unregistered model for usage 'enrichment.contradiction-classify'.
+        Write-Warning "contradiction-classify: model call failed: $($_.Exception.Message)"
         return $null
     }
 }
@@ -157,6 +164,13 @@ if (-not $env:CC_CLASSIFIER_NOEXEC) {
 
     $ModulePath = Join-Path $PSScriptRoot 'AITriad' 'AITriad.psd1'
     Import-Module $ModulePath -Force -ErrorAction Stop
+
+    # Get-Prompt is a module-PRIVATE helper — Import-Module does NOT expose it to this standalone
+    # script's scope, so a bare call fails with 'Get-Prompt is not recognized' (t/3302 live-run root
+    # cause). Dot-source it here and set $script:ModuleRoot so its default Prompts/ dir resolves.
+    # (Invoke-AIByUsage IS exported, so it needs no such handling.)
+    $script:ModuleRoot = Join-Path $PSScriptRoot 'AITriad'
+    . (Join-Path $PSScriptRoot 'AITriad' 'Private' 'Get-Prompt.ps1')
 
     $allResults = [System.Collections.Generic.List[object]]::new()
     if ($batch.PSObject.Properties['conflicts']) {

--- a/scripts/invoke-contradiction-classifier.ps1
+++ b/scripts/invoke-contradiction-classifier.ps1
@@ -1,0 +1,148 @@
+#Requires -Version 7
+# Fork-B contradiction-classifier bridge (t/3302, TL-approved seam t/3302#16).
+#
+# Python (enrich_conflicts_qbaf.py) writes the pair texts to a temp JSON file and passes the PATH
+# here — NOT inline as args/stdin text. Assertion texts carry quotes/newlines, the #1 shell-corruption
+# hazard (TL load-bearing condition: FILE-BASED marshaling across the Python<->pwsh boundary).
+#
+# Classifies each within-conflict assertion pair as contradict|entail|neutral via Invoke-AIByUsage
+# (reuses the module's key-mgmt / rate-limiting / AI-call-log). Per-conflict BATCH first; on a
+# malformed/incomplete batch response, FALL BACK to per-pair for the missing ids — a pair is NEVER
+# silently dropped (unclassifiable -> label 'unresolved', which the caller treats as "no edge").
+# Temperature pinned 0 for determinism.
+#
+# Input file JSON:  { "conflicts": [ { "cid": "<id>", "pairs": [ {"id","a","b"}, ... ] }, ... ] }
+# stdout JSON:      { "results": [ {"id","label","confidence","method"}, ... ] }
+#   label  : contradict | entail | neutral | unresolved
+#   method : llm-batch | llm-perpair | unresolved
+[CmdletBinding()]
+param(
+    # Non-mandatory so the file can be dot-sourced for unit tests (a Mandatory param blocks
+    # dot-source with a missing-parameter error). main() validates it below.
+    [string]$InputPath = '',
+    [ValidateSet('per-conflict', 'per-pair')][string]$Mode = 'per-conflict',
+    [ValidateRange(0.0, 2.0)][double]$Temperature = 0.0
+)
+
+Set-StrictMode -Version Latest
+
+$script:CC_VALID_LABELS = @('contradict', 'entail', 'neutral')
+
+function Format-CCPairsBlock {
+    # Render pairs into the prompt's {{pairs_block}}. PS string only — no shell — so quotes/newlines
+    # in the assertion texts are safe.
+    param([object[]]$Pairs)
+    $sb = [System.Text.StringBuilder]::new()
+    foreach ($p in $Pairs) {
+        [void]$sb.AppendLine("### pair $($p.id)")
+        [void]$sb.AppendLine("A: $([string]$p.a)")
+        [void]$sb.AppendLine("B: $([string]$p.b)")
+        [void]$sb.AppendLine("")
+    }
+    return $sb.ToString().TrimEnd()
+}
+
+function Invoke-CCModel {
+    # One AI call over a pair list. Returns a hashtable id -> @{label; confidence}, or $null on any
+    # failure (unavailable / non-JSON / no results). Fallback-path failures are the caller's problem.
+    param([object[]]$Pairs, [double]$Temperature)
+    if (-not $Pairs -or @($Pairs).Count -eq 0) { return @{} }
+    try {
+        $block    = Format-CCPairsBlock -Pairs $Pairs
+        $rendered = Get-Prompt -Name 'contradiction-classify' -Replacements @{ pairs_block = $block }
+        $resp     = Invoke-AIByUsage -UsageId 'enrichment.contradiction-classify' `
+            -Values @{ prompt = $rendered } -Override @{ temperature = $Temperature } -ErrorAction Stop
+        if (-not $resp -or -not $resp.PSObject.Properties['Text'] -or [string]::IsNullOrWhiteSpace($resp.Text)) {
+            return $null
+        }
+        $parsed = $resp.Text | ConvertFrom-Json -ErrorAction Stop
+        if (-not $parsed.PSObject.Properties['results']) { return $null }
+        $map = @{}
+        foreach ($r in @($parsed.results)) {
+            # Positive guard (no `continue`): a `continue` inside a function escapes to Pester's
+            # enclosing loop under issue #2669 and silently aborts the run.
+            if ($r.PSObject.Properties['id'] -and $r.PSObject.Properties['label']) {
+                $label = [string]$r.label
+                if ($label -in $script:CC_VALID_LABELS) {
+                    $conf = if ($r.PSObject.Properties['confidence']) { [double]$r.confidence } else { 0.0 }
+                    $map[[string]$r.id] = @{ label = $label; confidence = [Math]::Round($conf, 4) }
+                }
+            }
+        }
+        return $map
+    }
+    catch {
+        return $null
+    }
+}
+
+function Convert-ContradictionPairs {
+    # Classify one conflict's pairs. Batch-first with per-pair fallback on missing/malformed ids.
+    # Returns [{id; label; confidence; method}] — one entry per input pair, never fewer.
+    param(
+        [object[]]$Pairs,
+        [ValidateSet('per-conflict', 'per-pair')][string]$Mode = 'per-conflict',
+        [double]$Temperature = 0.0
+    )
+    $out = [System.Collections.Generic.List[object]]::new()
+    if (-not $Pairs -or @($Pairs).Count -eq 0) { return @($out) }
+
+    $batchMap = @{}
+    if ($Mode -eq 'per-conflict') {
+        $r = Invoke-CCModel -Pairs $Pairs -Temperature $Temperature
+        if ($null -ne $r) { $batchMap = $r }
+        else {
+            Write-Warning "contradiction-classify: batch call failed/empty for a conflict of $(@($Pairs).Count) pair(s) — falling back to per-pair (t/3302)."
+        }
+    }
+
+    # Positive-guard branches only (no `continue`) — see Invoke-CCModel note re: Pester #2669.
+    foreach ($p in $Pairs) {
+        # NB: $pairId, not $pid — $PID is a read-only PowerShell automatic variable (the process id).
+        $pairId = [string]$p.id
+        if ($batchMap.ContainsKey($pairId)) {
+            $out.Add([ordered]@{ id = $pairId; label = $batchMap[$pairId].label; confidence = $batchMap[$pairId].confidence; method = 'llm-batch' })
+        }
+        else {
+            # Missing from the batch (or per-pair mode) -> classify this single pair on its own.
+            $single = Invoke-CCModel -Pairs @($p) -Temperature $Temperature
+            if ($null -ne $single -and $single.ContainsKey($pairId)) {
+                $out.Add([ordered]@{ id = $pairId; label = $single[$pairId].label; confidence = $single[$pairId].confidence; method = 'llm-perpair' })
+            }
+            else {
+                # Never silently drop — emit an explicit unresolved (caller adds no edge) + WARN.
+                Write-Warning "contradiction-classify: pair '$pairId' unresolved after batch + per-pair fallback — emitting 'unresolved' (no edge, t/3302)."
+                $out.Add([ordered]@{ id = $pairId; label = 'unresolved'; confidence = 0.0; method = 'unresolved' })
+            }
+        }
+    }
+    return @($out)
+}
+
+# ── main (skipped when dot-sourced for unit tests: $env:CC_CLASSIFIER_NOEXEC) ──
+if (-not $env:CC_CLASSIFIER_NOEXEC) {
+    $ErrorActionPreference = 'Stop'
+
+    if ([string]::IsNullOrWhiteSpace($InputPath)) {
+        throw "invoke-contradiction-classifier: -InputPath is required."
+    }
+    if (-not (Test-Path -LiteralPath $InputPath -PathType Leaf)) {
+        throw "invoke-contradiction-classifier: input file not found: '$InputPath'"
+    }
+    $batch = Get-Content -LiteralPath $InputPath -Raw | ConvertFrom-Json
+
+    $ModulePath = Join-Path $PSScriptRoot 'AITriad' 'AITriad.psd1'
+    Import-Module $ModulePath -Force -ErrorAction Stop
+
+    $allResults = [System.Collections.Generic.List[object]]::new()
+    if ($batch.PSObject.Properties['conflicts']) {
+        foreach ($c in @($batch.conflicts)) {
+            $pairs = if ($c.PSObject.Properties['pairs']) { @($c.pairs) } else { @() }
+            foreach ($res in (Convert-ContradictionPairs -Pairs $pairs -Mode $Mode -Temperature $Temperature)) {
+                $allResults.Add($res)
+            }
+        }
+    }
+
+    [ordered]@{ results = @($allResults) } | ConvertTo-Json -Depth 6 -Compress | Write-Output
+}

--- a/scripts/run-semantic-golden-classifier.ps1
+++ b/scripts/run-semantic-golden-classifier.ps1
@@ -1,0 +1,214 @@
+#Requires -Version 7
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+#
+# Fork-B validation runner (t/3302) — the ONE paid command for the semantic-opposition gate.
+#
+# Reads CL's frozen blind golden (semantic-opposition-golden.json, 122 pairs), runs each within-conflict
+# assertion pair through the contradiction classifier (invoke-contradiction-classifier.ps1, per-conflict
+# batch + per-pair fallback), and writes a PREDICTIONS file that CL scores against the golden labels/splits
+# (precision on REP held_out, recall on all held_out contradicts, P/R curve). This script produces
+# predictions ONLY — it does NOT compute the gate metrics (CL owns scoring, to keep the grader independent
+# of the code under test). A pair is never dropped: a missing/unresolved classifier verdict → predicted
+# 'unresolved' (= no edge), so precision/recall denominators stay honest.
+#
+# PAID: the classifier calls the AI backend (Invoke-AIByUsage). Set GEMINI_API_KEY (or register a backend)
+# before running. Bounded to the golden's 122 pairs (~ one batch per conflict + per-pair fallbacks).
+#
+#   pwsh -File scripts/run-semantic-golden-classifier.ps1 -OutPath predictions.json
+#
+# Pure transforms (ConvertTo-CCInput / Join-CCPredictions) are dot-source unit-tested with
+# $env:SEMGOLD_RUNNER_NOEXEC set (no AI, no subprocess).
+[CmdletBinding()]
+param(
+    # Non-mandatory so the file can be dot-sourced for unit tests (a Mandatory param blocks dot-source).
+    [string]$GoldenPath = '',
+    [string]$OutPath = '',
+    [ValidateSet('per-conflict', 'per-pair')][string]$Mode = 'per-conflict'
+)
+
+Set-StrictMode -Version Latest
+
+function Get-GoldenPairField {
+    # StrictMode-safe read of a property that may be absent on a ConvertFrom-Json object.
+    param([object]$Obj, [string]$Name, $Default = $null)
+    if ($Obj.PSObject.Properties[$Name]) { return $Obj.$Name }
+    return $Default
+}
+
+function ConvertTo-CCInput {
+    <#
+    .SYNOPSIS
+        Map golden pairs -> the classifier's frozen input contract, grouped by conflict for batch mode:
+        { conflicts: [ { cid, pairs: [ { id, a, b } ] } ] }.  Pure; no AI, no I/O.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param([Parameter(Mandatory)][object[]]$Pairs)
+
+    $byConflict = [ordered]@{}
+    foreach ($p in $Pairs) {
+        $cid = [string](Get-GoldenPairField $p 'conflict_id' 'unknown-conflict')
+        if (-not $byConflict.Contains($cid)) {
+            $byConflict[$cid] = [System.Collections.Generic.List[object]]::new()
+        }
+        $byConflict[$cid].Add([ordered]@{
+                id = [string](Get-GoldenPairField $p 'pair_id')
+                a  = [string](Get-GoldenPairField $p 'assertion_a')
+                b  = [string](Get-GoldenPairField $p 'assertion_b')
+            })
+    }
+
+    $conflicts = [System.Collections.Generic.List[object]]::new()
+    foreach ($cid in $byConflict.Keys) {
+        $conflicts.Add([ordered]@{ cid = $cid; pairs = @($byConflict[$cid]) })
+    }
+    return @{ conflicts = @($conflicts) }
+}
+
+function Join-CCPredictions {
+    <#
+    .SYNOPSIS
+        Join classifier results (keyed by pair id) back onto the golden pairs, carrying the gold label,
+        pool, and split so CL's scorer has everything in one file. A pair with no result -> predicted
+        'unresolved' / method 'missing' (never silently dropped). Pure; no AI, no I/O.
+    #>
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory)][object[]]$Pairs,
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Results
+    )
+
+    $map = @{}
+    foreach ($r in $Results) {
+        $id = [string](Get-GoldenPairField $r 'id')
+        if (-not [string]::IsNullOrWhiteSpace($id)) { $map[$id] = $r }
+    }
+
+    $out = [System.Collections.Generic.List[object]]::new()
+    foreach ($p in $Pairs) {
+        $pid2 = [string](Get-GoldenPairField $p 'pair_id')   # $pid is a read-only automatic variable
+        if ($map.ContainsKey($pid2)) {
+            $r = $map[$pid2]
+            $predicted = [string](Get-GoldenPairField $r 'label' 'unresolved')
+            $confidence = [double](Get-GoldenPairField $r 'confidence' 0.0)
+            $method = [string](Get-GoldenPairField $r 'method' 'unknown')
+        }
+        else {
+            $predicted = 'unresolved'
+            $confidence = 0.0
+            $method = 'missing'
+        }
+        $out.Add([ordered]@{
+                pair_id        = $pid2
+                conflict_id    = [string](Get-GoldenPairField $p 'conflict_id')
+                gold_label     = [string](Get-GoldenPairField $p 'label')
+                predicted      = $predicted
+                confidence     = $confidence
+                method         = $method
+                pool           = [string](Get-GoldenPairField $p 'pool')
+                split          = [string](Get-GoldenPairField $p 'split')
+                stratum        = [string](Get-GoldenPairField $p 'stratum')
+                precision_trap = [bool](Get-GoldenPairField $p 'precision_trap' $false)
+            })
+    }
+    return @($out)
+}
+
+function Invoke-CCClassifier {
+    # Run the classifier as a child pwsh process (it imports the module + calls the AI backend in its main).
+    # Returns the parsed results array. Isolated so the paid boundary is a single call site.
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param([Parameter(Mandatory)][string]$InputPath, [string]$Mode = 'per-conflict')
+
+    $classifier = Join-Path $PSScriptRoot 'invoke-contradiction-classifier.ps1'
+    if (-not (Test-Path -LiteralPath $classifier -PathType Leaf)) {
+        throw (New-ActionableError -PassThru -ErrorType 'ClassifierMissing' `
+                -Goal 'Run the semantic-opposition golden through the contradiction classifier' `
+                -Problem "invoke-contradiction-classifier.ps1 not found next to this runner ('$classifier')" `
+                -Location 'run-semantic-golden-classifier.ps1' `
+                -NextSteps @('Run from the fork-B branch (feat/qbaf-semantic-classifier-t3302), where the classifier lives'))
+    }
+    $raw = & pwsh -NoProfile -File $classifier -InputPath $InputPath -Mode $Mode
+    $text = ($raw -join "`n").Trim()
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        throw (New-ActionableError -PassThru -ErrorType 'ClassifierNoOutput' `
+                -Goal 'Run the semantic-opposition golden through the contradiction classifier' `
+                -Problem 'the classifier produced no stdout — likely a missing API key or backend error' `
+                -Location 'run-semantic-golden-classifier.ps1' `
+                -NextSteps @('Set GEMINI_API_KEY (or Register-AIBackend) and retry', 'Check the classifier stderr above for the AI error'))
+    }
+    $parsed = $text | ConvertFrom-Json
+    if (-not $parsed.PSObject.Properties['results']) {
+        throw (New-ActionableError -PassThru -ErrorType 'ClassifierBadOutput' `
+                -Goal 'Run the semantic-opposition golden through the contradiction classifier' `
+                -Problem "the classifier stdout was not the expected { results: [...] } shape" `
+                -Location 'run-semantic-golden-classifier.ps1' `
+                -NextSteps @('Inspect the raw classifier output above'))
+    }
+    return @($parsed.results)
+}
+
+# ── main (skipped when dot-sourced for unit tests: $env:SEMGOLD_RUNNER_NOEXEC) ──
+if (-not $env:SEMGOLD_RUNNER_NOEXEC) {
+    $ErrorActionPreference = 'Stop'
+    Import-Module (Join-Path $PSScriptRoot 'AITriad' 'AITriad.psd1') -Force -ErrorAction Stop
+
+    if ([string]::IsNullOrWhiteSpace($GoldenPath)) {
+        $GoldenPath = Join-Path $PSScriptRoot '..' 'research' 'comp-linguist' 'analyses' 'semantic-opposition-golden' 'semantic-opposition-golden.json'
+    }
+    if (-not (Test-Path -LiteralPath $GoldenPath -PathType Leaf)) {
+        throw (New-ActionableError -PassThru -ErrorType 'GoldenMissing' `
+                -Goal 'Score the contradiction classifier against the frozen golden' `
+                -Problem "golden not found: '$GoldenPath'" `
+                -Location 'run-semantic-golden-classifier.ps1' `
+                -NextSteps @('Pass -GoldenPath, or run from a checkout that includes research/comp-linguist/analyses/semantic-opposition-golden/'))
+    }
+    if ([string]::IsNullOrWhiteSpace($OutPath)) { $OutPath = Join-Path (Get-Location) 'semantic-golden-predictions.json' }
+
+    $golden = Get-Content -LiteralPath $GoldenPath -Raw | ConvertFrom-Json
+    $pairs = @(Get-GoldenPairField $golden 'pairs' @())
+    if (@($pairs).Count -eq 0) {
+        throw (New-ActionableError -PassThru -ErrorType 'GoldenEmpty' `
+                -Goal 'Score the contradiction classifier against the frozen golden' `
+                -Problem "the golden at '$GoldenPath' has no 'pairs'" `
+                -Location 'run-semantic-golden-classifier.ps1' `
+                -NextSteps @('Confirm the golden JSON has a top-level pairs[] array'))
+    }
+
+    Write-Host "Golden: $(@($pairs).Count) pairs from $GoldenPath" -ForegroundColor Cyan
+    $ccInput = ConvertTo-CCInput -Pairs $pairs
+    Write-Host "Grouped into $(@($ccInput.conflicts).Count) conflict batch(es); mode=$Mode. Calling classifier (PAID)..." -ForegroundColor Cyan
+
+    $tmpIn = [System.IO.Path]::GetTempFileName()
+    try {
+        $ccInput | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $tmpIn -Encoding utf8
+        $results = Invoke-CCClassifier -InputPath $tmpIn -Mode $Mode
+    }
+    finally {
+        Remove-Item -LiteralPath $tmpIn -Force -ErrorAction SilentlyContinue
+    }
+
+    $predictions = Join-CCPredictions -Pairs $pairs -Results $results
+
+    $doc = [ordered]@{
+        _meta       = [ordered]@{
+            ticket      = 't/3302'
+            purpose     = 'Fork-B semantic-opposition classifier predictions (hand to CL to score)'
+            golden_path = $GoldenPath
+            mode        = $Mode
+            n_pairs     = @($pairs).Count
+            note        = 'Predictions only. CL scores precision (REP held_out) / recall (all held_out contradicts) + P/R curve vs the gold labels.'
+        }
+        predictions = @($predictions)
+    }
+    $doc | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $OutPath -Encoding utf8
+
+    $n = @($predictions).Count
+    $nContradict = @($predictions | Where-Object { $_.predicted -eq 'contradict' }).Count
+    $nMissing = @($predictions | Where-Object { $_.method -eq 'missing' }).Count
+    Write-Host "Wrote $n predictions -> $OutPath  (predicted contradict: $nContradict; missing: $nMissing)" -ForegroundColor Green
+    Write-Host "Next: hand $OutPath to CL (Main (Comp Linguist)) to score against the golden's blind labels/splits." -ForegroundColor Green
+}

--- a/scripts/run-semantic-golden-classifier.ps1
+++ b/scripts/run-semantic-golden-classifier.ps1
@@ -131,22 +131,40 @@ function Invoke-CCClassifier {
                 -Location 'run-semantic-golden-classifier.ps1' `
                 -NextSteps @('Run from the fork-B branch (feat/qbaf-semantic-classifier-t3302), where the classifier lives'))
     }
-    $raw = & pwsh -NoProfile -File $classifier -InputPath $InputPath -Mode $Mode
-    $text = ($raw -join "`n").Trim()
-    if ([string]::IsNullOrWhiteSpace($text)) {
+    # Read results from a FILE, not stdout: the classifier's Write-Warning fallback notices render onto
+    # captured stdout ahead of the JSON and break ConvertFrom-Json (t/3302 live-run failure). Warnings
+    # flow to the console (operator sees progress); the data channel is the file.
+    $resultsFile = [System.IO.Path]::GetTempFileName()
+    $exit = 0
+    $text = ''
+    try {
+        # Discard the child's success-stream output ($null =): warnings/host lines would otherwise
+        # pollute this function's output. The data is read from $resultsFile below.
+        $null = & pwsh -NoProfile -NonInteractive -File $classifier -InputPath $InputPath -Mode $Mode -OutPath $resultsFile
+        $exit = $LASTEXITCODE
+        if (Test-Path -LiteralPath $resultsFile) { $text = [string](Get-Content -LiteralPath $resultsFile -Raw) }
+    }
+    finally {
+        Remove-Item -LiteralPath $resultsFile -Force -ErrorAction SilentlyContinue
+    }
+
+    if ($exit -ne 0 -or [string]::IsNullOrWhiteSpace($text)) {
         throw (New-ActionableError -PassThru -ErrorType 'ClassifierNoOutput' `
                 -Goal 'Run the semantic-opposition golden through the contradiction classifier' `
-                -Problem 'the classifier produced no stdout — likely a missing API key or backend error' `
+                -Problem "the classifier wrote no results (exit $exit) — likely a missing API key or backend error" `
                 -Location 'run-semantic-golden-classifier.ps1' `
-                -NextSteps @('Set GEMINI_API_KEY (or Register-AIBackend) and retry', 'Check the classifier stderr above for the AI error'))
+                -NextSteps @('Set GEMINI_API_KEY (or Register-AIBackend) and retry', 'Check the classifier warnings above for the AI error'))
     }
-    $parsed = $text | ConvertFrom-Json
-    if (-not $parsed.PSObject.Properties['results']) {
+
+    $parsed = $null
+    try { $parsed = $text | ConvertFrom-Json } catch { $parsed = $null }
+    if ($null -eq $parsed -or -not $parsed.PSObject.Properties['results']) {
+        $snip = $text.Substring(0, [Math]::Min(200, $text.Length))
         throw (New-ActionableError -PassThru -ErrorType 'ClassifierBadOutput' `
                 -Goal 'Run the semantic-opposition golden through the contradiction classifier' `
-                -Problem "the classifier stdout was not the expected { results: [...] } shape" `
+                -Problem "the classifier output was not the expected { results: [...] } shape. First 200 chars: $snip" `
                 -Location 'run-semantic-golden-classifier.ps1' `
-                -NextSteps @('Inspect the raw classifier output above'))
+                -NextSteps @('Inspect the results file content shown above'))
     }
     return @($parsed.results)
 }

--- a/scripts/run-semantic-golden-classifier.ps1
+++ b/scripts/run-semantic-golden-classifier.ps1
@@ -184,7 +184,11 @@ if (-not $env:SEMGOLD_RUNNER_NOEXEC) {
                 -Location 'run-semantic-golden-classifier.ps1' `
                 -NextSteps @('Pass -GoldenPath, or run from a checkout that includes research/comp-linguist/analyses/semantic-opposition-golden/'))
     }
-    if ([string]::IsNullOrWhiteSpace($OutPath)) { $OutPath = Join-Path (Get-Location) 'semantic-golden-predictions.json' }
+    if ([string]::IsNullOrWhiteSpace($OutPath)) { $OutPath = 'semantic-golden-predictions.json' }
+    # Anchor a relative -OutPath to the caller's location explicitly. A bare relative literal path can be
+    # resolved against the .NET process cwd (which diverges from Get-Location after a `cd`), landing the
+    # file somewhere surprising — a live run wrote the results out of sight this way (t/3302).
+    if (-not [System.IO.Path]::IsPathRooted($OutPath)) { $OutPath = Join-Path (Get-Location).Path $OutPath }
 
     $golden = Get-Content -LiteralPath $GoldenPath -Raw | ConvertFrom-Json
     $pairs = @(Get-GoldenPairField $golden 'pairs' @())

--- a/scripts/test_enrich_conflicts_qbaf.py
+++ b/scripts/test_enrich_conflicts_qbaf.py
@@ -197,6 +197,61 @@ def test_bare_numbers_weak_overlap_no_conflict():
         "labs used 3 chips", "labs used 7 servers") is False
 
 
+# detect_semantic_edges + enrich_conflict extra_edges — fork-B wiring (t/3302, AI mocked)
+
+def _si(stance, doc, text):
+    return {"stance": stance, "doc_id": doc, "assertion": text}
+
+
+def test_detect_semantic_edges_numeric_and_llm():
+    to_process = [
+        (None, {"claim_id": "c0", "instances": [
+            _si("neutral", "d1", "compute among safety labs grew 30 percent last year"),
+            _si("neutral", "d2", "compute among safety labs grew 10 percent last year")]}),
+        (None, {"claim_id": "c1", "instances": [
+            _si("neutral", "d1", "cats are calm household pets"),
+            _si("neutral", "d2", "dogs are loud household pets")]}),
+    ]
+    # Only c1's pair (id "1:0:1") reaches the LLM (c0 is caught by the numeric detector first).
+    def runner(batch, mode, temp):
+        ids = {p["id"] for c in batch for p in c["pairs"]}
+        assert ids == {"1:0:1"}, f"numeric pair must not reach the LLM; got {ids}"
+        return {"1:0:1": {"label": "contradict", "confidence": 0.9}}
+    by_ci = eq.detect_semantic_edges(to_process, min_confidence=0.5, mode="per-conflict", cc_runner=runner)
+    assert by_ci[0][0]["detector"] == "numeric" and by_ci[0][0]["type"] == "attacks"
+    assert by_ci[1][0]["detector"] == "llm" and by_ci[1][0]["type"] == "attacks"
+    assert by_ci[1][0]["confidence"] == 0.9
+
+
+def test_detect_semantic_edges_entail_is_support():
+    to_process = [(None, {"claim_id": "c0", "instances": [
+        _si("neutral", "d1", "the model reduces latency"),
+        _si("neutral", "d2", "the model cuts latency")]})]
+    runner = lambda batch, mode, temp: {"0:0:1": {"label": "entail", "confidence": 0.8}}
+    by_ci = eq.detect_semantic_edges(to_process, min_confidence=0.5, cc_runner=runner)
+    assert by_ci[0][0]["type"] == "supports"
+    assert by_ci[0][0]["detector"] == "llm"
+
+
+def test_detect_semantic_edges_low_confidence_dropped():
+    to_process = [(None, {"claim_id": "c0", "instances": [
+        _si("neutral", "d1", "alpha beta gamma"),
+        _si("neutral", "d2", "delta epsilon zeta")]})]
+    runner = lambda batch, mode, temp: {"0:0:1": {"label": "contradict", "confidence": 0.2}}
+    by_ci = eq.detect_semantic_edges(to_process, min_confidence=0.5, cc_runner=runner)
+    assert by_ci == {}  # below threshold -> no edge
+
+
+def test_enrich_conflict_merges_extra_edges_with_provenance():
+    conflict = {"instances": [_si("neutral", "d1", "aaa"), _si("neutral", "d2", "bbb")]}
+    extra = [{"source": "inst-0", "target": "inst-1", "type": "attacks", "weight": 0.6,
+              "attack_type": "rebut", "detector": "llm", "edge_origin": "semantic", "confidence": 0.77}]
+    pre = eq.enrich_conflict(conflict, {}, extra_edges=extra)
+    assert pre.get("_needs_bridge") is True   # extra edge -> needs propagation
+    eo = pre["edge_output"][0]
+    assert eo["detector"] == "llm" and eo["edge_origin"] == "semantic" and eo["confidence"] == 0.77
+
+
 if __name__ == "__main__":
     import pytest
 

--- a/scripts/test_enrich_conflicts_qbaf.py
+++ b/scripts/test_enrich_conflicts_qbaf.py
@@ -157,6 +157,46 @@ def test_testedness_adversarial_when_attack_present():
     assert tm["stance_hist"] == {"supports": 1, "disputes": 1}
 
 
+# _detect_numeric_temporal_conflict — deterministic complement (t/3302 fork-B, TL's mandatory
+# high-precision detector). Conservative: subject overlap + same-kind disjoint quantities.
+
+def test_numeric_conflicting_percentages_same_subject():
+    assert eq._detect_numeric_temporal_conflict(
+        "Compute among safety labs grew 30 percent last year",
+        "Compute among safety labs grew 10 percent last year") is True
+
+
+def test_numeric_same_percentage_no_conflict():
+    assert eq._detect_numeric_temporal_conflict(
+        "Compute among safety labs grew 30 percent last year",
+        "Compute among safety labs grew 30 percent last year") is False
+
+
+def test_numeric_different_subject_no_conflict():
+    # Different percentages but the subjects don't overlap (<3 shared content words) -> no fire.
+    assert eq._detect_numeric_temporal_conflict(
+        "GDP rose 30 percent", "unemployment fell 10 percent") is False
+
+
+def test_temporal_conflicting_years_same_subject():
+    assert eq._detect_numeric_temporal_conflict(
+        "The superintelligence ban takes effect by 2027 under this act",
+        "The superintelligence ban takes effect by 2030 under this act") is True
+
+
+def test_bare_numbers_conflict_requires_strong_overlap():
+    # 4+ shared content words + disjoint bare numbers -> conflict.
+    assert eq._detect_numeric_temporal_conflict(
+        "The frontier training run used 3 data centers in the cluster",
+        "The frontier training run used 7 data centers in the cluster") is True
+
+
+def test_bare_numbers_weak_overlap_no_conflict():
+    # Disjoint numbers but too few shared words -> no fire (subject gate not met).
+    assert eq._detect_numeric_temporal_conflict(
+        "labs used 3 chips", "labs used 7 servers") is False
+
+
 if __name__ == "__main__":
     import pytest
 

--- a/taxonomy-editor/src/renderer/data/promptCatalog.ts
+++ b/taxonomy-editor/src/renderer/data/promptCatalog.ts
@@ -989,6 +989,17 @@ export const PROMPT_CATALOG: PromptCatalogEntry[] = [
     promptFiles: ['qbaf-pair-confirm'],
   },
   {
+    id: 'ps-contradiction-classify',
+    title: 'Contradiction Classifier (Fork-B Semantic Opposition)',
+    description: 'Classifies the logical relation (contradict | entail | neutral) between two within-conflict factual assertions.',
+    source: 'AITriad/Prompts/contradiction-classify.prompt',
+    template: '(Loading from disk...)',
+    group: 'powershell',
+    purpose: 'Used by invoke-contradiction-classifier.ps1 (fork-B semantic-opposition edges, t/3302). Per-conflict batch classification of within-conflict assertion pairs — contradict → attack edge, entail → support edge — feeding the QBAF via enrich_conflicts_qbaf.py --semantic-edges.',
+    applicableDataSources: ['taxonomyNodes'],
+    promptFiles: ['contradiction-classify'],
+  },
+  {
     id: 'ps-entity-link-judge',
     title: 'Entity Link Judge',
     description: 'LLM judge prompt that classifies entity_refs as genuine or spurious surface/alias matches in extraction quality audits.',

--- a/tests/InvokeContradictionClassifier.Tests.ps1
+++ b/tests/InvokeContradictionClassifier.Tests.ps1
@@ -99,6 +99,26 @@ Describe 'Convert-ContradictionPairs (fork-B bridge)' -Tag 'qbaf' {
     }
 }
 
+Describe 'Get-Prompt wiring — subprocess-scope regression (t/3302 live-run root cause)' -Tag 'qbaf' {
+
+    It 'the classifier dot-sources the private Get-Prompt helper' {
+        # Import-Module does NOT expose the private Get-Prompt to this standalone script's scope; the
+        # dot-source is what makes the real (unstubbed) subprocess run work. Guard against its removal.
+        $src = Get-Content (Join-Path $PSScriptRoot '..' 'scripts' 'invoke-contradiction-classifier.ps1') -Raw
+        $src | Should -Match 'Get-Prompt\.ps1'
+    }
+
+    It 'the REAL Get-Prompt renders contradiction-classify.prompt with the pairs block' {
+        # Exercises the actual private helper + prompt file (no stub, no AI) — proves the render path
+        # the subprocess depends on actually works.
+        . (Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'Private' 'Get-Prompt.ps1')
+        $promptsDir = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'Prompts'
+        $rendered = Get-Prompt -Name 'contradiction-classify' -PromptsDir $promptsDir -Replacements @{ pairs_block = 'PAIRZONE_SENTINEL' }
+        $rendered | Should -Match 'PAIRZONE_SENTINEL'
+        $rendered | Should -Match 'contradict'
+    }
+}
+
 Describe 'Write-CCResult — file is the clean data channel (t/3302 live-run fix)' -Tag 'qbaf' {
 
     It 'writes valid { results } JSON to -OutPath and nothing to stdout' {

--- a/tests/InvokeContradictionClassifier.Tests.ps1
+++ b/tests/InvokeContradictionClassifier.Tests.ps1
@@ -98,3 +98,30 @@ Describe 'Convert-ContradictionPairs (fork-B bridge)' -Tag 'qbaf' {
         @($r | Where-Object method -eq 'llm-perpair').Count | Should -Be 2
     }
 }
+
+Describe 'Write-CCResult — file is the clean data channel (t/3302 live-run fix)' -Tag 'qbaf' {
+
+    It 'writes valid { results } JSON to -OutPath and nothing to stdout' {
+        $tmp = [System.IO.Path]::GetTempFileName()
+        try {
+            $results = @([ordered]@{ id = 'P001'; label = 'contradict'; confidence = 0.9; method = 'llm-batch' })
+            $stdout = Write-CCResult -Results $results -OutPath $tmp
+            # Empty success stream is the whole point: warnings would otherwise interleave with stdout
+            # JSON and break the caller's parse (the live-run failure this fix prevents).
+            $stdout | Should -BeNullOrEmpty
+            $parsed = Get-Content -LiteralPath $tmp -Raw | ConvertFrom-Json
+            @($parsed.results).Count | Should -Be 1
+            $parsed.results[0].id    | Should -Be 'P001'
+            $parsed.results[0].label | Should -Be 'contradict'
+        }
+        finally { Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'falls back to stdout when -OutPath is empty (legacy)' {
+        $results = @([ordered]@{ id = 'P001'; label = 'neutral'; confidence = 0.5; method = 'llm-batch' })
+        $stdout = Write-CCResult -Results $results -OutPath ''
+        $parsed = $stdout | ConvertFrom-Json
+        @($parsed.results).Count | Should -Be 1
+        $parsed.results[0].label | Should -Be 'neutral'
+    }
+}

--- a/tests/InvokeContradictionClassifier.Tests.ps1
+++ b/tests/InvokeContradictionClassifier.Tests.ps1
@@ -1,0 +1,100 @@
+# Tag: qbaf (t/3302 fork-B)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Unit tests for the fork-B contradiction-classifier bridge (t/3302).
+.DESCRIPTION
+    Dot-sources invoke-contradiction-classifier.ps1 with $env:CC_CLASSIFIER_NOEXEC set (so main() is
+    skipped) and exercises Convert-ContradictionPairs with STUBBED Get-Prompt / Invoke-AIByUsage — no
+    AI, no network. Proves TL's load-bearing conditions (t/3302#16): per-conflict batch, per-pair
+    FALLBACK on an incomplete/malformed batch, and NEVER silently dropping a pair (unresolved).
+#>
+
+BeforeAll {
+    # Stub the two module commands the shim calls, in THIS scope, before dot-sourcing the shim, so its
+    # functions bind to the stubs (no AITriad import / no AI). Responses come from a per-test queue.
+    $script:CCQueue = [System.Collections.Generic.Queue[string]]::new()
+    $script:CCLastBlock = $null
+
+    function Get-Prompt { param($Name, $Replacements) $script:CCLastBlock = [string]$Replacements.pairs_block; return $script:CCLastBlock }
+    function Invoke-AIByUsage {
+        param($UsageId, $Values, $Override, $ErrorAction)
+        if ($script:CCQueue.Count -eq 0) { return [PSCustomObject]@{ Text = '' } }
+        return [PSCustomObject]@{ Text = $script:CCQueue.Dequeue() }
+    }
+
+    $env:CC_CLASSIFIER_NOEXEC = '1'
+    . (Join-Path $PSScriptRoot '..' 'scripts' 'invoke-contradiction-classifier.ps1')
+}
+
+AfterAll { Remove-Item Env:\CC_CLASSIFIER_NOEXEC -ErrorAction SilentlyContinue }
+
+Describe 'Convert-ContradictionPairs (fork-B bridge)' -Tag 'qbaf' {
+
+    BeforeEach { $script:CCQueue.Clear() }
+
+    It 'batch success: labels every pair from one batch call, method=llm-batch' {
+        $script:CCQueue.Enqueue('{"results":[{"id":"p1","label":"contradict","confidence":0.9},{"id":"p2","label":"neutral","confidence":0.8}]}')
+        $pairs = @([pscustomobject]@{ id = 'p1'; a = 'X is 30%'; b = 'X is 10%' },
+                   [pscustomobject]@{ id = 'p2'; a = 'cats'; b = 'dogs' })
+        $r = Convert-ContradictionPairs -Pairs $pairs -Mode 'per-conflict'
+        @($r).Count           | Should -Be 2
+        ($r | Where-Object id -eq 'p1').label  | Should -Be 'contradict'
+        ($r | Where-Object id -eq 'p1').method | Should -Be 'llm-batch'
+        ($r | Where-Object id -eq 'p2').label  | Should -Be 'neutral'
+        $script:CCQueue.Count | Should -Be 0 -Because 'one batch call covered both pairs — no per-pair fallback'
+    }
+
+    It 'incomplete batch: falls back to per-pair for the missing id (never drops it)' {
+        # Batch returns only p1; p2 is missing -> one per-pair call resolves p2.
+        $script:CCQueue.Enqueue('{"results":[{"id":"p1","label":"entail","confidence":0.7}]}')
+        $script:CCQueue.Enqueue('{"results":[{"id":"p2","label":"contradict","confidence":0.6}]}')
+        $pairs = @([pscustomobject]@{ id = 'p1'; a = 'a1'; b = 'b1' },
+                   [pscustomobject]@{ id = 'p2'; a = 'a2'; b = 'b2' })
+        $r = Convert-ContradictionPairs -Pairs $pairs -Mode 'per-conflict'
+        @($r).Count | Should -Be 2
+        ($r | Where-Object id -eq 'p1').method | Should -Be 'llm-batch'
+        ($r | Where-Object id -eq 'p2').method | Should -Be 'llm-perpair'
+        ($r | Where-Object id -eq 'p2').label  | Should -Be 'contradict'
+    }
+
+    It 'total failure: emits unresolved, never drops the pair' {
+        # Empty queue -> every call returns Text='' -> null map -> unresolved after batch + per-pair.
+        $pairs = @([pscustomobject]@{ id = 'p1'; a = 'a1'; b = 'b1' })
+        $r = @(Convert-ContradictionPairs -Pairs $pairs -Mode 'per-conflict' -WarningAction SilentlyContinue)
+        $r.Count | Should -Be 1
+        $r[0].label  | Should -Be 'unresolved'
+        $r[0].method | Should -Be 'unresolved'
+    }
+
+    It 'invalid label from the batch is treated as missing -> per-pair fallback' {
+        $script:CCQueue.Enqueue('{"results":[{"id":"p1","label":"maybe","confidence":0.9}]}')  # bad label
+        $script:CCQueue.Enqueue('{"results":[{"id":"p1","label":"neutral","confidence":0.5}]}')
+        $pairs = @([pscustomobject]@{ id = 'p1'; a = 'a1'; b = 'b1' })
+        $r = @(Convert-ContradictionPairs -Pairs $pairs -Mode 'per-conflict')
+        $r[0].label  | Should -Be 'neutral'
+        $r[0].method | Should -Be 'llm-perpair'
+    }
+
+    It 'pairs block carries both assertion texts (incl. quotes/newlines) safely' {
+        $script:CCQueue.Enqueue('{"results":[{"id":"p1","label":"neutral","confidence":0.5}]}')
+        $pairs = @([pscustomobject]@{ id = 'p1'; a = 'she said "no"'; b = "line1`nline2" })
+        $null = Convert-ContradictionPairs -Pairs $pairs -Mode 'per-conflict'
+        $script:CCLastBlock | Should -Match 'she said "no"'
+        $script:CCLastBlock | Should -Match 'line2'
+    }
+
+    It 'per-pair mode: one call per pair, no batch attempt' {
+        $script:CCQueue.Enqueue('{"results":[{"id":"p1","label":"contradict","confidence":0.9}]}')
+        $script:CCQueue.Enqueue('{"results":[{"id":"p2","label":"entail","confidence":0.9}]}')
+        $pairs = @([pscustomobject]@{ id = 'p1'; a = 'a1'; b = 'b1' },
+                   [pscustomobject]@{ id = 'p2'; a = 'a2'; b = 'b2' })
+        $r = Convert-ContradictionPairs -Pairs $pairs -Mode 'per-pair'
+        @($r).Count | Should -Be 2
+        @($r | Where-Object method -eq 'llm-perpair').Count | Should -Be 2
+    }
+}

--- a/tests/RunSemanticGoldenClassifier.Tests.ps1
+++ b/tests/RunSemanticGoldenClassifier.Tests.ps1
@@ -1,0 +1,86 @@
+# Tag: qbaf (t/3302 Fork-B — golden runner pure transforms)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Tests for run-semantic-golden-classifier.ps1's pure transforms (t/3302).
+.DESCRIPTION
+    ConvertTo-CCInput (golden pairs -> classifier input) and Join-CCPredictions (results -> predictions)
+    are exercised WITHOUT the AI backend or a subprocess: the script is dot-sourced with
+    $env:SEMGOLD_RUNNER_NOEXEC set, so main() is skipped and only the functions load.
+#>
+
+BeforeAll {
+    $env:SEMGOLD_RUNNER_NOEXEC = '1'
+    . "$PSScriptRoot/../scripts/run-semantic-golden-classifier.ps1"
+}
+
+AfterAll {
+    Remove-Item Env:\SEMGOLD_RUNNER_NOEXEC -ErrorAction SilentlyContinue
+}
+
+Describe 'ConvertTo-CCInput — golden pairs -> classifier contract' -Tag 'qbaf' {
+
+    It 'groups pairs by conflict_id and maps assertion_a/b -> a/b keyed by pair_id' {
+        $pairs = @(
+            [pscustomobject]@{ conflict_id = 'c1'; pair_id = 'P001'; assertion_a = 'A one'; assertion_b = 'B one' }
+            [pscustomobject]@{ conflict_id = 'c1'; pair_id = 'P002'; assertion_a = 'A two'; assertion_b = 'B two' }
+            [pscustomobject]@{ conflict_id = 'c2'; pair_id = 'P003'; assertion_a = 'A three'; assertion_b = 'B three' }
+        )
+        $out = ConvertTo-CCInput -Pairs $pairs
+        @($out.conflicts).Count | Should -Be 2
+        $c1 = @($out.conflicts | Where-Object { $_.cid -eq 'c1' })
+        @($c1[0].pairs).Count | Should -Be 2
+        $c1[0].pairs[0].id | Should -Be 'P001'
+        $c1[0].pairs[0].a  | Should -Be 'A one'
+        $c1[0].pairs[0].b  | Should -Be 'B one'
+    }
+
+    It 'preserves quotes/newlines in assertion text (no shell corruption — file-based)' {
+        $pairs = @([pscustomobject]@{ conflict_id = 'c1'; pair_id = 'P001'; assertion_a = "line1`nline2 `"q`""; assertion_b = "it's" })
+        $out = ConvertTo-CCInput -Pairs $pairs
+        $out.conflicts[0].pairs[0].a | Should -Match 'line2'
+        $out.conflicts[0].pairs[0].b | Should -Be "it's"
+    }
+}
+
+Describe 'Join-CCPredictions — results -> scoreable predictions' -Tag 'qbaf' {
+
+    It 'joins by pair_id and carries gold label + pool + split' {
+        $pairs = @(
+            [pscustomobject]@{ pair_id = 'P001'; conflict_id = 'c1'; label = 'contradict'; pool = 'REP'; split = 'held_out'; stratum = 'numeric'; precision_trap = $false }
+        )
+        $results = @([pscustomobject]@{ id = 'P001'; label = 'contradict'; confidence = 0.9; method = 'llm-batch' })
+        $preds = @(Join-CCPredictions -Pairs $pairs -Results $results)
+        @($preds).Count | Should -Be 1
+        $preds[0].gold_label | Should -Be 'contradict'
+        $preds[0].predicted  | Should -Be 'contradict'
+        $preds[0].confidence | Should -Be 0.9
+        $preds[0].pool       | Should -Be 'REP'
+        $preds[0].split      | Should -Be 'held_out'
+    }
+
+    It 'never drops a pair with no result — emits unresolved / missing' {
+        $pairs = @(
+            [pscustomobject]@{ pair_id = 'P001'; conflict_id = 'c1'; label = 'neutral'; pool = 'REP'; split = 'tune' }
+            [pscustomobject]@{ pair_id = 'P002'; conflict_id = 'c1'; label = 'contradict'; pool = 'ENR'; split = 'held_out' }
+        )
+        $results = @([pscustomobject]@{ id = 'P001'; label = 'neutral'; confidence = 0.7; method = 'llm-batch' })
+        $preds = Join-CCPredictions -Pairs $pairs -Results $results
+        @($preds).Count | Should -Be 2
+        $missing = @($preds | Where-Object { $_.pair_id -eq 'P002' })
+        $missing[0].predicted | Should -Be 'unresolved'
+        $missing[0].method    | Should -Be 'missing'
+        $missing[0].gold_label | Should -Be 'contradict'
+    }
+
+    It 'tolerates an empty results set (all missing, none dropped)' {
+        $pairs = @([pscustomobject]@{ pair_id = 'P001'; conflict_id = 'c1'; label = 'neutral'; pool = 'REP'; split = 'tune' })
+        $preds = @(Join-CCPredictions -Pairs $pairs -Results @())
+        @($preds).Count | Should -Be 1
+        $preds[0].method | Should -Be 'missing'
+    }
+}


### PR DESCRIPTION
## Fork-B: QBAF semantic-opposition edges (t/3302)

NLI-first failed the golden bar (recall ceiling 25–29%; t/3302#11). Per TL's approved seam (t/3302#16), this adds an **opt-in** semantic-opposition pass classifying within-conflict pairs with NO stance edge — the "97% never attacked" recall gap.

### Pieces (all AI mocked in tests)
- **Prompt** `contradiction-classify.prompt` + **usage** `enrichment.contradiction-classify` (temperature pinned 0, jsonMode).
- **Bridge** `scripts/invoke-contradiction-classifier.ps1` — FILE-BASED pair-text handoff (temp-file path, not inline: quotes/newlines shell-corruption hazard); per-conflict **batch + per-pair fallback**; a pair is **never silently dropped** (→ `unresolved` = no edge). 6 PS tests.
- **Deterministic numeric/temporal detector** (`_detect_numeric_temporal_conflict`) — TL's high-precision complement (shared-subject + same-kind disjoint quantities). 6 Python tests.
- **`enrich_conflicts_qbaf.py --semantic-edges` wiring** — numeric detector first, then the LLM classifier; contradict→attack, entail→support; `--semantic-min-confidence` gate + `--classify-mode`; provenance (`detector`/`edge_origin`/`confidence`) persisted; **bridge input whitelisted** to source/target/type/weight. 4 Python tests.

**21/21 pytest + 6/6 Pester green.** Three PS gotchas handled: mandatory-param-blocks-dot-source, `$PID` read-only collision, Pester #2669.

### ⚠️ DRAFT — gated, do not merge yet
Default runs are **byte-identical** (flag off — zero production impact). The LLM path is **paid**: owner runs `--semantic-edges` on a sample → **CL scores the frozen split golden** (P≥0.85 / R≥0.50, precision lower-bound clears via CIs) → **Main GV** → set `--semantic-min-confidence` from the P/R curve, then enable the corpus `--write`. Per-conflict batch is primary; per-pair is the fallback if per-conflict scores P<0.85 (t/3302#16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
