### PR TITLE
feat(ingestion): Import-AITriadDocument URL fetch -> shared Node fetch-CLI (t/3310)

### DIFF
--- a/scripts/AITriad/Private/Get-UrlViaSharedFetcher.ps1
+++ b/scripts/AITriad/Private/Get-UrlViaSharedFetcher.ps1
@@ -1,0 +1,110 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+#
+# Shared PS wrapper over the Node fetch-CLI (lib/url-fetch/fetch-url-cli.mjs, t/3324) — the ONE
+# PS-side external-URL fetch path for the WAF-fingerprint class (t/3312): Import-AITriadDocument
+# (t/3310), Repair-PovLineage (t/3313), and New-OpEd's CLI path (t/3320) all route through here.
+# Node's undici passes WAFs that block the .NET/PowerShell client fingerprint (t/3306), and the CLI
+# reuses fetchUrlForPromptBinary's SSRF guards. File-based handoff: response bytes go to a temp --out
+# file, metadata comes back as stdout JSON. Contract FROZEN to t/3324:
+#   { status, contentType, finalUrl, error, bodySnippet }   (status 200 | HTTP code | null)
+# Dot-sourced by AITriad.psm1 — do NOT export. This is the single allowlisted call site for the
+# t/3314 WAF-fetch prevention guard.
+
+function ConvertFrom-FetchCliOutput {
+    <#
+    .SYNOPSIS
+        Pure parse of fetch-url-cli.mjs stdout → the frozen t/3324 contract object, or throw on
+        unparseable output. Extracted so the contract mapping is unit-testable WITHOUT spawning node.
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [string]$Stdout,
+        [string]$Stderr,
+        [int]$ExitCode,
+        [Parameter(Mandatory)][string]$OutPath,
+        [string]$Url = ''
+    )
+    Set-StrictMode -Version Latest
+
+    $meta = $null
+    if (-not [string]::IsNullOrWhiteSpace($Stdout)) {
+        try { $meta = $Stdout | ConvertFrom-Json } catch { $meta = $null }
+    }
+    if ($null -eq $meta) {
+        Remove-Item -LiteralPath $OutPath -Force -ErrorAction SilentlyContinue
+        throw (New-ActionableError -PassThru -ErrorType 'FetcherUnparseable' `
+            -Goal "Fetch '$Url' via the shared Node fetcher" `
+            -Problem "fetch-url-cli emitted no parseable JSON (exit $ExitCode): $($Stderr.Trim())" `
+            -Location 'Get-UrlViaSharedFetcher' `
+            -NextSteps @('Confirm node can run lib/url-fetch/fetch-url-cli.mjs', 'Retry, or supply local content'))
+    }
+
+    # Guarded property reads (StrictMode + ConvertFrom-Json).
+    $get = { param($o, $n) if ($o.PSObject.Properties[$n]) { $o.$n } else { $null } }
+    return [PSCustomObject]@{
+        Status      = (& $get $meta 'status')        # 200 | HTTP code | $null (transport failure)
+        ContentType = [string](& $get $meta 'contentType')
+        FinalUrl    = [string](& $get $meta 'finalUrl')
+        Error       = (& $get $meta 'error')          # $null on success
+        BodySnippet = [string](& $get $meta 'bodySnippet')
+        OutPath     = $OutPath                         # caller reads + deletes
+        ExitCode    = $ExitCode
+    }
+}
+
+
+function Get-UrlViaSharedFetcher {
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Url,
+
+        [ValidateRange(1000, 600000)]
+        [int]$TimeoutMs = 30000,
+
+        [long]$MaxBytes = 0   # 0 => CLI default
+    )
+
+    Set-StrictMode -Version Latest
+
+    $node = Get-Command node -ErrorAction SilentlyContinue
+    if (-not $node) {
+        throw (New-ActionableError -PassThru -ErrorType 'NodeMissing' `
+            -Goal "Fetch '$Url' via the shared Node fetcher" `
+            -Problem 'node was not found on PATH — the shared URL fetcher requires Node.js' `
+            -Location 'Get-UrlViaSharedFetcher' `
+            -NextSteps @('Install Node.js and ensure `node` is on PATH', 'Or supply local content instead of a URL'))
+    }
+    $cli = Join-Path (Get-CodeRoot) 'lib' 'url-fetch' 'fetch-url-cli.mjs'
+    if (-not (Test-Path -LiteralPath $cli)) {
+        throw (New-ActionableError -PassThru -ErrorType 'FetcherMissing' `
+            -Goal "Fetch '$Url' via the shared Node fetcher" `
+            -Problem "fetch-url-cli.mjs not found at '$cli'" `
+            -Location 'Get-UrlViaSharedFetcher' `
+            -NextSteps @('Confirm lib/url-fetch/fetch-url-cli.mjs is present (t/3324)'))
+    }
+
+    # Caller owns OutPath (reads bytes + deletes). $cliArgs, NOT $args ($args is an automatic variable).
+    $outFile = [System.IO.Path]::GetTempFileName()
+    $cliArgs = @($cli, $Url, '--out', $outFile, '--timeout-ms', [string]$TimeoutMs)
+    if ($MaxBytes -gt 0) { $cliArgs += @('--max-bytes', [string]$MaxBytes) }
+
+    $proc = [System.Diagnostics.Process]::new()
+    $proc.StartInfo.FileName = $node.Source
+    foreach ($a in $cliArgs) { $proc.StartInfo.ArgumentList.Add([string]$a) }
+    $proc.StartInfo.UseShellExecute = $false
+    $proc.StartInfo.RedirectStandardOutput = $true
+    $proc.StartInfo.RedirectStandardError = $true
+    $proc.StartInfo.WorkingDirectory = (Get-CodeRoot)
+    $null = $proc.Start()
+    $stdout = $proc.StandardOutput.ReadToEnd()
+    $stderr = $proc.StandardError.ReadToEnd()
+    $proc.WaitForExit()
+    $exit = $proc.ExitCode
+
+    return (ConvertFrom-FetchCliOutput -Stdout $stdout -Stderr $stderr -ExitCode $exit -OutPath $outFile -Url $Url)
+}

