### PR TITLE
feat(oped): public "Get link" button for COMMUNITY op-eds (t/3315)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
@@ -338,6 +338,7 @@ export const api: AppAPI = {
   // desktop has no public URL, so reject with the standard web-only actionable error.
   shareOpEdSet: () => rejectOpEdIpc('share an op-ed', 'shareOpEdSet'),
   unshareOpEdSet: () => rejectOpEdIpc('un-share an op-ed', 'unshareOpEdSet'),
+  shareCommunityOpEd: () => rejectOpEdIpc('share a community op-ed', 'shareCommunityOpEd'), // t/3315: web-only
 
   // News Report
   generateNewsReport: (debateId) => window.electronAPI.generateNewsReport(debateId),

--- a/taxonomy-editor/src/renderer/bridge/types.ts
+++ b/taxonomy-editor/src/renderer/bridge/types.ts
@@ -438,6 +438,9 @@ export interface AppAPI {
   shareOpEdSet: (setId: string) => Promise<{ shareId: string; url: string }>;
   /** t/2728: revoke a public share (owner-only). */
   unshareOpEdSet: (setId: string) => Promise<{ ok: boolean }>;
+  /** t/3315: publish a public share link for a COMMUNITY op-ed (any submitter — community is public).
+   *  Same public /share/oped view as own-op-ed share. Web-only; Electron rejects. */
+  shareCommunityOpEd: (id: string) => Promise<{ shareId: string; url: string }>;
 
   // --- News Report ---
   generateNewsReport: (debateId: string) => Promise<{ article: string }>;

--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -1055,9 +1055,9 @@ const rawApi: AppAPI = {
   createOpEdSet: (payload) => runOpEdCreate(fetchWithSessionRecovery, payload),
   cancelOpEdSet: () => cancelActiveOpEdRun(), // aborts the in-flight POST → server cancels voices
   onOpEdProgress: (cb) => opedProgressBus.onProgress(cb),
-  // t/2728: publish/revoke a durable public share link (server: routes/oped.ts + opedShare.ts).
-  shareOpEdSet: (id) => post<{ shareId: string; url: string }>(`/api/oped-sets/${encodeURIComponent(id)}/share`, {}),
+  shareOpEdSet: (id) => post<{ shareId: string; url: string }>(`/api/oped-sets/${encodeURIComponent(id)}/share`, {}), // t/2728: publish/revoke a public share link (routes/oped.ts)
   unshareOpEdSet: (id) => del<{ ok: boolean }>(`/api/oped-sets/${encodeURIComponent(id)}/share`),
+  shareCommunityOpEd: (id) => post<{ shareId: string; url: string }>(`/api/community/opeds/${encodeURIComponent(id)}/share`, {}), // t/3315: public link for a community op-ed
   exportDebateToFile: async (session, format = 'json', exportOptions) => {
     const { debateToText, debateToMarkdown, debateToHtml, debateToPackage, debateExportFilename } = await import('@lib/debate/debateExport');
     const debate = session as Parameters<typeof debateToText>[0] & { diagnostics?: unknown };

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTab.shareGuard.test.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTab.shareGuard.test.tsx
@@ -2,10 +2,10 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-// t/2987 — the reader's Share control was shown for ANY open op-ed, so sharing a
-// community-loaded op-ed hit /api/oped-sets/:id/share → 404 (the id isn't in the user's
-// own oped-sets store). Design: Share (My) / Copy (Community). This locks the guard:
-// Share renders only when the open op-ed is the user's own (canShare).
+// t/2987 + t/3315 — the reader's Share control. Own op-eds share via /api/oped-sets/:id/share ("🔗
+// Share"); community op-eds are PUBLIC and share via /api/community/opeds/:id/share ("🔗 Get public
+// link", t/3315). This locks the guard: no share when shareSource is null; own vs community render
+// distinct controls (different endpoint + label). Share is web-only (t/2728).
 
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
@@ -13,17 +13,18 @@ import type { OpEdSet } from '../../../../../lib/oped/types';
 
 // Web mode (share is web-only, t/2728); api is only touched on click, not on render.
 vi.mock('@bridge', () => ({
-  api: { shareOpEdSet: vi.fn(), unshareOpEdSet: vi.fn() },
+  api: { shareOpEdSet: vi.fn(), unshareOpEdSet: vi.fn(), shareCommunityOpEd: vi.fn() },
   isElectronMode: () => false,
 }));
 
 import { OpEdReaderView } from './OpEdTab';
 
-const SHARE_LABEL = 'Create a public share link';
+const SHARE_LABEL_MY = 'Create a public share link';
+const SHARE_LABEL_COMMUNITY = 'Get a public share link for this community op-ed';
 const set = { set_id: 'set-1' } as unknown as OpEdSet;
 
 // readerLoading keeps OpEdReader unrendered so we isolate the reader bar (where Share lives).
-function renderReader(canShare: boolean) {
+function renderReader(shareSource: 'my' | 'community' | null) {
   return render(
     <OpEdReaderView
       readerSet={set}
@@ -31,19 +32,27 @@ function renderReader(canShare: boolean) {
       readerError={null}
       status={null}
       onBack={() => {}}
-      canShare={canShare}
+      shareSource={shareSource}
     />,
   );
 }
 
-describe('OpEdReaderView Share guard (t/2987)', () => {
-  it('does NOT render Share for a community op-ed (canShare=false)', () => {
-    renderReader(false);
-    expect(screen.queryByLabelText(SHARE_LABEL)).toBeNull();
+describe('OpEdReaderView Share guard (t/2987 + t/3315)', () => {
+  it('renders NO share control when shareSource is null', () => {
+    renderReader(null);
+    expect(screen.queryByLabelText(SHARE_LABEL_MY)).toBeNull();
+    expect(screen.queryByLabelText(SHARE_LABEL_COMMUNITY)).toBeNull();
   });
 
-  it("renders Share for the user's own op-ed (canShare=true)", () => {
-    renderReader(true);
-    expect(screen.queryByLabelText(SHARE_LABEL)).not.toBeNull();
+  it("renders '🔗 Share' for the user's own op-ed (shareSource='my')", () => {
+    renderReader('my');
+    expect(screen.queryByLabelText(SHARE_LABEL_MY)).not.toBeNull();
+    expect(screen.queryByLabelText(SHARE_LABEL_COMMUNITY)).toBeNull();
+  });
+
+  it("renders '🔗 Get public link' for a community op-ed (shareSource='community', t/3315)", () => {
+    renderReader('community');
+    expect(screen.queryByLabelText(SHARE_LABEL_COMMUNITY)).not.toBeNull();
+    expect(screen.queryByLabelText(SHARE_LABEL_MY)).toBeNull();
   });
 });

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
@@ -171,8 +171,11 @@ type ShareState =
   | { status: 'shared'; url: string; copied: boolean }
   | { status: 'error'; message: string };
 
-function ShareOpEdControl({ setId }: { setId: string }) {
+function ShareOpEdControl({ setId, source = 'my' }: { setId: string; source?: 'my' | 'community' }) {
   const [state, setState] = useState<ShareState>({ status: 'idle' });
+  // t/3315: community op-eds are public → linkable via the community-share endpoint. Get-link-only
+  // (no Un-share — revoke is an admin/submitter capability, not exposed to a general viewer).
+  const isCommunity = source === 'community';
 
   const copy = useCallback(async (url: string) => {
     try {
@@ -187,7 +190,7 @@ function ShareOpEdControl({ setId }: { setId: string }) {
   const onShare = useCallback(async () => {
     setState({ status: 'working' });
     try {
-      const { shareId } = await api.shareOpEdSet(setId);
+      const { shareId } = isCommunity ? await api.shareCommunityOpEd(setId) : await api.shareOpEdSet(setId);
       const url = new URL(`/share/oped/${encodeURIComponent(shareId)}`, window.location.origin).href;
       await copy(url);
     } catch (err) {
@@ -198,7 +201,7 @@ function ShareOpEdControl({ setId }: { setId: string }) {
       });
       setState({ status: 'error', message: mapErrorToUserMessage(err) });
     }
-  }, [setId, copy]);
+  }, [setId, copy, isCommunity]);
 
   const onUnshare = useCallback(async () => {
     setState({ status: 'working' });
@@ -222,7 +225,7 @@ function ShareOpEdControl({ setId }: { setId: string }) {
         <input className="oped-share-url" type="text" readOnly value={state.url} aria-label="Public share link"
           onFocus={e => e.currentTarget.select()} />
         <button type="button" className="btn btn-sm btn-ghost" onClick={() => void copy(state.url)}>Copy</button>
-        <button type="button" className="btn btn-sm btn-ghost" onClick={() => void onUnshare()}>Un-share</button>
+        {!isCommunity && <button type="button" className="btn btn-sm btn-ghost" onClick={() => void onUnshare()}>Un-share</button>}
       </span>
     );
   }
@@ -230,8 +233,8 @@ function ShareOpEdControl({ setId }: { setId: string }) {
   return (
     <span className="oped-share">
       <button type="button" className="btn btn-sm btn-ghost" onClick={() => void onShare()}
-        disabled={state.status === 'working'} aria-label="Create a public share link">
-        {state.status === 'working' ? 'Sharing…' : '🔗 Share'}
+        disabled={state.status === 'working'} aria-label={isCommunity ? 'Get a public share link for this community op-ed' : 'Create a public share link'}>
+        {state.status === 'working' ? 'Sharing…' : (isCommunity ? '🔗 Get public link' : '🔗 Share')}
       </button>
       {state.status === 'error' && <span className="oped-share-error" role="alert">{state.message}</span>}
     </span>
@@ -241,15 +244,16 @@ function ShareOpEdControl({ setId }: { setId: string }) {
 // ── Reader view (back bar + article/loading/error) ────────────────────────────
 
 export function OpEdReaderView({
-  readerSet, readerLoading, readerError, status, onBack, canShare,
+  readerSet, readerLoading, readerError, status, onBack, shareSource,
 }: {
   readerSet: OpEdSet | null;
   readerLoading: boolean;
   readerError: string | null;
   status: string | null;
   onBack: () => void;
-  /** t/2987: only the user's OWN op-eds are shareable — community ones 404 the share endpoint. */
-  canShare: boolean;
+  /** t/2987/t/3315: which store the op-ed came from — 'my' (own share) or 'community' (public community
+   *  share); null = not shareable. Both mint a public /share/oped link via their respective endpoint. */
+  shareSource: 'my' | 'community' | null;
 }) {
   return (
     <div className="two-column oped-tab-table-mode">
@@ -257,10 +261,10 @@ export function OpEdReaderView({
         <div className="oped-reader-bar">
           <button type="button" className="oped-reader-back" onClick={onBack}>‹ Op-Ed Studies</button>
           {status && <span className="oped-status">{status}</span>}
-          {/* Share is web-only (electron-bridge rejects shareOpEdSet, t/2728) AND only for the
-              user's OWN op-eds — a community op-ed isn't in the user's oped-sets store, so its
-              share endpoint 404s (t/2987). Design: Share (My) / Copy (Community). */}
-          {readerSet && canShare && !isElectronMode() && <ShareOpEdControl setId={readerSet.set_id} />}
+          {/* Share is web-only (electron-bridge rejects, t/2728). Own op-eds use the own-share endpoint;
+              community op-eds use the community-share endpoint (t/3315 — community is public). Both mint
+              a public /share/oped link. */}
+          {readerSet && shareSource && !isElectronMode() && <ShareOpEdControl setId={readerSet.set_id} source={shareSource} />}
         </div>
         {readerLoading && <p className="oped-reader-loading">Loading op-ed…</p>}
         {readerError && <p className="oped-reader-error">{readerError}</p>}
@@ -493,7 +497,7 @@ export function OpEdTab() {
         readerError={readerError}
         status={status}
         onBack={closeReader}
-        canShare={readerSource === 'my'}
+        shareSource={readerSource}
       />
     );
   }


### PR DESCRIPTION
The PI wanted a public no-login URL for a community op-ed. Community op-eds are public (PI ruling, t/3315#7) but previously only offered "Copy". This adds a **"🔗 Get public link"** control on the community op-ed reader, reusing the existing publish-on-share machinery — mints a public `/share/oped/:id` link via the community-share endpoint (**PR #1960**).

## Renderer half (this PR)
- **Bridge:** `shareCommunityOpEd(id) → {shareId, url}` — web-bridge POSTs `/api/community/opeds/:id/share`; electron-bridge rejects (share is web-only, t/2728). web-bridge held at the 1500 max-lines ceiling.
- **UI:** `ShareOpEdControl` parameterized with `source: 'my' | 'community'` — community uses the community endpoint + **"🔗 Get public link"** label and is **get-link-only** (no Un-share — revoke is admin/submitter, not exposed to a general viewer). `OpEdReaderView`'s `canShare` → `shareSource: 'my'|'community'|null`.
- Updated `OpEdTab.shareGuard.test.tsx` for the tri-state (null → none; my → Share; community → Get link).

## JOINT-GV — server-first
**PR #1960** (ServerAPI — `POST /api/community/opeds/:id/share`, pending TL GV) must land **before** this (the button POSTs to it). Manual `--match-head-commit`, never `--auto` (t/3318). Draft — held for #1960's GV + merge.

## Verify
renderer-tsc clean · eslint 0 errors · oped suite + appapi-completeness **89 pass**.

Self-cert /add-bridge-method. Reuses the existing public `/share/oped` viewer — zero new public surface.