### PR TITLE
feat(settings): restore deepseek picker + fix gemini default label (t/3286)

### DIFF
--- a/ai-models.json
+++ b/ai-models.json
@@ -136,7 +136,7 @@
       "label": "Gemini 3.5 Flash Lite",
       "backend": "gemini",
       "picker": {
-        "label": "3.1 Flash Lite Preview (default)",
+        "label": "3.5 Flash Lite (default)",
         "order": 10
       }
     },
@@ -872,13 +872,21 @@
       "id": "deepseek-deepseek-v4-flash",
       "apiModelId": "deepseek-v4-flash",
       "label": "Deepseek V4 Flash",
-      "backend": "deepseek"
+      "backend": "deepseek",
+      "picker": {
+        "label": "V4 Flash (default)",
+        "order": 10
+      }
     },
     {
       "id": "deepseek-deepseek-v4-pro",
       "apiModelId": "deepseek-v4-pro",
       "label": "Deepseek V4 Pro",
-      "backend": "deepseek"
+      "backend": "deepseek",
+      "picker": {
+        "label": "V4 Pro (reasoning)",
+        "order": 20
+      }
     },
     {
       "id": "ollama-gemma4-e4b-it-q4-k-m",

--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/__tests__/deriveModelsByBackend.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/__tests__/deriveModelsByBackend.test.ts
@@ -24,10 +24,12 @@ import { dirname, resolve } from 'node:path';
 import {
   deriveModelsByBackend,
   deriveBackends,
+  resolveStoredModel,
   MODELS_BY_BACKEND,
   AI_BACKENDS,
   getStoredModel,
   type AIBackend,
+  type AIModel,
 } from '../settingsSlice';
 import { DEFAULT_MODEL } from '@lib/ai-client/defaults';
 
@@ -191,5 +193,31 @@ describe('t/3328: derive keyspace = config.backends ∪ constant keys', () => {
   it('deriveBackends includes the new config-only backend (membership follows config)', () => {
     const b = deriveBackends(synthConfig as never);
     expect(b).toContainEqual({ value: 'newbackend', label: 'New Backend' });
+  });
+});
+
+describe('resolveStoredModel — graceful-empty guard, both arms (t/3286, TL t/3286#11)', () => {
+  // Pure extraction of getStoredModel's resolution, so BOTH branches of the empty-backend guard are
+  // exercised directly — including the FALSE branch (backend default is not a real model → globalDefault)
+  // that the real-config integration test can't reach (it lands on a valid default).
+  const ALL = new Set<string>(['real-model', 'other-model', 'global-default']);
+  const GLOBAL = 'global-default' as AIModel;
+  const DEFAULTS = { good: 'real-model', empty: 'not-a-model' } as unknown as Record<AIBackend, AIModel>;
+
+  it('ARM (a): a valid backend default is returned as-is', () => {
+    expect(resolveStoredModel(null, 'good' as AIBackend, DEFAULTS, ALL, GLOBAL)).toBe('real-model');
+  });
+
+  it('ARM (b): a NON-model backend default falls back to the global default (no strand)', () => {
+    // The empty/misconfigured-backend leg: DEFAULT_MODELS[backend] is not a real id → globalDefault.
+    expect(resolveStoredModel(null, 'empty' as AIBackend, DEFAULTS, ALL, GLOBAL)).toBe('global-default');
+  });
+
+  it('a valid stored id wins over the backend default', () => {
+    expect(resolveStoredModel('other-model', 'good' as AIBackend, DEFAULTS, ALL, GLOBAL)).toBe('other-model');
+  });
+
+  it('a bogus stored id is rejected, then the backend default resolves', () => {
+    expect(resolveStoredModel('bogus-id', 'good' as AIBackend, DEFAULTS, ALL, GLOBAL)).toBe('real-model');
   });
 });

--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/__tests__/deriveModelsByBackend.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/__tests__/deriveModelsByBackend.test.ts
@@ -9,7 +9,10 @@
 //   1. PARITY — deriveModelsByBackend(ai-models.json) is byte-identical to the curated
 //      MODELS_BY_BACKEND checked into source (so the pre-load fallback == the runtime derive; no drift).
 //   2. DEFAULT_MODEL is present as a selectable picker entry (the global default must be pickable).
-//   3. Empty-picker backend (deepseek) derives to [] without crashing, and getStoredModel guards it.
+//   3. (t/3286) The graceful-empty invariant — a ZERO-picker backend derives to [], is filtered from the
+//      selector, and getStoredModel never yields a non-model id — held against a SYNTHETIC subject (since
+//      t/3286 restored deepseek's picker, no real backend is empty; the invariant is nonetheless permanent).
+//      Plus a general real-config no-strand guard: every OFFERED backend has ≥1 picker entry.
 //   4. (t/3329) AI_BACKENDS is SSOT-derived — deriveBackends(config) byte-identical to the pre-load list.
 //   5. (t/3328) derive keyspace = config.backends ∪ constant keys — a config-only backend still surfaces.
 // Wired into `npm run verify:config`.
@@ -36,6 +39,21 @@ const aiModels = JSON.parse(
   backends: { id: string; label: string }[];
   models: { id: string; label: string; backend: string; picker?: { label: string; order: number } }[];
   defaults: Record<string, string>;
+};
+
+// t/3286: synthetic config for the permanent graceful-empty invariant — a fabricated zero-picker
+// backend ('emptybackend': has a model, but NONE carry `picker`) alongside a normal one. Keeps the
+// empty-backend coverage decoupled from whichever real backend happens to be curated-out.
+const ZERO_PICKER_CONFIG = {
+  backends: [
+    { id: 'gemini', label: 'Google Gemini' },
+    { id: 'emptybackend', label: 'Empty Backend' },
+  ],
+  models: [
+    { id: 'gemini-3.1-pro-preview', label: 'x', backend: 'gemini', picker: { label: 'x', order: 10 } },
+    { id: 'emptybackend-hidden', label: 'Hidden', backend: 'emptybackend' },
+  ],
+  defaults: {},
 };
 
 describe('deriveModelsByBackend (t/3280 SSOT derive)', () => {
@@ -78,17 +96,20 @@ describe('deriveModelsByBackend (t/3280 SSOT derive)', () => {
     expect(allValues.has(DEFAULT_MODEL), `DEFAULT_MODEL '${DEFAULT_MODEL}' absent from the derived picker`).toBe(true);
   });
 
-  it('an empty-picker backend (deepseek) derives to [] without crashing', () => {
-    expect(derived.deepseek).toEqual([]);
+  it('a zero-picker backend derives to [] without crashing (synthetic subject, t/3286)', () => {
+    // Post-t/3286 no real backend is empty (deepseek restored); the graceful-empty invariant is
+    // permanent, so exercise it on a synthetic config with a fabricated zero-picker backend.
+    const d = deriveModelsByBackend(ZERO_PICKER_CONFIG as never);
+    expect(d['emptybackend' as AIBackend]).toEqual([]);
   });
 
-  it('no user-selectable backend has an empty picker (would strand the model dropdown)', () => {
-    // Pre-load AI_BACKENDS must offer only backends with ≥1 curated model; initAIModels applies the
-    // same picker-presence filter at runtime. deepseek is the empty-picker case that must be excluded.
+  it('GENERAL no-strand guard: every offered backend has ≥1 picker entry (t/3286)', () => {
+    // Durable real-config invariant (TL t/3286#3) — strictly stronger than a deepseek-specific ===[]:
+    // any backend surfaced in the selector must have at least one selectable model or the dropdown
+    // strands. Covers ALL current + future offered backends, not one hard-coded subject.
     for (const b of AI_BACKENDS) {
-      expect(MODELS_BY_BACKEND[b.value].length, `backend '${b.value}' is selectable but has no picker models`).toBeGreaterThan(0);
+      expect(MODELS_BY_BACKEND[b.value].length, `offered backend '${b.value}' has no picker models`).toBeGreaterThan(0);
     }
-    expect(AI_BACKENDS.some(b => b.value === 'deepseek'), 'deepseek (no picker models) must not be selectable').toBe(false);
   });
 
   it('BACKEND PARITY (t/3329): deriveBackends(config) is byte-identical to pre-load AI_BACKENDS', () => {
@@ -98,17 +119,39 @@ describe('deriveModelsByBackend (t/3280 SSOT derive)', () => {
     expect(deriveBackends(aiModels)).toEqual(AI_BACKENDS);
   });
 
-  it('deriveBackends excludes a zero-picker backend (deepseek)', () => {
-    expect(deriveBackends(aiModels).some(b => b.value === 'deepseek')).toBe(false);
+  it('deriveBackends excludes a zero-picker backend (synthetic subject, t/3286)', () => {
+    // deepseek is now offered (t/3286 restored its picker); prove the exclusion mechanism on a
+    // synthetic zero-picker backend, while a sibling WITH picker models in the same config IS offered.
+    const b = deriveBackends(ZERO_PICKER_CONFIG as never);
+    expect(b.some(x => x.value === 'emptybackend')).toBe(false);
+    expect(b.some(x => x.value === 'gemini')).toBe(true);
   });
 
-  it('getStoredModel never returns a non-model id even when its backend has an empty picker', () => {
-    // deepseek is the empty-picker case; the phantom-default guard must fall back to DEFAULT_MODEL.
-    localStorage.clear();
-    localStorage.setItem('taxonomy-editor-backend', 'deepseek');
-    const model = getStoredModel();
+  it('deepseek is now an offered backend with its restored v4 picker (t/3286)', () => {
+    // Positive assertion that the restore actually took effect (guards against a silent re-emptying).
+    expect(derived.deepseek).toEqual([
+      { value: 'deepseek-deepseek-v4-flash', label: 'V4 Flash (default)' },
+      { value: 'deepseek-deepseek-v4-pro', label: 'V4 Pro (reasoning)' },
+    ]);
+    expect(deriveBackends(aiModels).some(b => b.value === 'deepseek')).toBe(true);
+  });
+
+  it('getStoredModel never returns a non-model id (guard property)', () => {
+    // The guard rejects a stored/default id that is not a real model and falls back to DEFAULT_MODEL.
+    // getStoredModel reads module singletons (ALL_MODEL_IDS/DEFAULT_MODELS), so the empty-backend →
+    // DEFAULT_MODEL leg is covered by the pure-fn derive/exclude tests above; here we prove the
+    // "never a non-model id" property directly across clean + poisoned localStorage.
+    // NOTE (t/3286): the stored-backend key is 'taxonomy-editor-ai-backend' — the #1971 test used
+    // 'taxonomy-editor-backend' (wrong key), so getStoredBackend never saw it and the test was vacuous.
     const allValues = new Set(Object.values(MODELS_BY_BACKEND).flat().map(e => e.value));
-    expect(allValues.has(model) || model === DEFAULT_MODEL).toBe(true);
+    localStorage.clear();
+    // (a) clean storage → a real model (the global default).
+    expect(allValues.has(getStoredModel())).toBe(true);
+    // (b) a bogus stored model id is rejected → still a real model, never the bogus id.
+    localStorage.setItem('taxonomy-editor-gemini-model', 'not-a-real-model-xyz');
+    const m = getStoredModel();
+    expect(m).not.toBe('not-a-real-model-xyz');
+    expect(allValues.has(m)).toBe(true);
     localStorage.clear();
   });
 

--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/settingsSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/settingsSlice.ts
@@ -192,18 +192,33 @@ function getStoredBackend(): AIBackend {
   return 'gemini';
 }
 
+/**
+ * t/3286: PURE model-resolution guard, extracted from getStoredModel for both-arms testability (TL
+ * t/3286#11 — the t/2971 extract-don't-seam discipline). Resolution order: a valid stored id wins;
+ * else the backend's default IF it is a real model; else the always-present global default. The final
+ * branch is the graceful-empty guard — an empty/misconfigured backend whose default isn't a real id
+ * must never strand the UI on a non-model string.
+ */
+export function resolveStoredModel(
+  storedId: string | null,
+  backend: AIBackend,
+  defaultModels: Record<AIBackend, AIModel>,
+  allModelIds: ReadonlySet<string>,
+  globalDefault: AIModel,
+): AIModel {
+  if (storedId && allModelIds.has(storedId)) return storedId as AIModel;
+  const fallback = defaultModels[backend];
+  return allModelIds.has(fallback) ? fallback : globalDefault;
+}
+
 export function getStoredModel(): AIModel {
+  let stored: string | null = null;
   try {
-    const stored = localStorage.getItem('taxonomy-editor-gemini-model');
-    if (stored && ALL_MODEL_IDS.has(stored)) return stored as AIModel;
+    stored = localStorage.getItem('taxonomy-editor-gemini-model');
   } catch (err) {
     getGlobalRecorder()?.record({ type: 'system.error', component: 'taxonomy-store', level: 'warn', message: 'Failed to read stored AI model from localStorage', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
   }
-  // t/3280: guard an empty-picker backend (deepseek) / a pre-load phantom default — never strand the
-  // UI on a non-model id; fall back to the always-present global DEFAULT_MODEL.
-  const backend = getStoredBackend();
-  const fallback = DEFAULT_MODELS[backend];
-  return ALL_MODEL_IDS.has(fallback) ? fallback : DEFAULT_MODEL;
+  return resolveStoredModel(stored, getStoredBackend(), DEFAULT_MODELS, ALL_MODEL_IDS, DEFAULT_MODEL);
 }
 
 interface AIModelsConfig {

--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/settingsSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/settingsSlice.ts
@@ -52,9 +52,11 @@ export type OpenAIModel =
   | 'openai-gpt-5.5'
   | 'openai-gpt-5.5-pro';
 
+// t/3286: real config model ids (the old 'deepseek-chat'/'deepseek-reasoner' were phantoms — no
+// ai-models.json entry). deepseek-v4-flash is defaults.deepseek.
 export type DeepSeekModel =
-  | 'deepseek-chat'
-  | 'deepseek-reasoner';
+  | 'deepseek-deepseek-v4-flash'
+  | 'deepseek-deepseek-v4-pro';
 
 export type AzureModel =
   | 'azure-gpt-4o'
@@ -82,13 +84,14 @@ export interface AIModelEntry { value: AIModel; label: string }
 
 // t/3329: pre-load fallback ONLY — at runtime initAIModels replaces this with deriveBackends(config).
 // A parity gate keeps it byte-identical to deriveBackends(ai-models.json): membership, order, and labels
-// all follow config.backends (SSOT). deepseek is absent because it has no picker models (zero-picker →
-// not selectable). Order matches config.backends (deepseek filtered out).
+// all follow config.backends (SSOT). Order matches config.backends. (t/3286: deepseek re-added once its
+// v4 models gained picker entries — deriveBackends now offers it automatically, this fallback mirrors it.)
 export const AI_BACKENDS: { value: AIBackend; label: string }[] = [
   { value: 'gemini', label: 'Google Gemini' },
   { value: 'claude', label: 'Anthropic Claude' },
   { value: 'groq', label: 'Groq' },
   { value: 'openai', label: 'OpenAI' },
+  { value: 'deepseek', label: 'DeepSeek' },
   { value: 'azure', label: 'Azure OpenAI' },
   { value: 'zai', label: 'Z.AI (GLM)' },
   { value: 'moonshot', label: 'Moonshot (Kimi)' },
@@ -98,7 +101,7 @@ export const AI_BACKENDS: { value: AIBackend; label: string }[] = [
 
 export const MODELS_BY_BACKEND: Record<AIBackend, AIModelEntry[]> = {
   gemini: [
-    { value: DEFAULT_MODEL, label: '3.1 Flash Lite Preview (default)' },
+    { value: DEFAULT_MODEL, label: '3.5 Flash Lite (default)' },
     { value: 'gemini-3.1-pro-preview', label: '3.1 Pro Preview (best quality)' },
     { value: 'gemini-3.8-flash', label: '3.8 Flash' },
     { value: 'gemini-3.6-flash', label: '3.6 Flash' },
@@ -121,10 +124,13 @@ export const MODELS_BY_BACKEND: Record<AIBackend, AIModelEntry[]> = {
     { value: 'openai-gpt-5.5', label: 'GPT-5.5' },
     { value: 'openai-gpt-5.5-pro', label: 'GPT-5.5 Pro' },
   ],
-  // t/3280: deepseek has NO picker entries in ai-models.json — both prior entries (deepseek-chat,
-  // deepseek-reasoner) were phantoms (no config id → misroute on select). Empty picker; the runtime
-  // derive keeps it []. Empty-backend handling: getStoredModel falls back to DEFAULT_MODEL (below).
-  deepseek: [],
+  // t/3286: deepseek picker restored — its real config models (v4-flash/v4-pro) gained `picker` entries
+  // in ai-models.json, replacing the old phantoms (deepseek-chat/reasoner). Kept byte-identical to the
+  // derive by the parity gate. v4-flash is defaults.deepseek → its label carries the '(default)' marker.
+  deepseek: [
+    { value: 'deepseek-deepseek-v4-flash', label: 'V4 Flash (default)' },
+    { value: 'deepseek-deepseek-v4-pro', label: 'V4 Pro (reasoning)' },
+  ],
   azure: [
     { value: 'azure-gpt-4o', label: 'GPT-4o' },
     { value: 'azure-gpt-4o-mini', label: 'GPT-4o Mini' },
@@ -157,7 +163,7 @@ const DEFAULT_MODELS: Record<AIBackend, AIModel> = {
   claude: 'claude-sonnet-4-6',
   groq: 'groq-llama-4-scout-17b-16e',
   openai: 'openai-gpt-5.5',
-  deepseek: 'deepseek-chat',
+  deepseek: 'deepseek-deepseek-v4-flash',
   azure: 'azure-gpt-4o',
   ollama: 'ollama-gemma4-e4b-it-q4-k-m',
   zai: 'zai-glm-5-2',


### PR DESCRIPTION
## t/3286 — post-derive picker corrections (joint root+renderer)

Kept out of the verbatim Phase-2a backfill to preserve the byte-identical parity target; landing now that the derive + parity gate are locked (t/3280/#1971). The parity gate couples `ai-models.json` to `settingsSlice.ts`, so all three files move atomically in one PR.

### `ai-models.json` (root spec, pinned t/3286#6 + #8 — root reviews this diff)
- `gemini-3.5-flash-lite` picker.label `"3.1 Flash Lite Preview (default)"` → `"3.5 Flash Lite (default)"`
- `deepseek-deepseek-v4-flash` + `picker {label:"V4 Flash (default)", order:10}` (it's `defaults.deepseek` → carries the `(default)` marker)
- `deepseek-deepseek-v4-pro` + `picker {label:"V4 Pro (reasoning)", order:20}`

### `settingsSlice.ts` (parity mirror + coupled correctness)
- gemini default label + `MODELS_BY_BACKEND.deepseek` (was `[]`) mirror the config verbatim → parity holds
- `AI_BACKENDS` re-adds deepseek (config order) — with #1971's `deriveBackends` it's offered automatically; the constant is the pre-load fallback
- `DEFAULT_MODELS.deepseek` `'deepseek-chat'` (phantom) → `'deepseek-deepseek-v4-flash'`, and `DeepSeekModel` type union → the real v4 ids (were phantoms) — **coupled correctness fixes so the now-selectable backend has a valid pre-load default + type**

### test rework → **TL focused GV** (edits a GV'd gate)
Per TL t/3286#3: re-point the **5** deepseek-keyed empty-backend assertions at a **synthetic zero-picker backend** (deepseek is no longer empty), add the **general no-strand guard** (every *offered* backend has ≥1 picker entry — strictly stronger than a deepseek-specific `===[]`), and a positive "deepseek restored" assertion. Also fixed a latent bug: the #1971 `getStoredModel` test used the wrong localStorage key (`taxonomy-editor-backend` vs `-ai-backend`) and was vacuous.

**Coverage note for GV:** `getStoredModel` reads module singletons, so the empty-backend→DEFAULT_MODEL leg is covered by the pure-fn derive/exclude tests on the synthetic config; the guard's "never a non-model id" property is proven directly against clean + poisoned localStorage. Flagging in case you want a test-only seam instead.

### Verification
renderer tsc clean · `deriveModelsByBackend` 15/15 · `useTaxonomyStore` 148/148 · `verify:config` all 7 gates green (JSON round-trips; parity + phantom gates catch any config-restore regression automatically).

**Draft + `joint-gv`** — manual `--match-head-commit` merge only (never `--auto`), after TL focused GV on the test change + root config-diff review.

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>

🤖 Generated with [Claude Code](https://claude.com/claude-code)