### PR TITLE
feat(settings): derive renderer model picker from ai-models.json (t/3280 Phase 2b)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/__tests__/deriveModelsByBackend.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/__tests__/deriveModelsByBackend.test.ts
@@ -19,6 +19,7 @@ import { dirname, resolve } from 'node:path';
 import {
   deriveModelsByBackend,
   MODELS_BY_BACKEND,
+  AI_BACKENDS,
   getStoredModel,
   type AIBackend,
 } from '../settingsSlice';
@@ -76,6 +77,25 @@ describe('deriveModelsByBackend (t/3280 SSOT derive)', () => {
 
   it('an empty-picker backend (deepseek) derives to [] without crashing', () => {
     expect(derived.deepseek).toEqual([]);
+  });
+
+  it('no user-selectable backend has an empty picker (would strand the model dropdown)', () => {
+    // Pre-load AI_BACKENDS must offer only backends with ≥1 curated model; initAIModels applies the
+    // same picker-presence filter at runtime. deepseek is the empty-picker case that must be excluded.
+    for (const b of AI_BACKENDS) {
+      expect(MODELS_BY_BACKEND[b.value].length, `backend '${b.value}' is selectable but has no picker models`).toBeGreaterThan(0);
+    }
+    expect(AI_BACKENDS.some(b => b.value === 'deepseek'), 'deepseek (no picker models) must not be selectable').toBe(false);
+  });
+
+  it('the selectable-backend set derived from config == pre-load AI_BACKENDS', () => {
+    // The runtime filter (initAIModels) keeps a config backend iff it has ≥1 derived picker model;
+    // that set must equal the pre-load constant so pre-load and post-load never disagree.
+    const selectableFromConfig = new Set(
+      aiModels.backends.filter(b => (derived[b.id as AIBackend]?.length ?? 0) > 0).map(b => b.id),
+    );
+    const preLoad = new Set(AI_BACKENDS.map(b => b.value));
+    expect(preLoad).toEqual(selectableFromConfig);
   });
 
   it('getStoredModel never returns a non-model id even when its backend has an empty picker', () => {

--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/__tests__/deriveModelsByBackend.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/__tests__/deriveModelsByBackend.test.ts
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// @vitest-environment jsdom
+
+// t/3280 Phase 2b: the renderer model picker (MODELS_BY_BACKEND) is DERIVED from ai-models.json's
+// per-model `picker:{label,order}` field — the single source of truth — not maintained by hand.
+// These gates prove the derive is faithful and lock the SSOT invariant:
+//   1. PARITY — deriveModelsByBackend(ai-models.json) is byte-identical to the curated
+//      MODELS_BY_BACKEND checked into source (so the pre-load fallback == the runtime derive; no drift).
+//   2. DEFAULT_MODEL is present as a selectable picker entry (the global default must be pickable).
+//   3. Empty-picker backend (deepseek) derives to [] without crashing, and getStoredModel guards it.
+// Wired into `npm run verify:config`.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import {
+  deriveModelsByBackend,
+  MODELS_BY_BACKEND,
+  getStoredModel,
+  type AIBackend,
+} from '../settingsSlice';
+import { DEFAULT_MODEL } from '@lib/ai-client/defaults';
+
+const here = dirname(fileURLToPath(import.meta.url));
+// __tests__ → slices → useTaxonomyStore → hooks → renderer → src → taxonomy-editor → repo root
+const aiModels = JSON.parse(
+  readFileSync(resolve(here, '../../../../../../../ai-models.json'), 'utf8'),
+) as {
+  backends: { id: string; label: string }[];
+  models: { id: string; label: string; backend: string; picker?: { label: string; order: number } }[];
+  defaults: Record<string, string>;
+};
+
+describe('deriveModelsByBackend (t/3280 SSOT derive)', () => {
+  const derived = deriveModelsByBackend(aiModels);
+
+  it('has a non-empty picker to derive from (guards against a false-green empty read)', () => {
+    const withPicker = aiModels.models.filter(m => m.picker);
+    expect(withPicker.length).toBeGreaterThan(0);
+  });
+
+  it('PARITY: derived picker is byte-identical to the curated MODELS_BY_BACKEND', () => {
+    // Deep-equal per backend for a legible diff on failure, then the whole object.
+    for (const backend of Object.keys(MODELS_BY_BACKEND) as AIBackend[]) {
+      expect(derived[backend], `backend '${backend}' derive != curated`).toEqual(MODELS_BY_BACKEND[backend]);
+    }
+    expect(derived).toEqual(MODELS_BY_BACKEND);
+  });
+
+  it('every derived entry has a real ai-models.json model id (no phantoms)', () => {
+    const configIds = new Set(aiModels.models.map(m => m.id));
+    const phantoms: string[] = [];
+    for (const entries of Object.values(derived)) {
+      for (const e of entries) if (!configIds.has(e.value)) phantoms.push(e.value);
+    }
+    expect(phantoms, `derived picker entries with no config model:\n${phantoms.join('\n')}`).toEqual([]);
+  });
+
+  it('entries within a backend are sorted by picker.order', () => {
+    for (const backend of Object.keys(derived) as AIBackend[]) {
+      const orders = derived[backend].map(
+        e => aiModels.models.find(m => m.id === e.value)?.picker?.order ?? Number.NaN,
+      );
+      const sorted = [...orders].sort((a, b) => a - b);
+      expect(orders, `backend '${backend}' not order-sorted`).toEqual(sorted);
+    }
+  });
+
+  it('DEFAULT_MODEL is a selectable picker entry (the global default must be pickable)', () => {
+    const allValues = new Set(Object.values(derived).flat().map(e => e.value));
+    expect(allValues.has(DEFAULT_MODEL), `DEFAULT_MODEL '${DEFAULT_MODEL}' absent from the derived picker`).toBe(true);
+  });
+
+  it('an empty-picker backend (deepseek) derives to [] without crashing', () => {
+    expect(derived.deepseek).toEqual([]);
+  });
+
+  it('getStoredModel never returns a non-model id even when its backend has an empty picker', () => {
+    // deepseek is the empty-picker case; the phantom-default guard must fall back to DEFAULT_MODEL.
+    localStorage.clear();
+    localStorage.setItem('taxonomy-editor-backend', 'deepseek');
+    const model = getStoredModel();
+    const allValues = new Set(Object.values(MODELS_BY_BACKEND).flat().map(e => e.value));
+    expect(allValues.has(model) || model === DEFAULT_MODEL).toBe(true);
+    localStorage.clear();
+  });
+});

--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/settingsSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/settingsSlice.ts
@@ -85,7 +85,8 @@ export const AI_BACKENDS: { value: AIBackend; label: string }[] = [
   { value: 'claude', label: 'Anthropic Claude' },
   { value: 'groq', label: 'Groq' },
   { value: 'openai', label: 'OpenAI' },
-  { value: 'deepseek', label: 'DeepSeek' },
+  // t/3280 (TL GV): deepseek has no `picker` models → not user-selectable (it would strand the model
+  // dropdown). Excluded from the pre-load list to match the runtime picker-presence filter in initAIModels.
   { value: 'azure', label: 'Azure OpenAI' },
   { value: 'ollama', label: 'Ollama (Local)' },
   { value: 'zai', label: 'Z.AI (GLM)' },
@@ -231,11 +232,6 @@ export async function initAIModels(): Promise<void> {
     const config = await api.loadAIModels() as AIModelsConfig | null;
     if (!config?.models?.length) return;
 
-    AI_BACKENDS.length = 0;
-    for (const b of config.backends) {
-      AI_BACKENDS.push({ value: b.id as AIBackend, label: b.label });
-    }
-
     // t/3280: derive the picker from the curated `picker` entries (SSOT) — not every config model.
     // The former all-models push surfaced 100+ backend variants in the dropdown; the picker is the
     // hand-curated subset. deriveModelsByBackend guarantees every backend key gets an array (empty if
@@ -243,6 +239,16 @@ export async function initAIModels(): Promise<void> {
     const derived = deriveModelsByBackend(config);
     for (const key of Object.keys(MODELS_BY_BACKEND) as AIBackend[]) {
       MODELS_BY_BACKEND[key] = derived[key] ?? [];
+    }
+
+    // t/3280 (TL GV, t/3280#7): a backend is selectable iff it has ≥1 picker model. deepseek is in
+    // config.backends but carries no `picker` entries → derives to []; offering it would strand the
+    // model dropdown into a silent DEFAULT_MODEL fallback. Filter here (SSOT — no hardcoded exclusion,
+    // so any future zero-picker backend is handled automatically).
+    AI_BACKENDS.length = 0;
+    for (const b of config.backends) {
+      if ((derived[b.id as AIBackend]?.length ?? 0) === 0) continue;
+      AI_BACKENDS.push({ value: b.id as AIBackend, label: b.label });
     }
 
     for (const [k, v] of Object.entries(config.defaults)) {

--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/settingsSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/settingsSlice.ts
@@ -96,7 +96,6 @@ export const AI_BACKENDS: { value: AIBackend; label: string }[] = [
 export const MODELS_BY_BACKEND: Record<AIBackend, AIModelEntry[]> = {
   gemini: [
     { value: DEFAULT_MODEL, label: '3.1 Flash Lite Preview (default)' },
-    { value: 'gemini-3-flash-preview', label: '3 Flash Preview' },
     { value: 'gemini-3.1-pro-preview', label: '3.1 Pro Preview (best quality)' },
     { value: 'gemini-3.8-flash', label: '3.8 Flash' },
     { value: 'gemini-3.6-flash', label: '3.6 Flash' },
@@ -112,7 +111,6 @@ export const MODELS_BY_BACKEND: Record<AIBackend, AIModelEntry[]> = {
     { value: 'claude-haiku-4-5', label: 'Haiku 4.5 (fastest)' },
   ],
   groq: [
-    { value: 'groq-llama-4-scout-17b-16e', label: 'Llama 4 Scout' },
     { value: 'groq-llama-3.3-70b-versatile', label: 'Llama 3.3 70B' },
     { value: 'groq-openai-gpt-oss-120b', label: 'GPT-OSS 120B' },
   ],
@@ -120,10 +118,10 @@ export const MODELS_BY_BACKEND: Record<AIBackend, AIModelEntry[]> = {
     { value: 'openai-gpt-5.5', label: 'GPT-5.5' },
     { value: 'openai-gpt-5.5-pro', label: 'GPT-5.5 Pro' },
   ],
-  deepseek: [
-    { value: 'deepseek-chat', label: 'DeepSeek V3 (default)' },
-    { value: 'deepseek-reasoner', label: 'DeepSeek R1 (reasoning)' },
-  ],
+  // t/3280: deepseek has NO picker entries in ai-models.json — both prior entries (deepseek-chat,
+  // deepseek-reasoner) were phantoms (no config id → misroute on select). Empty picker; the runtime
+  // derive keeps it []. Empty-backend handling: getStoredModel falls back to DEFAULT_MODEL (below).
+  deepseek: [],
   azure: [
     { value: 'azure-gpt-4o', label: 'GPT-4o' },
     { value: 'azure-gpt-4o-mini', label: 'GPT-4o Mini' },
@@ -192,16 +190,40 @@ export function getStoredModel(): AIModel {
   } catch (err) {
     getGlobalRecorder()?.record({ type: 'system.error', component: 'taxonomy-store', level: 'warn', message: 'Failed to read stored AI model from localStorage', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
   }
+  // t/3280: guard an empty-picker backend (deepseek) / a pre-load phantom default — never strand the
+  // UI on a non-model id; fall back to the always-present global DEFAULT_MODEL.
   const backend = getStoredBackend();
-  return DEFAULT_MODELS[backend];
+  const fallback = DEFAULT_MODELS[backend];
+  return ALL_MODEL_IDS.has(fallback) ? fallback : DEFAULT_MODEL;
 }
 
 interface AIModelsConfig {
   backends: { id: string; label: string }[];
-  models: { id: string; label: string; backend: string }[];
+  models: { id: string; label: string; backend: string; picker?: { label: string; order: number } }[];
   defaults: Record<string, string>;
   debateTiers?: Record<string, Record<string, string>>;
   fallbackChains?: Record<string, string[]>;
+}
+
+/**
+ * t/3280: DERIVE the renderer model picker from ai-models.json's per-model `picker` field — the single
+ * source of truth. A model is selectable iff it carries `picker:{label,order}`; the picker is that
+ * curated subset per backend, sorted by `picker.order`, labelled with `picker.label` verbatim (the
+ * "(default)" suffix is baked into the config label). Curated-out models (no `picker`) never appear, so
+ * phantoms (picker ids with no config entry) are impossible by construction, and a backend with zero
+ * selectable models (e.g. deepseek) derives to [] — rendered gracefully; getStoredModel guards the default.
+ */
+export function deriveModelsByBackend(config: AIModelsConfig): Record<AIBackend, AIModelEntry[]> {
+  const buckets: Record<string, { value: AIModel; label: string; order: number }[]> = {};
+  for (const m of config.models) {
+    if (!m.picker) continue;
+    (buckets[m.backend] ??= []).push({ value: m.id as AIModel, label: m.picker.label, order: m.picker.order });
+  }
+  const out = {} as Record<AIBackend, AIModelEntry[]>;
+  for (const backend of Object.keys(MODELS_BY_BACKEND) as AIBackend[]) {
+    out[backend] = (buckets[backend] ?? []).sort((a, b) => a.order - b.order).map(({ value, label }) => ({ value, label }));
+  }
+  return out;
 }
 
 export async function initAIModels(): Promise<void> {
@@ -214,13 +236,13 @@ export async function initAIModels(): Promise<void> {
       AI_BACKENDS.push({ value: b.id as AIBackend, label: b.label });
     }
 
+    // t/3280: derive the picker from the curated `picker` entries (SSOT) — not every config model.
+    // The former all-models push surfaced 100+ backend variants in the dropdown; the picker is the
+    // hand-curated subset. deriveModelsByBackend guarantees every backend key gets an array (empty if
+    // none carry `picker`), so no backend is left with a stale pre-load list.
+    const derived = deriveModelsByBackend(config);
     for (const key of Object.keys(MODELS_BY_BACKEND) as AIBackend[]) {
-      MODELS_BY_BACKEND[key] = [];
-    }
-    for (const m of config.models) {
-      const backend = m.backend as AIBackend;
-      if (!MODELS_BY_BACKEND[backend]) MODELS_BY_BACKEND[backend] = [];
-      MODELS_BY_BACKEND[backend].push({ value: m.id as AIModel, label: m.label });
+      MODELS_BY_BACKEND[key] = derived[key] ?? [];
     }
 
     for (const [k, v] of Object.entries(config.defaults)) {


### PR DESCRIPTION
## t/3280 Phase 2b — derive MODELS_BY_BACKEND from the config SSOT

The renderer's `MODELS_BY_BACKEND` was a hand-maintained **second registry** duplicating what `ai-models.json` already declares. This makes it **derived** from the config's per-model `picker:{label,order}` field — the single source of truth.

### What changed
- **`deriveModelsByBackend(config)`** (new, exported, pure): a model is selectable iff it carries a `picker` entry; the picker is that curated subset per backend, sorted by `picker.order`, labelled with `picker.label` verbatim (the `(default)` suffix is baked into the config label). Every backend key gets an array (empty if none).
- **`initAIModels`** now wires the derive at runtime, replacing the former all-models push (which surfaced 100+ backend variants in the dropdown).
- **Trimmed 4 phantoms** from the curated in-source fallback so it stays **byte-identical to the derive**: `gemini-3-flash-preview`, `groq-llama-4-scout-17b-16e`, `deepseek-chat`, `deepseek-reasoner` (the last two had no config id → misroute on select).
- **deepseek** has no picker entries → derives to `[]` gracefully. `getStoredModel` now **guards a phantom/empty-picker default**, falling back to the always-present global `DEFAULT_MODEL`.

### Why keep the in-source fallback at all?
Config loads **async** (`api.loadAIModels()`), so a pure build-time derive would need vite `fs.allow` changes. The in-source `MODELS_BY_BACKEND` is the **pre-load fallback**; the runtime derive overwrites it. The new **parity gate** proves fallback === derive byte-for-byte, so they can't drift. *(Flagging this fallback-vs-pure-derive nuance for GV.)*

### Gates (wired into `verify:config`)
`deriveModelsByBackend.test.ts` — **parity** (derive === curated, per-backend + whole), **no-phantoms**, **order-sorted**, **DEFAULT_MODEL is pickable**, **empty-deepseek → []**, **getStoredModel never returns a non-model id**.

### Verification
- renderer `tsc --noEmit`: clean
- `deriveModelsByBackend.test.ts`: 7/7 · `registryCompleteness`: 11/11 · `useTaxonomyStore`: 141/141
- `npm run verify:config`: **all 7 registry gates green**

Draft pending TL Gate Verification (gate-touching). Follow-up once landed: update `/add-ai-backend` §4 to "derived — no manual picker step."

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>

🤖 Generated with [Claude Code](https://claude.com/claude-code)