### PR TITLE
feat(oped): New-OpEd CLI fetch -> shared Node fetch-CLI (t/3320)

### DIFF
--- a/scripts/AITriad/Private/Get-OpEdSourceFromUrl.ps1
+++ b/scripts/AITriad/Private/Get-OpEdSourceFromUrl.ps1
@@ -1,16 +1,12 @@
 # Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 # Licensed under the MIT License. See LICENSE file in the project root.
 #
-# CLI convenience: best-effort PS fetch → temp file → convert-only Get-OpEdSource, so `New-OpEd -Url`
-# keeps working from the command line after Get-OpEdSource became convert-only (t/3307).
-#
-# WAF-limited interim (t/3312): PowerShell's Invoke-WebRequest client fingerprint is blocked by some
-# WAFs (Akamai .gov/news PDFs will 403 it) — the same WAF-fingerprint fetch class the Electron op-ed
-# path already avoids by fetching via Node (fetchUrlForPromptBinary) and calling the convert-only
-# shim. This helper is the ONE remaining PS-side external URL fetch; it migrates to the shared Node
-# fetch-CLI entrypoint when that lands under t/3312. Kept for now so the CLI is not broken. Because it
-# is a t/3312 class-member, it is intentionally localized here (one entry point) rather than inlined
-# into New-OpEd, so the migration and any WAF-fetch prevention guard have a single site to target.
+# CLI convenience: fetch (via the shared Node fetch-CLI) → temp file → convert-only Get-OpEdSource,
+# so `New-OpEd -Url` works from the command line after Get-OpEdSource became convert-only (t/3307).
+# Migrated off PowerShell Invoke-WebRequest to Get-UrlViaSharedFetcher (t/3320) — Node's undici passes
+# WAFs that block the .NET/PS client fingerprint (t/3306), and the fetch is SSRF-guarded, routed
+# through the ONE shared PS-side external-URL fetch path (t/3312 class). Localized here (one entry
+# point) so New-OpEd stays convert-only.
 #
 # Dot-sourced by AITriad.psm1 — do NOT export.
 
