### PR TITLE
feat(server): fold data-root validation into /readyz readiness gate (t/3309 step-1)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/dataRootReadiness.test.ts
+++ b/taxonomy-editor/src/server/__tests__/dataRootReadiness.test.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3309 — the cache-once data-root readiness singleton that backs the /readyz gate.
+// Verifies the three-state machine (validating → ready | failed) the boot validation block
+// drives and the /readyz handler reads. Pure state, no I/O — so this is a fast unit test.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getDataRootReadyState,
+  setDataRootReady,
+  setDataRootFailed,
+  __resetDataRootReadinessForTest,
+} from '../routes/dataRootReadiness.js';
+
+describe('dataRootReadiness singleton (t/3309)', () => {
+  beforeEach(() => __resetDataRootReadinessForTest());
+
+  it("starts 'validating' with no reason (initial state before boot validation resolves)", () => {
+    expect(getDataRootReadyState()).toEqual({ state: 'validating' });
+  });
+
+  it("setDataRootReady() → 'ready', no reason", () => {
+    setDataRootReady();
+    expect(getDataRootReadyState()).toEqual({ state: 'ready' });
+  });
+
+  it("setDataRootFailed(reason) → 'failed' carrying the cause", () => {
+    setDataRootFailed("sentinel 'taxonomy/' present but empty");
+    expect(getDataRootReadyState()).toEqual({ state: 'failed', reason: "sentinel 'taxonomy/' present but empty" });
+  });
+
+  it('recovers ready → failed → ready (a flapping replica re-caches each transition)', () => {
+    setDataRootReady();
+    expect(getDataRootReadyState().state).toBe('ready');
+    setDataRootFailed('github-api transiently unreachable after 3 attempts');
+    expect(getDataRootReadyState().state).toBe('failed');
+    setDataRootReady();
+    expect(getDataRootReadyState()).toEqual({ state: 'ready' }); // reason cleared on recovery
+  });
+
+  it('the getter returns the live cached value (no per-call recomputation)', () => {
+    setDataRootFailed('no creds');
+    const a = getDataRootReadyState();
+    const b = getDataRootReadyState();
+    expect(a).toEqual(b);
+    expect(a.state).toBe('failed');
+  });
+});