--- a/scripts/AITriad/Public/Import-AITriadDocument.ps1
+++ b/scripts/AITriad/Public/Import-AITriadDocument.ps1
@@ -188,39 +188,46 @@ function Import-AITriadDocument {
             $SourceType   = 'web_article'
             $RawExtension = '.html'
 
+            # Fetch via the shared Node fetch-CLI (t/3310) — Node's undici passes WAFs that block the
+            # PowerShell client (t/3306); SSRF-guarded. Convert-only PS: dispatch on Content-Type
+            # (authoritative), which unifies the HTML/PDF branches and closes the PDF-over-WAF gap.
+            $Fetch = Get-UrlViaSharedFetcher -Url $SourceUrl -TimeoutMs 60000
             try {
-                $TempHtml   = [System.IO.Path]::GetTempFileName() + '.html'
-                $WebHeaders = @{ 'User-Agent' = 'Mozilla/5.0 (AI Triad Research Bot; +https://cyber.harvard.edu)' }
-                Invoke-RestMethod -Uri $SourceUrl -OutFile $TempHtml -TimeoutSec 30 -Headers $WebHeaders -ErrorAction Stop
-                $HtmlContent = Get-Content -Path $TempHtml -Raw -Encoding UTF8
-                Remove-Item $TempHtml -Force -ErrorAction SilentlyContinue
-                Write-OK "Fetched $([int]$HtmlContent.Length) characters"
-            } catch {
-                Remove-Item $TempHtml -Force -ErrorAction SilentlyContinue
-                Write-Fail "Failed to fetch URL: $_"
-                throw
-            }
+                if ($Fetch.Status -ne 200 -or $Fetch.Error) {
+                    $code = if ($null -ne $Fetch.Status) { $Fetch.Status } else { 'transport-failure' }
+                    $detail = if ($Fetch.Error) { "; $($Fetch.Error)" } else { '' }
+                    throw (New-ActionableError -PassThru -ErrorType 'FetchFailed' `
+                        -Goal "Ingest document from $SourceUrl" `
+                        -Problem "Could not fetch '$SourceUrl' (status: $code$detail)." `
+                        -Location 'Import-AITriadDocument' `
+                        -NextSteps @(
+                            'The shared fetcher (Node) already passes most WAFs; a persistent failure usually means the URL is unreachable, access-blocked, or SSRF-guarded',
+                            'Download the document and import it as a local file with -SourceFile instead'
+                        ))
+                }
 
-            $Meta    = Get-HtmlMeta -Html $HtmlContent
-            if ($Meta.Title) { $Title = $Meta.Title } else { $Title = $SourceUrl }
-            $Authors = $Meta.Author
-
-            $MarkdownText = ConvertFrom-Html -Html $HtmlContent -SourceUrl $SourceUrl
-            $RawContent   = $HtmlContent
-
-            if ($SourceUrl -match '\.pdf(\?.*)?$') {
-                Write-Info "URL points to a PDF — attempting direct PDF download"
-                try {
-                    $TempPdf = [System.IO.Path]::GetTempFileName() + '.pdf'
-                    Invoke-RestMethod -Uri $SourceUrl -OutFile $TempPdf -TimeoutSec 60 -ErrorAction Stop
-                    $RawContent   = [System.IO.File]::ReadAllBytes($TempPdf)
-                    $MarkdownText = ConvertFrom-Pdf -PdfPath $TempPdf
-                    Remove-Item $TempPdf -Force
+                if ($Fetch.ContentType -match 'application/pdf') {
+                    Write-OK "Fetched PDF ($($Fetch.ContentType))"
+                    $RawContent   = [System.IO.File]::ReadAllBytes($Fetch.OutPath)
+                    $MarkdownText = ConvertFrom-Pdf -PdfPath $Fetch.OutPath
                     $RawExtension = '.pdf'
                     $SourceType   = 'pdf'
-                } catch {
-                    Write-Warn "PDF download failed, falling back to HTML content: $_"
-                    Remove-Item $TempPdf -Force -ErrorAction SilentlyContinue
+                    $Title        = $SourceUrl
+                }
+                else {
+                    $HtmlContent  = [System.IO.File]::ReadAllText($Fetch.OutPath, [System.Text.Encoding]::UTF8)
+                    Write-OK "Fetched $([int]$HtmlContent.Length) characters ($($Fetch.ContentType))"
+                    $Meta    = Get-HtmlMeta -Html $HtmlContent
+                    if ($Meta.Title) { $Title = $Meta.Title } else { $Title = $SourceUrl }
+                    $Authors = $Meta.Author
+                    $MarkdownText = ConvertFrom-Html -Html $HtmlContent -SourceUrl $SourceUrl
+                    $RawContent   = $HtmlContent
+                    $RawExtension = '.html'
+                    $SourceType   = 'web_article'
+                }
+            } finally {
+                if ($Fetch -and $Fetch.OutPath -and (Test-Path -LiteralPath $Fetch.OutPath)) {
+                    Remove-Item -LiteralPath $Fetch.OutPath -Force -ErrorAction SilentlyContinue
                 }
             }
         } else {

--- a/tests/Get-UrlViaSharedFetcher.Tests.ps1
+++ b/tests/Get-UrlViaSharedFetcher.Tests.ps1
@@ -1,0 +1,68 @@
+# Tag: ingestion (t/3310 — shared WAF-fetch wrapper)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Tests for Get-UrlViaSharedFetcher — the shared PS wrapper over the Node fetch-CLI (t/3310/t/3324).
+.DESCRIPTION
+    Covers the load-bearing contract mapping (ConvertFrom-FetchCliOutput — pure, no node spawn) and
+    the pre-flight guards. Both are private, exercised via InModuleScope.
+#>
+
+BeforeAll {
+    Import-Module "$PSScriptRoot/../scripts/AITriad/AITriad.psm1" -Force -WarningAction SilentlyContinue
+}
+
+Describe 'ConvertFrom-FetchCliOutput — frozen t/3324 contract' -Tag 'ingestion' {
+
+    It 'maps status/contentType/finalUrl/bodySnippet from valid CLI JSON' {
+        $r = InModuleScope AITriad {
+            ConvertFrom-FetchCliOutput -Stdout '{"status":200,"contentType":"application/pdf","finalUrl":"https://x/y.pdf","error":null,"bodySnippet":"hello"}' `
+                -Stderr '' -ExitCode 0 -OutPath 'C:\tmp\out.bin' -Url 'https://x/y.pdf'
+        }
+        $r.Status      | Should -Be 200
+        $r.ContentType | Should -Be 'application/pdf'
+        $r.FinalUrl    | Should -Be 'https://x/y.pdf'
+        $r.BodySnippet | Should -Be 'hello'
+        $r.OutPath     | Should -Be 'C:\tmp\out.bin'
+        $r.Error       | Should -BeNullOrEmpty
+    }
+
+    It 'carries an HTTP-error status + error reason through' {
+        $r = InModuleScope AITriad {
+            ConvertFrom-FetchCliOutput -Stdout '{"status":403,"contentType":"","finalUrl":"","error":"forbidden","bodySnippet":"blocked"}' `
+                -Stderr '' -ExitCode 1 -OutPath 'C:\tmp\o'
+        }
+        $r.Status | Should -Be 403
+        $r.Error  | Should -Be 'forbidden'
+    }
+
+    It 'throws FetcherUnparseable AND deletes OutPath on non-JSON stdout' {
+        $tmp = [System.IO.Path]::GetTempFileName()
+        $result = InModuleScope AITriad -Parameters @{ tmp = $tmp } {
+            param($tmp)
+            try {
+                ConvertFrom-FetchCliOutput -Stdout 'not json at all' -Stderr 'boom' -ExitCode 1 -OutPath $tmp | Out-Null
+                return @{ matched = $false }
+            }
+            catch { return @{ matched = ($_.Exception.Message -match 'FetcherUnparseable') } }
+        }
+        $result.matched | Should -BeTrue
+        Test-Path -LiteralPath $tmp | Should -BeFalse -Because 'the temp out-file is cleaned up on an unparseable result'
+    }
+}
+
+Describe 'Get-UrlViaSharedFetcher — pre-flight guards' -Tag 'ingestion' {
+
+    It 'throws NodeMissing when node is not on PATH' {
+        $matched = InModuleScope AITriad {
+            Mock Get-Command -ParameterFilter { $Name -eq 'node' } -MockWith { $null }
+            try { Get-UrlViaSharedFetcher -Url 'https://example.com' | Out-Null; return $false }
+            catch { return ($_.Exception.Message -match 'NodeMissing') }
+        }
+        $matched | Should -BeTrue
+    }
+}


### PR DESCRIPTION
Migrates Import-AITriadDocument off PowerShell Invoke-RestMethod (WAF-fingerprint-blocked, t/3306) to the shared Node fetch-CLI (t/3324). New Private helper Get-UrlViaSharedFetcher wraps the CLI - the ONE PS-side external-URL fetch path (t/3312 class; t/3313/t/3320 reuse it; single allowlisted call site for the t/3314 guard), frozen to the t/3324 contract {status,contentType,finalUrl,error,bodySnippet}, file-based (bytes to a temp --out, metadata as stdout JSON). Import fetches once + dispatches conversion on Content-Type (authoritative) - unifies the HTML/PDF branches + closes the PDF-over-WAF gap; non-200/error -> status-classified ActionableError. Contract parse extracted to ConvertFrom-FetchCliOutput for unit-testing without spawning node. 7/7 Pester green. Follows the TL-approved t/3307 convert-only pattern (Quality nod p/360#311).

Co-Authored-By: PowerShell (Orca) <main.scripts@ai-triad-research.orca.local>

Co-Authored-By: Tech Lead (Orca) <main.engineering-tech-lead@ai-triad-research.orca.local>

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

Claude-Session: https://claude.ai/code/session_017oTzBj4a5mVYFzy96D3dny