@@ -34,52 +30,38 @@ function Get-OpEdSourceFromUrl {
 
     Set-StrictMode -Version Latest
 
+    $Fetch = Get-UrlViaSharedFetcher -Url $Url -TimeoutMs 60000
     try {
-        $Resp = Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 60
-    } catch {
-        throw (New-ActionableError -PassThru `
-            -ErrorType 'FetchFailed' `
-            -Goal 'Fetch source URL for op-ed generation' `
-            -Problem "Could not fetch '$Url': $($_.Exception.Message)" `
-            -Location 'Get-OpEdSourceFromUrl' `
-            -NextSteps @(
-                'Confirm the URL is reachable and publicly accessible',
-                'This CLI fetch is WAF-limited (Akamai .gov/news PDFs may 403 the PowerShell client); use the Electron op-ed path or supply -Topic text in New-OpEd instead'
-            ))
-    }
-
-    # Content-Type is authoritative for the convert step; fall back to the URL extension only when the
-    # server omitted it. Get-OpEdSource dispatches on ContentType, so the temp-file extension is advisory.
-    $ContentType = [string]($Resp.Headers['Content-Type'] ?? '')
-    if ([string]::IsNullOrWhiteSpace($ContentType)) {
-        $UrlExt = [System.IO.Path]::GetExtension(([uri]$Url).LocalPath).ToLowerInvariant()
-        $ContentType = switch ($UrlExt) {
-            '.pdf'  { 'application/pdf' }
-            '.docx' { 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' }
-            default { 'text/html' }
+        if ($Fetch.Status -ne 200 -or $Fetch.Error) {
+            $code   = if ($null -ne $Fetch.Status) { $Fetch.Status } else { 'transport-failure' }
+            $detail = if ($Fetch.Error) { "; $($Fetch.Error)" } else { '' }
+            throw (New-ActionableError -PassThru -ErrorType 'FetchFailed' `
+                -Goal 'Fetch source URL for op-ed generation' `
+                -Problem "Could not fetch '$Url' (status: $code$detail)." `
+                -Location 'Get-OpEdSourceFromUrl' `
+                -NextSteps @(
+                    'The shared fetcher (Node) already passes most WAFs; a persistent failure usually means the URL is unreachable, access-blocked, or SSRF-guarded',
+                    'Supply -Topic text in New-OpEd instead'
+                ))
         }
-    }
 
-    $TempExt = if ($ContentType -match 'pdf') { '.pdf' } elseif ($ContentType -match 'wordprocessingml') { '.docx' } else { '.html' }
-    $TempFile = [System.IO.Path]::GetTempFileName() + $TempExt
-    try {
-        # Persist RAW bytes so binary sources (PDF/DOCX) stay intact. Prefer RawContentStream — for a
-        # binary body $Resp.Content is a decoded string that corrupts the bytes. Property-guarded for
-        # StrictMode + test doubles that lack RawContentStream.
-        $HasRaw = $Resp.PSObject.Properties['RawContentStream'] -and $null -ne $Resp.RawContentStream
-        $Bytes = if ($HasRaw) {
-            $Ms = [System.IO.MemoryStream]::new()
-            try { $Resp.RawContentStream.Position = 0; $Resp.RawContentStream.CopyTo($Ms); $Ms.ToArray() }
-            finally { $Ms.Dispose() }
-        } elseif ($Resp.PSObject.Properties['Content'] -and ($Resp.Content -is [byte[]])) {
-            $Resp.Content
-        } else {
-            [System.Text.Encoding]::UTF8.GetBytes([string]$Resp.Content)
+        # Content-Type is authoritative for the convert step; fall back to the URL extension only when
+        # the server omitted it. Get-OpEdSource dispatches on ContentType (the temp path is advisory).
+        $ContentType = [string]$Fetch.ContentType
+        if ([string]::IsNullOrWhiteSpace($ContentType)) {
+            $UrlExt = [System.IO.Path]::GetExtension(([uri]$Url).LocalPath).ToLowerInvariant()
+            $ContentType = switch ($UrlExt) {
+                '.pdf'  { 'application/pdf' }
+                '.docx' { 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' }
+                default { 'text/html' }
+            }
         }
-        [System.IO.File]::WriteAllBytes($TempFile, $Bytes)
-        Get-OpEdSource -ContentPath $TempFile -ContentType $ContentType -SourceUrl $Url `
+
+        Get-OpEdSource -ContentPath $Fetch.OutPath -ContentType $ContentType -SourceUrl $Url `
             -MaxChars $MaxChars -MinReadableWords $MinReadableWords -MinAlphaDensity $MinAlphaDensity
     } finally {
-        Remove-Item -LiteralPath $TempFile -Force -ErrorAction SilentlyContinue
+        if ($Fetch -and $Fetch.OutPath -and (Test-Path -LiteralPath $Fetch.OutPath)) {
+            Remove-Item -LiteralPath $Fetch.OutPath -Force -ErrorAction SilentlyContinue
+        }
     }
 }

--- a/tests/Get-OpEdSourceFromUrl.Tests.ps1
+++ b/tests/Get-OpEdSourceFromUrl.Tests.ps1
@@ -1,0 +1,54 @@
+# Tag: oped (t/3320 — shared-fetcher migration)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Tests for Get-OpEdSourceFromUrl after its migration to the shared Node fetcher (t/3320).
+.DESCRIPTION
+    Private helper — exercised via InModuleScope with Get-UrlViaSharedFetcher + Get-OpEdSource mocked
+    (no node, no network). Verifies it delegates convert to Get-OpEdSource with the fetcher's OutPath +
+    Content-Type on success, and throws a FetchFailed ActionableError on a non-200 status.
+#>
+
+BeforeAll {
+    Import-Module "$PSScriptRoot/../scripts/AITriad/AITriad.psm1" -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Get-OpEdSourceFromUrl — shared-fetcher migration' -Tag 'oped' {
+
+    It 'delegates to Get-OpEdSource with the fetcher OutPath + ContentType on status 200' {
+        $captured = InModuleScope AITriad {
+            $tmp = [System.IO.Path]::GetTempFileName()
+            Mock Get-UrlViaSharedFetcher {
+                [PSCustomObject]@{ Status = 200; ContentType = 'application/pdf'; FinalUrl = 'https://x/y.pdf'
+                    Error = $null; BodySnippet = ''; OutPath = $tmp; ExitCode = 0 }
+            }
+            $script:seen = $null
+            Mock Get-OpEdSource {
+                $script:seen = @{ ContentPath = $ContentPath; ContentType = $ContentType; SourceUrl = $SourceUrl }
+                [pscustomobject]@{ SourceMarkdown = 'ok' }
+            }
+            Get-OpEdSourceFromUrl -Url 'https://x/y.pdf' | Out-Null
+            $script:seen
+        }
+        $captured.ContentType | Should -Be 'application/pdf'
+        $captured.SourceUrl   | Should -Be 'https://x/y.pdf'
+        $captured.ContentPath | Should -Not -BeNullOrEmpty
+    }
+
+    It 'throws FetchFailed on a non-200 status (and does not call the converter)' {
+        $matched = InModuleScope AITriad {
+            Mock Get-UrlViaSharedFetcher {
+                [PSCustomObject]@{ Status = 403; ContentType = ''; FinalUrl = ''; Error = 'forbidden'
+                    BodySnippet = 'blocked'; OutPath = [System.IO.Path]::GetTempFileName(); ExitCode = 1 }
+            }
+            Mock Get-OpEdSource { throw 'Get-OpEdSource must not be called on a fetch failure' }
+            try { Get-OpEdSourceFromUrl -Url 'https://x' | Out-Null; return $false }
+            catch { return ($_.Exception.Message -match 'FetchFailed') }
+        }
+        $matched | Should -BeTrue
+    }
+}

--- a/tests/New-OpEd.Tests.ps1
+++ b/tests/New-OpEd.Tests.ps1
@@ -175,11 +175,13 @@ Describe 'New-OpEd' -Tag 'oped' {
 
     Context 'URL input' {
         It 'Fetches and converts the URL into source material' {
-            Mock Invoke-WebRequest { [PSCustomObject]@{
-                Content    = '<html><body><p>Source body text.</p></body></html>'
-                Headers    = @{ 'Content-Type' = 'text/html; charset=utf-8' }
-                StatusCode = 200
-            } } -ModuleName AITriad
+            # t/3320: the CLI fetch now routes through the shared Node fetcher (Get-UrlViaSharedFetcher),
+            # which writes bytes to OutPath + returns the t/3324 contract metadata.
+            Mock Get-UrlViaSharedFetcher {
+                $tmp = [System.IO.Path]::GetTempFileName()
+                [System.IO.File]::WriteAllText($tmp, '<html><body><p>Source body text.</p></body></html>')
+                [PSCustomObject]@{ Status = 200; ContentType = 'text/html; charset=utf-8'; FinalUrl = 'https://example.com/article'; Error = $null; BodySnippet = 'Source body text.'; OutPath = $tmp; ExitCode = 0 }
+            } -ModuleName AITriad
             # 35 alpha words per sentence × 3 = 105 — passes the MinReadableWords=100
             # gate; "Source body text" preserved for the seenPrompt assertion.
             Mock ConvertFrom-Html {
@@ -196,7 +198,7 @@ Describe 'New-OpEd' -Tag 'oped' {
             $r = New-OpEd -Url 'https://example.com/article' -Pov accelerationist
             $r.Headline | Should -Be 'Stop Stalling on AI Safety'
             $script:seenPrompt | Should -Match 'Source body text'
-            Should -Invoke Invoke-WebRequest -ModuleName AITriad -Times 1
+            Should -Invoke Get-UrlViaSharedFetcher -ModuleName AITriad -Times 1
         }
     }
 


### PR DESCRIPTION
Migrates Get-OpEdSourceFromUrl (New-OpEd -Url CLI path) off the WAF-limited interim Invoke-WebRequest to the shared Get-UrlViaSharedFetcher (t/3310/t/3324) - Node's undici passes WAFs that block the PS client (t/3306), SSRF-guarded; the last PS-side external Invoke-* in the op-ed path is now gone. Simpler: the helper does the fetch + bytes-to-temp; Get-OpEdSourceFromUrl dispatches convert on Content-Type (authoritative) + status-classified FetchFailed on non-200. New-OpEd.Tests URL path re-mocked to the helper; new Get-OpEdSourceFromUrl.Tests (delegation + FetchFailed). 22/22 Pester green. Self-cert Quality (t/3307 convert-only pattern, TL nod p/360#311).

Co-Authored-By: PowerShell (Orca) <main.scripts@ai-triad-research.orca.local>

Co-Authored-By: Tech Lead (Orca) <main.engineering-tech-lead@ai-triad-research.orca.local>

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

Claude-Session: https://claude.ai/code/session_017oTzBj4a5mVYFzy96D3dny
