### PR TITLE
fix(lineage): Repair-PovLineage citation liveness via shared Node fetch-CLI (t/3313)

### DIFF
--- a/scripts/AITriad/Private/Test-LineageUrl.ps1
+++ b/scripts/AITriad/Private/Test-LineageUrl.ps1
@@ -1,0 +1,44 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+#
+# Citation-liveness check for POV intellectual-lineage URLs (used by Repair-PovLineage -FixUrls).
+# Fetches via the shared Node fetch-CLI (Get-UrlViaSharedFetcher, t/3313) instead of Invoke-WebRequest:
+# Node's undici passes WAFs that 403 the .NET/PowerShell client fingerprint (t/3306), so a live
+# WAF-protected citation is no longer falsely marked dead (the data-integrity bug this fixes).
+# GET + soft-404 body scan. Extracted from the Repair-PovLineage cmdlet body so the migration is
+# unit-testable. Dot-sourced by AITriad.psm1 — do NOT export.
+
+function Test-LineageUrl {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param([string]$Url)
+
+    Set-StrictMode -Version Latest
+
+    if ([string]::IsNullOrWhiteSpace($Url) -or $Url -notmatch '^https?://') { return $false }
+
+    $Fetch = $null
+    try {
+        $Fetch = Get-UrlViaSharedFetcher -Url $Url -TimeoutMs 8000
+        if ($Fetch.Status -ne 200) { return $false }
+        # Soft-404: some hosts return 200 for a "not found" page. Scan the CLI-provided body snippet.
+        if ($Fetch.BodySnippet -match '(?i)(page not found|does not exist|no article|404 error|there is no page)') {
+            return $false
+        }
+        return $true
+    }
+    catch {
+        # Fallback-path logging (docs/error-handling.md): an environment failure (NodeMissing /
+        # fetch-cli missing) or transport error means we could not verify — treated as not-live (same
+        # as the pre-migration catch), but logged so a mass "dead" run is diagnosable, not silent.
+        Write-Verbose "Test-LineageUrl: '$Url' treated as unreachable — $($_.Exception.Message)"
+        return $false
+    }
+    finally {
+        # Get-UrlViaSharedFetcher writes response bytes to a caller-owned temp file; liveness only
+        # needs status + snippet, so clean it up.
+        if ($null -ne $Fetch -and $Fetch.PSObject.Properties['OutPath'] -and $Fetch.OutPath) {
+            Remove-Item -LiteralPath $Fetch.OutPath -Force -ErrorAction SilentlyContinue
+        }
+    }
+}

--- a/scripts/AITriad/Public/Repair-PovLineage.ps1
+++ b/scripts/AITriad/Public/Repair-PovLineage.ps1
@@ -126,22 +126,9 @@ function Repair-PovLineage {
         Write-Verbose "Loaded $($Cache.Count) cached enrichments"
     }
 
