### PR TITLE
feat(settings): AI_BACKENDS SSOT-derived + union derive keyspace (t/3328, t/3329)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/__tests__/deriveModelsByBackend.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/__tests__/deriveModelsByBackend.test.ts
@@ -10,6 +10,8 @@
 //      MODELS_BY_BACKEND checked into source (so the pre-load fallback == the runtime derive; no drift).
 //   2. DEFAULT_MODEL is present as a selectable picker entry (the global default must be pickable).
 //   3. Empty-picker backend (deepseek) derives to [] without crashing, and getStoredModel guards it.
+//   4. (t/3329) AI_BACKENDS is SSOT-derived — deriveBackends(config) byte-identical to the pre-load list.
+//   5. (t/3328) derive keyspace = config.backends ∪ constant keys — a config-only backend still surfaces.
 // Wired into `npm run verify:config`.
 
 import { describe, it, expect } from 'vitest';
@@ -18,6 +20,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import {
   deriveModelsByBackend,
+  deriveBackends,
   MODELS_BY_BACKEND,
   AI_BACKENDS,
   getStoredModel,
@@ -88,14 +91,15 @@ describe('deriveModelsByBackend (t/3280 SSOT derive)', () => {
     expect(AI_BACKENDS.some(b => b.value === 'deepseek'), 'deepseek (no picker models) must not be selectable').toBe(false);
   });
 
-  it('the selectable-backend set derived from config == pre-load AI_BACKENDS', () => {
-    // The runtime filter (initAIModels) keeps a config backend iff it has ≥1 derived picker model;
-    // that set must equal the pre-load constant so pre-load and post-load never disagree.
-    const selectableFromConfig = new Set(
-      aiModels.backends.filter(b => (derived[b.id as AIBackend]?.length ?? 0) > 0).map(b => b.id),
-    );
-    const preLoad = new Set(AI_BACKENDS.map(b => b.value));
-    expect(preLoad).toEqual(selectableFromConfig);
+  it('BACKEND PARITY (t/3329): deriveBackends(config) is byte-identical to pre-load AI_BACKENDS', () => {
+    // AI_BACKENDS is now SSOT-derived (membership + order + label from config.backends); the in-source
+    // constant is only a pre-load fallback. Full ordered deep-equal (not just set equality) so pre-load
+    // and post-load never disagree on order or label.
+    expect(deriveBackends(aiModels)).toEqual(AI_BACKENDS);
+  });
+
+  it('deriveBackends excludes a zero-picker backend (deepseek)', () => {
+    expect(deriveBackends(aiModels).some(b => b.value === 'deepseek')).toBe(false);
   });
 
   it('getStoredModel never returns a non-model id even when its backend has an empty picker', () => {
@@ -106,5 +110,43 @@ describe('deriveModelsByBackend (t/3280 SSOT derive)', () => {
     const allValues = new Set(Object.values(MODELS_BY_BACKEND).flat().map(e => e.value));
     expect(allValues.has(model) || model === DEFAULT_MODEL).toBe(true);
     localStorage.clear();
+  });
+
+  it('every config backend with ≥1 picker model has a non-empty derived entry (keyspace coverage)', () => {
+    const withPicker = new Set(aiModels.models.filter(m => m.picker).map(m => m.backend));
+    for (const backend of withPicker) {
+      expect(derived[backend as AIBackend]?.length ?? 0, `config backend '${backend}' has picker models but derived empty`).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('t/3328: derive keyspace = config.backends ∪ constant keys', () => {
+  // A backend added to ai-models.json (with picker models) but ABSENT from the in-source
+  // MODELS_BY_BACKEND keys must still surface — the former constant-only keyspace silently dropped it.
+  const synthConfig = {
+    backends: [
+      { id: 'gemini', label: 'Google Gemini' },
+      { id: 'newbackend', label: 'New Backend' },
+    ],
+    models: [
+      { id: 'newbackend-model-a', label: 'Model A', backend: 'newbackend', picker: { label: 'Model A', order: 10 } },
+      { id: 'newbackend-model-b', label: 'Model B', backend: 'newbackend', picker: { label: 'Model B', order: 20 } },
+      // A curated-out model (no picker) on the new backend must NOT appear.
+      { id: 'newbackend-hidden', label: 'Hidden', backend: 'newbackend' },
+    ],
+    defaults: {},
+  };
+
+  it('surfaces picker models for a backend not present in the constant keyspace', () => {
+    const d = deriveModelsByBackend(synthConfig as never);
+    expect(d['newbackend' as AIBackend]).toEqual([
+      { value: 'newbackend-model-a', label: 'Model A' },
+      { value: 'newbackend-model-b', label: 'Model B' },
+    ]);
+  });
+
+  it('deriveBackends includes the new config-only backend (membership follows config)', () => {
+    const b = deriveBackends(synthConfig as never);
+    expect(b).toContainEqual({ value: 'newbackend', label: 'New Backend' });
   });
 });

--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/settingsSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/settingsSlice.ts
@@ -80,18 +80,20 @@ export interface AIModelEntry { value: AIModel; label: string }
 
 // -- Exported constants --
 
+// t/3329: pre-load fallback ONLY — at runtime initAIModels replaces this with deriveBackends(config).
+// A parity gate keeps it byte-identical to deriveBackends(ai-models.json): membership, order, and labels
+// all follow config.backends (SSOT). deepseek is absent because it has no picker models (zero-picker →
+// not selectable). Order matches config.backends (deepseek filtered out).
 export const AI_BACKENDS: { value: AIBackend; label: string }[] = [
   { value: 'gemini', label: 'Google Gemini' },
   { value: 'claude', label: 'Anthropic Claude' },
   { value: 'groq', label: 'Groq' },
   { value: 'openai', label: 'OpenAI' },
-  // t/3280 (TL GV): deepseek has no `picker` models → not user-selectable (it would strand the model
-  // dropdown). Excluded from the pre-load list to match the runtime picker-presence filter in initAIModels.
   { value: 'azure', label: 'Azure OpenAI' },
-  { value: 'ollama', label: 'Ollama (Local)' },
   { value: 'zai', label: 'Z.AI (GLM)' },
-  { value: 'moonshot', label: 'Moonshot AI (Kimi)' },
+  { value: 'moonshot', label: 'Moonshot (Kimi)' },
   { value: 'xai', label: 'xAI (Grok)' },
+  { value: 'ollama', label: 'Ollama (Local)' },
 ];
 
 export const MODELS_BY_BACKEND: Record<AIBackend, AIModelEntry[]> = {
@@ -220,11 +222,30 @@ export function deriveModelsByBackend(config: AIModelsConfig): Record<AIBackend,
     if (!m.picker) continue;
     (buckets[m.backend] ??= []).push({ value: m.id as AIModel, label: m.picker.label, order: m.picker.order });
   }
+  // t/3328: keyspace = config.backends ∪ constant keys. Iterating only the constant keys would silently
+  // drop a backend added to ai-models.json (with picker models) whose key the in-source constant lacks.
+  const backends = new Set<AIBackend>([
+    ...config.backends.map(b => b.id as AIBackend),
+    ...(Object.keys(MODELS_BY_BACKEND) as AIBackend[]),
+  ]);
   const out = {} as Record<AIBackend, AIModelEntry[]>;
-  for (const backend of Object.keys(MODELS_BY_BACKEND) as AIBackend[]) {
+  for (const backend of backends) {
     out[backend] = (buckets[backend] ?? []).sort((a, b) => a.order - b.order).map(({ value, label }) => ({ value, label }));
   }
   return out;
+}
+
+/**
+ * t/3329: DERIVE the selectable-backend list (AI_BACKENDS) from ai-models.json — a backend is offered
+ * iff it has ≥1 picker model. Membership, order, and label all come from config.backends (SSOT); the
+ * in-source AI_BACKENDS constant is only a pre-load fallback, kept byte-identical by a parity gate.
+ * Subsumes the t/3280 deepseek exclusion structurally — a zero-picker backend is simply not emitted.
+ */
+export function deriveBackends(config: AIModelsConfig): { value: AIBackend; label: string }[] {
+  const derived = deriveModelsByBackend(config);
+  return config.backends
+    .filter(b => (derived[b.id as AIBackend]?.length ?? 0) > 0)
+    .map(b => ({ value: b.id as AIBackend, label: b.label }));
 }
 
 export async function initAIModels(): Promise<void> {
@@ -232,24 +253,19 @@ export async function initAIModels(): Promise<void> {
     const config = await api.loadAIModels() as AIModelsConfig | null;
     if (!config?.models?.length) return;
 
-    // t/3280: derive the picker from the curated `picker` entries (SSOT) — not every config model.
-    // The former all-models push surfaced 100+ backend variants in the dropdown; the picker is the
-    // hand-curated subset. deriveModelsByBackend guarantees every backend key gets an array (empty if
-    // none carry `picker`), so no backend is left with a stale pre-load list.
+    // t/3280/t/3328: derive the picker from the curated `picker` entries (SSOT) — not every config
+    // model. Assign over the DERIVED keyspace (config.backends ∪ constant keys) so a new config
+    // backend's picker models are applied, not just the constant's keys.
     const derived = deriveModelsByBackend(config);
-    for (const key of Object.keys(MODELS_BY_BACKEND) as AIBackend[]) {
+    for (const key of Object.keys(derived) as AIBackend[]) {
       MODELS_BY_BACKEND[key] = derived[key] ?? [];
     }
 
-    // t/3280 (TL GV, t/3280#7): a backend is selectable iff it has ≥1 picker model. deepseek is in
-    // config.backends but carries no `picker` entries → derives to []; offering it would strand the
-    // model dropdown into a silent DEFAULT_MODEL fallback. Filter here (SSOT — no hardcoded exclusion,
-    // so any future zero-picker backend is handled automatically).
+    // t/3280/t/3329: a backend is selectable iff it has ≥1 picker model. deriveBackends filters the
+    // zero-picker ones (e.g. deepseek) so no dead-end backend strands the model dropdown; membership,
+    // order, and label all come from config.backends (SSOT — no hardcoded exclusion).
     AI_BACKENDS.length = 0;
-    for (const b of config.backends) {
-      if ((derived[b.id as AIBackend]?.length ?? 0) === 0) continue;
-      AI_BACKENDS.push({ value: b.id as AIBackend, label: b.label });
-    }
+    AI_BACKENDS.push(...deriveBackends(config));
 
     for (const [k, v] of Object.entries(config.defaults)) {
       DEFAULT_MODELS[k as AIBackend] = v as AIModel;


### PR DESCRIPTION
## t/3280 follow-ups — TL GV hardening (t/3280#7 items 1 & 2)

Completes the SSOT-first direction from the t/3280 GV: the renderer model **picker** was already derived; this makes the **backend list** derived too and closes the keyspace gap the TL flagged.

### t/3329 — `AI_BACKENDS` is now SSOT-derived
- **`deriveBackends(config)`** (new, exported, pure): a backend is offered iff it has ≥1 picker model; **membership + order + label all come from `config.backends`** (SSOT). Subsumes the t/3280 deepseek exclusion structurally.
- `initAIModels` uses it (replaces the inline picker-presence filter).
- The in-source `AI_BACKENDS` constant is reduced to a **pre-load fallback**, reordered + relabelled to match config. **No runtime UX change** — `initAIModels` already rebuilt `AI_BACKENDS` from `config.backends` (order + label) at runtime, so the two diffs (ollama moved last; moonshot label `Moonshot AI (Kimi)` → `Moonshot (Kimi)`) were only ever visible pre-load and are now aligned with the already-live post-load values. No `ai-models.json` edit.
- **Parity gate:** `deriveBackends(ai-models.json)` byte-identical (ordered deep-equal) to the constant.

### t/3328 — derive keyspace = `config.backends ∪ constant keys`
`deriveModelsByBackend` and the parity gate iterated only `Object.keys(MODELS_BY_BACKEND)`. A backend added to `ai-models.json` with picker models would surface in the selector (via the config-driven backend list) but its **models would silently drop** from the picker, uncaught by the gate. Now the keyspace is the union; `initAIModels` assigns over `Object.keys(derived)`. **Gate:** a synthetic config-only backend (absent from the constant) still derives its picker models, and `deriveBackends` includes it.

### Verification
- Both **RED arms proven** (parity break → parity test fails; keyspace revert → the 2 synthetic tests fail; reverted → green).
- renderer `tsc --noEmit` clean · `deriveModelsByBackend.test.ts` 13/13 · `useTaxonomyStore` 147/147 · `npm run verify:config` all 7 registry gates green.

Draft pending TL Gate Verification (gate-touching). Design pre-specified by TL in t/3280#7; recorded plan in t/3329#1.

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>

🤖 Generated with [Claude Code](https://claude.com/claude-code)