--- a/taxonomy-editor/src/server/__tests__/readyz.test.ts
+++ b/taxonomy-editor/src/server/__tests__/readyz.test.ts
@@ -41,9 +41,18 @@ describe('publicPaths — /readyz', () => {
 
 const CANARY = 'acc-beliefs-003';
 type Resolution = { present: boolean; nodeCount: number | null; resolves: boolean };
+type DataRoot = { state: 'validating' | 'ready' | 'failed'; reason?: string };
 type HandlerResult = { statusCode: number; body: Record<string, unknown> };
 
-function simulateReadyz(r: Resolution): HandlerResult {
+// t/3309: the data-root gate composes AHEAD of the embeddings gate. Default 'ready' so the
+// existing embeddings-branch cases below are unaffected (data-root ready → falls through).
+function simulateReadyz(r: Resolution, dataRoot: DataRoot = { state: 'ready' }): HandlerResult {
+  if (dataRoot.state === 'failed') {
+    return { statusCode: 503, body: { status: 'failed', reason: `data-root-failed: ${dataRoot.reason ?? 'unknown'}` } };
+  }
+  if (dataRoot.state === 'validating') {
+    return { statusCode: 503, body: { status: 'warming', reason: 'data-root-validating' } };
+  }
   const { present, nodeCount, resolves } = r;
   if (present && (nodeCount ?? 0) > 0 && resolves) {
     return { statusCode: 200, body: { status: 'ready', nodeCount, resolves: true } };
@@ -79,6 +88,47 @@ describe('GET /readyz — response shape (t/3112, t/3165 resolution)', () => {
     const { statusCode, body } = simulateReadyz({ present: true, nodeCount: 0, resolves: false });
     expect(statusCode).toBe(503);
     expect(body.status).toBe('warming');
+  });
+});
+
+// ── t/3309: data-root readiness gate composes ahead of embeddings ─────────────
+// The data-root state (validating/ready/failed) gates /readyz BEFORE the embeddings check.
+// 'failed' is a definitive 503 (status:'failed', not warming) so a misprovisioned corpus is
+// not masked as a slow warm-up (cond 3); 'validating' is a warming 503; 'ready' falls through.
+describe('GET /readyz — data-root gate (t/3309)', () => {
+  const RESOLVING: Resolution = { present: true, nodeCount: 4144, resolves: true };
+
+  it("503 { status: failed, data-root-failed:<reason> } when data-root validation failed — even if embeddings resolve", () => {
+    const { statusCode, body } = simulateReadyz(RESOLVING, { state: 'failed', reason: "sentinel 'taxonomy/' present but empty" });
+    expect(statusCode).toBe(503);
+    expect(body.status).toBe('failed'); // definitive, NOT 'warming' — not masked as slow warm-up
+    expect(String(body.reason)).toMatch(/^data-root-failed:/);
+    expect(String(body.reason)).toContain('taxonomy');
+  });
+
+  it("503 { status: warming, data-root-validating } while startup validation is in flight", () => {
+    const { statusCode, body } = simulateReadyz(RESOLVING, { state: 'validating' });
+    expect(statusCode).toBe(503);
+    expect(body.status).toBe('warming');
+    expect(body.reason).toBe('data-root-validating');
+  });
+
+  it('failed reason falls back to "unknown" when none is cached', () => {
+    const { body } = simulateReadyz(RESOLVING, { state: 'failed' });
+    expect(body.reason).toBe('data-root-failed: unknown');
+  });
+
+  it("data-root 'ready' falls through to the embeddings gate — 200 unchanged (fixture-contract preserved)", () => {
+    const { statusCode, body } = simulateReadyz(RESOLVING, { state: 'ready' });
+    expect(statusCode).toBe(200);
+    expect(body).toEqual({ status: 'ready', nodeCount: 4144, resolves: true });
+  });
+
+  it("data-root 'ready' but embeddings not resolving → the existing embeddings 503 (gates are independent)", () => {
+    const { statusCode, body } = simulateReadyz({ present: true, nodeCount: 4144, resolves: false }, { state: 'ready' });
+    expect(statusCode).toBe(503);
+    expect(body.status).toBe('warming');
+    expect(body.reason).toBe('canary-not-resolving');
   });
 });
 

--- a/taxonomy-editor/src/server/routes/dataRootReadiness.ts
+++ b/taxonomy-editor/src/server/routes/dataRootReadiness.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3309 — data-root validation as a /readyz READINESS signal (liveness ≠ readiness).
+//
+// Path B (TL-endorsed, t/3309#3): move server-side data-root validation off a boot
+// `process.exit(1)` and onto the /readyz readiness signal. The process BOOTS (liveness =
+// process-up, no smoke↔data-config coupling); /readyz stays not-ready until data validates,
+// so a misprovisioned revision never receives traffic (the blue-green warm-gate refuses a
+// not-ready rev) instead of crash-looping.
+//
+// This module is the cache-once readiness state (t/3309#2 cond 2): `validateDataRoot()` runs
+// ONCE at startup (its own 3-retry) and the outcome is cached here — /readyz reads the cache,
+// it never re-runs GitHub Contents per probe (ACA polls /readyz every few seconds).
+//
+// Three states (cond 3 — a definitive failure is not masked as a slow warm-up):
+//   - 'validating' : startup validation in flight → /readyz 503 'warming'.
+//   - 'ready'      : taxonomy/ + dictionary/ present & non-empty → /readyz data-root gate open.
+//   - 'failed'     : validation definitively failed (empty/no-creds/transient-exhausted)
+//                    → /readyz 503 'failed' (hard, not warming).
+//
+// Pure state only — no I/O and no logging here. The failure WARN→Log_s signal (cond 4) is
+// emitted by the /readyz handler on the transition into 'failed' (throttled), and the boot
+// path keeps its own existing WARN/error logs unchanged. During the migration the boot
+// exit(1) enforce path is RETAINED as the active protection (t/3309#3 gate 2); this cache is
+// populated alongside it and becomes the sole gate only once DevOps confirms /readyz gates
+// traffic live and the exit(1) is removed.
+
+export type DataRootReadyState = 'validating' | 'ready' | 'failed';
+
+export interface DataRootReadiness {
+  state: DataRootReadyState;
+  /** Present only when state === 'failed' — the ActionableError message naming the cause. */
+  reason?: string;
+}
+
+let _readiness: DataRootReadiness = { state: 'validating' };
+
+/** Pure getter — no I/O. /readyz reads this per probe (cache-once, cond 2). */
+export function getDataRootReadyState(): Readonly<DataRootReadiness> {
+  return _readiness;
+}
+
+/** Startup success → data root validated. Called once from the boot validation block. */
+export function setDataRootReady(): void {
+  _readiness = { state: 'ready' };
+}
+
+/** Startup failure → definitive not-ready with the cause. Called once from the boot catch. */
+export function setDataRootFailed(reason: string): void {
+  _readiness = { state: 'failed', reason };
+}
+
+/** Test-only: reset the module singleton between cases. */
+export function __resetDataRootReadinessForTest(): void {
+  _readiness = { state: 'validating' };
+}

--- a/taxonomy-editor/src/server/routes/meta.ts
+++ b/taxonomy-editor/src/server/routes/meta.ts
@@ -15,6 +15,7 @@ import type { Router } from '../httpKit.js';
 import type { ServerCtx } from './context.js';
 import { json, error } from '../httpKit.js';
 import { classifyDataUnavailable, type ReadinessState } from './readiness.js';
+import { getDataRootReadyState } from './dataRootReadiness.js'; // t/3309: cache-once data-root readiness
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 import { getProjectRoot, getDataRoot, hasApiKey, STORAGE_MODE } from '../config.js';
 import { getConfig } from '../runtimeConfig.js';
@@ -43,6 +44,24 @@ function logReadinessTransition(readiness: ReadinessState, dataRoot: string): vo
   } else {
     log.server.info({ dataRoot, reason: readiness.reason }, 'Readiness: warming (data load in progress)');
   }
+}
+
+// t/3309: /readyz data-root failure signal (cond 4), throttled to the transition INTO failed —
+// ACA polls /readyz every few seconds, so a per-probe WARN would spam. The message keeps the
+// "Data root validation failed" substring the boot-WARN alert (t/3308) keys on, so the Log_s
+// alert fires whether the failure surfaces at boot or here. Reset by the handler when the state
+// leaves 'failed' (a flap re-logs). The boot exit(1)/WARN path (server.ts) is unchanged — this is
+// the readyz-side signal that carries the migration once exit(1) is removed (step 3).
+let lastReadyzDataRootFailed = false;
+
+function logDataRootReadyzFailure(reason: string | undefined): void {
+  if (lastReadyzDataRootFailed) return;
+  lastReadyzDataRootFailed = true;
+  log.server.warn({ reason }, 'Data root validation failed — /readyz not-ready (t/3309)');
+  getGlobalRecorder()?.record({
+    type: 'system.error', component: 'readyz', level: 'error',
+    message: 'Data root validation failed — /readyz not-ready', data: { reason },
+  });
 }
 
 export function registerMetaRoutes(r: Router, ctx: ServerCtx): void {
@@ -91,6 +110,25 @@ export function registerMetaRoutes(r: Router, ctx: ServerCtx): void {
   // AND DevOps2's resolution deploy-gate (t/3091) both poll GET /readyz — status code 503 = block,
   // no auth (PUBLIC_EXACT_PATHS, anon). Distinct from /api/health/embeddings (ONNX model warmup).
   get('/readyz', (_req, res) => {
+    // t/3309: data-root validation composes into the readiness gate AHEAD of the embeddings
+    // check — a misprovisioned data root means the corpus is absent, so there's nothing for
+    // embeddings to resolve against. State is CACHE-ONCE (dataRootReadiness): validated once at
+    // startup, read here per probe — no per-probe GitHub Contents call (cond 2). A definitive
+    // 'failed' is a hard 503 (not masked as a slow warm-up, cond 3); 'validating' is warming.
+    // The 200-ready body is unchanged (data-root 'ready' falls through to the existing embeddings
+    // gate), preserving the shared warm-gate body-contract fixture (t/3114).
+    const dr = getDataRootReadyState();
+    if (dr.state === 'failed') {
+      logDataRootReadyzFailure(dr.reason); // cond 4: WARN→Log_s once per failure episode
+      json(res, { status: 'failed', reason: `data-root-failed: ${dr.reason ?? 'unknown'}` }, 503);
+      return;
+    }
+    // Reset the failure-log throttle so a later re-failure (flap: failed → ready → failed) re-logs.
+    lastReadyzDataRootFailed = false;
+    if (dr.state === 'validating') {
+      json(res, { status: 'warming', reason: 'data-root-validating' }, 503);
+      return;
+    }
     const { present, nodeCount, resolves, canaryId } = getEmbeddingsResolution();
     if (present && (nodeCount ?? 0) > 0 && resolves) {
       json(res, { status: 'ready', nodeCount, resolves: true });

--- a/taxonomy-editor/src/server/server.ts
+++ b/taxonomy-editor/src/server/server.ts
@@ -55,6 +55,7 @@ import { parseCookies } from './httpCookies.js';
 import { registerAllRoutes } from './routes/all.js';
 import { invalidateConflictsCache, warmConflictsCache } from './routes/conflicts.js';
 import { anonSessionCookiesWithCreated } from './routes/session.js';
+import { setDataRootReady, setDataRootFailed } from './routes/dataRootReadiness.js'; // t/3309: data-root → /readyz readiness cache
 import { buildLoginPage, FORBIDDEN_PAGE, SW_HEAL_SCRIPT_CSP_HASH, loginPageHeaders } from './loginPage.js';
 import type { ServerCtx } from './routes/context.js';
 import { listFlags, setFlag, deleteFlag, type FlagDef } from './featureFlags.js';
@@ -1301,7 +1302,14 @@ assertStateRootIsolation(); // t/2643: refuse start if staging's state root wasn
 // instead of silently serving empty panels. Before listen, so an un-provisioned revision never serves.
 try {
   await fileIO.validateDataRoot();
+  setDataRootReady(); // t/3309: cache data-root readiness for the /readyz gate (migration target)
 } catch (err) {
+  // t/3309: record the definitive failure for /readyz (Path B — data-root becomes a readiness
+  // signal). The boot exit(1)/WARN enforce path BELOW is RETAINED unchanged as the active
+  // protection during the migration (t/3309#3 gate 2 / #5 step-1): exit(1) ENFORCE is live in
+  // prod, so we fold the readyz gate in ALONGSIDE it and only remove exit(1) after staging
+  // proves the warm-gate blocks a misprovisioned rev (step 2) — never a no-protection window.
+  setDataRootFailed(err instanceof Error ? err.message : String(err));
   // t/3296/t/3305: the hard exit(1) is ENFORCE-gated (default WARN-only). A credential-less boot —
   // the container liveness smoke test (github-api mode, NO GitHub App creds) — MUST still start, so
   // exit(1) fires ONLY when DATA_ROOT_VALIDATION_ENFORCE is set. DevOps sets it in staging→prod (real


### PR DESCRIPTION
## t/3309 step-1 — fold data-root validation into the `/readyz` readiness gate

**Path B, step-1 of 3** (TL-approved design t/3309#2, ruling t/3309#3/#5). Makes server-side
data-root validation a `/readyz` readiness signal **alongside** the existing boot `exit(1)` enforce
path, which is **retained unchanged**. This is the additive step; the `exit(1)` removal + ENFORCE
retirement is step-3, gated on step-2 staging both-arms proof (never a no-protection window).

### Changes
- **`routes/dataRootReadiness.ts`** (new) — cache-once 3-state singleton (`validating → ready | failed`), pure state, no per-probe I/O (cond 2).
- **`server.ts`** — boot validation block populates the cache (`setDataRootReady` / `setDataRootFailed`). The `exit(1)`/WARN enforce block is **byte-identical** (gate-2 atomicity + t/3308 alert substring, gate 5).
- **`routes/meta.ts`** — `/readyz` composes the data-root gate **ahead** of the embeddings gate: `failed` → 503 `status:failed` (definitive, not masked as warming — cond 3); `validating` → 503 warming; `ready` → existing embeddings check. **200-ready body unchanged** → shared warm-gate body-contract fixture (t/3114) untouched. Failure WARN→Log_s throttled to the transition; message keeps the `"Data root validation failed"` substring (cond 4 / gate 5).

### Safety / inertness
In prod `ENFORCE=1` is live, so a data-root failure still `exit(1)`s **before** `listen()`; `/readyz` only ever observes `ready` in prod until `exit(1)` is removed in step-3. Fully additive, no behavior change in prod.

### Verification
- `dataRootReadiness.test.ts` (singleton state machine) + `readyz.test.ts` extended (failed-precedence-over-resolving-embeddings, validating, unknown-reason fallback, ready fall-through). **19/19 pass**.
- lint clean; tsc clean for changed files; **`verify:config` 7/7 green**.
- Worst-case validation 120s healthy vs 300s warm-gate = **2.5×** (DevOps p/526#112, TL p/522#263).

### Follow-up
Step-2: staging both-arms (healthy→200→promote; misprovisioned→503 `data-root-failed`→deploy-fail+alert) → **Main (TL) GV** → step-3 `exit(1)` removal + DevOps retires `DATA_ROOT_VALIDATION_ENFORCE`, one controlled deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