-    # ── URL validation helper (GET-based, soft 404 detection) ────────────────
-    function Test-LineageUrl {
-        param([string]$Url)
-        if ([string]::IsNullOrWhiteSpace($Url) -or $Url -notmatch '^https?://') { return $false }
-        try {
-            $Resp = Invoke-WebRequest -Uri $Url -Method Get -TimeoutSec 8 -MaximumRedirection 5 `
-                -ErrorAction Stop -UseBasicParsing
-            if ($Resp.StatusCode -ne 200) { return $false }
-            # Soft 404 detection: check first 1KB of body for "not found" signals
-            $BodySnippet = if ($Resp.Content.Length -gt 1024) { $Resp.Content.Substring(0, 1024) } else { $Resp.Content }
-            if ($BodySnippet -match '(?i)(page not found|does not exist|no article|404 error|there is no page)') {
-                return $false
-            }
-            return $true
-        } catch { return $false }
-    }
+    # URL validation helper (GET-based, soft-404 detection) lives in Private/Test-LineageUrl.ps1 —
+    # migrated to the shared Node fetch-CLI (Get-UrlViaSharedFetcher) so live WAF-protected citations
+    # aren't 403'd-as-dead by the PS client fingerprint (t/3313). Extracted for unit-testability.
 
     function Get-WikipediaFallbackUrl {
         param([string]$Name)

--- a/tests/Test-LineageUrl.Tests.ps1
+++ b/tests/Test-LineageUrl.Tests.ps1
@@ -1,0 +1,71 @@
+# Tag: lineage (t/3313)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Tests for Test-LineageUrl — the POV citation-liveness check migrated to the shared Node fetch-CLI
+    (t/3313). Proves the WAF-fingerprint fix: a live WAF-protected citation (Node fetches 200) is no
+    longer falsely marked dead, and the fetch no longer uses Invoke-WebRequest. Private function,
+    exercised via InModuleScope with Get-UrlViaSharedFetcher mocked (no node spawn, no network).
+#>
+
+BeforeAll {
+    Import-Module "$PSScriptRoot/../scripts/AITriad/AITriad.psm1" -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Test-LineageUrl — shared-fetcher migration (t/3313)' -Tag 'lineage' {
+
+    It 'treats a WAF-protected citation that Node fetches (200) as LIVE — the fix' {
+        InModuleScope AITriad {
+            Mock Get-UrlViaSharedFetcher { [PSCustomObject]@{ Status = 200; BodySnippet = 'The Federalist Papers, No. 10.'; OutPath = $null } }
+            Mock Invoke-WebRequest { throw 'the migration must not call Invoke-WebRequest' }
+            Test-LineageUrl -Url 'https://www.sanders.senate.gov/live-citation' | Should -BeTrue
+            Should -Invoke Get-UrlViaSharedFetcher -Times 1 -Exactly
+            Should -Not -Invoke Invoke-WebRequest
+        }
+    }
+
+    It 'treats a non-200 status as DEAD' {
+        InModuleScope AITriad {
+            Mock Get-UrlViaSharedFetcher { [PSCustomObject]@{ Status = 404; BodySnippet = ''; OutPath = $null } }
+            Test-LineageUrl -Url 'https://example.com/gone' | Should -BeFalse
+        }
+    }
+
+    It 'treats a 200 soft-404 body ("page not found") as DEAD' {
+        InModuleScope AITriad {
+            Mock Get-UrlViaSharedFetcher { [PSCustomObject]@{ Status = 200; BodySnippet = 'Sorry — this page not found on our server.'; OutPath = $null } }
+            Test-LineageUrl -Url 'https://example.com/soft404' | Should -BeFalse
+        }
+    }
+
+    It 'returns $false (not-verifiable) when the fetcher throws (e.g. NodeMissing) without leaking the error' {
+        InModuleScope AITriad {
+            Mock Get-UrlViaSharedFetcher { throw 'NodeMissing: node was not found on PATH' }
+            (Test-LineageUrl -Url 'https://example.com/x' 4>$null) | Should -BeFalse
+        }
+    }
+
+    It 'deletes the fetcher-owned OutPath temp file after a liveness check' {
+        $tmp = [System.IO.Path]::GetTempFileName()
+        InModuleScope AITriad -Parameters @{ tmp = $tmp } {
+            param($tmp)
+            Mock Get-UrlViaSharedFetcher { [PSCustomObject]@{ Status = 200; BodySnippet = 'ok'; OutPath = $tmp } }
+            Test-LineageUrl -Url 'https://example.com/live' | Out-Null
+        }
+        Test-Path -LiteralPath $tmp | Should -BeFalse -Because 'Test-LineageUrl only needs status+snippet, so it cleans up the temp bytes'
+    }
+
+    It 'rejects an empty or non-http(s) URL without invoking the fetcher' {
+        InModuleScope AITriad {
+            Mock Get-UrlViaSharedFetcher { throw 'must not fetch a malformed URL' }
+            Test-LineageUrl -Url ''             | Should -BeFalse
+            Test-LineageUrl -Url 'ftp://x/y'    | Should -BeFalse
+            Test-LineageUrl -Url 'not-a-url'    | Should -BeFalse
+            Should -Not -Invoke Get-UrlViaSharedFetcher
+        }
+    }
+}


### PR DESCRIPTION
## What

Migrates `Repair-PovLineage`'s citation-liveness check off PowerShell `Invoke-WebRequest` (WAF-403'd by the .NET/PS client fingerprint, t/3306) onto the shared Node fetch-CLI via `Get-UrlViaSharedFetcher` (landed in #1964). A **live WAF-protected citation** that was falsely marked **dead** is now correctly fetched (200 via Node's undici) — the data-integrity bug in t/3313.

Part of the t/3312 WAF-fingerprint fetch-class closure. Independent of the other migrations — lands on its own once the Quality-TL GV clears.

## Changes

- **Extract `Test-LineageUrl` → `scripts/AITriad/Private/Test-LineageUrl.ps1`** (was nested in `Repair-PovLineage`'s `end` block; self-contained, only takes `$Url`). *Deliberate deviation from a pure in-place swap:* a nested function isn't unit-testable — extraction is the minimal way to prove the AC. `Get-WikipediaFallbackUrl` stays nested and resolves the now-module-level `Test-LineageUrl`. Private → no manifest change.
- **Migrate the fetch:** `Get-UrlViaSharedFetcher -Url $Url -TimeoutMs 8000`; `Status -ne 200 → dead`; the soft-404 regex runs on the CLI-provided `BodySnippet` (resolves the "need a body snippet" open question in t/3313#1 — the helper exposes it); `finally` deletes `$Fetch.OutPath` (caller owns the temp bytes; liveness only needs status+snippet); `catch → $false` preserved **+ a `Write-Verbose` fallback log** so an environment failure (e.g. NodeMissing) is a diagnosable mass-"dead", not a silent one (error-handling convention).

## Tests (`tests/Test-LineageUrl.Tests.ps1`, InModuleScope + mocked fetcher)

- **WAF-200 → LIVE** (the fix) + `Should -Not -Invoke Invoke-WebRequest` (proves the migration)
- non-200 → dead; 200 soft-404 body → dead; fetcher throws → dead (no error leak); OutPath temp file cleaned up; empty/non-http URL → dead without invoking the fetcher

Local: `Test-LineageUrl` (6) + `Get-UrlViaSharedFetcher` (4) + `AITriad.Module` integrity (38) all green; `Test-ModuleManifest` valid. Full `Invoke-Pester ./tests/` runs in CI.

## Review

Self-certified against the #1964 shared-fetcher migration pattern (t/3310); routing to **Quality (TL)** for the Gate Verification per t/3313#2. Draft until the GV clears.

Closes t/3313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
