### PR TITLE
feat(debate): harvest-on-save incremental debate_tested update (t/3330)

### DIFF
--- a/lib/debate/backfillDebateTested.ts
+++ b/lib/debate/backfillDebateTested.ts
@@ -18,6 +18,7 @@ import fs from 'fs';
 import path from 'path';
 import { harvestDebateTested, computeTierAndSortKey, setDescriptionHasher, categoryToBdiImpact } from './debateTested.js';
 import { computeDescriptionHash } from './debateTestedHash.js';
+import { auditDebateTestedLag } from './harvestOnSave.js';
 import type { HarvestResult } from './debateTested.js';
 import type {
   PovNode,
@@ -341,6 +342,16 @@ export function runBackfill(repoRoot: string, writeMode: boolean): BackfillStats
     const after = tiersAfter[tier] ?? 0;
     const delta = after - before;
     console.log(`  ${tier.padEnd(14)} ${String(before).padEnd(8)} ${String(after).padEnd(8)} ${delta >= 0 ? '+' : ''}${delta}`);
+  }
+
+  // Lag audit: nodes cited in debates but lacking a debate_tested record.
+  // A persistent non-zero lag with harvest-on-save enabled (t/3330) signals
+  // the harvest is silently failing — treat as an alertable condition.
+  const lag = auditDebateTestedLag(nodeMap, debatesDir);
+  console.log(`\nDebate-tested lag check (cited in debates, no record):`);
+  console.log(`  Cited nodes (BDI): ${lag.total}  |  Harvested: ${lag.harvested}  |  Lag: ${lag.lag}`);
+  if (lag.lag > 0) {
+    console.log(`  Lagging node IDs (first 10): ${lag.lagNodeIds.slice(0, 10).join(', ')}`);
   }
 
   if (writeMode) {

--- a/lib/debate/harvestOnSave.test.ts
+++ b/lib/debate/harvestOnSave.test.ts
@@ -1,0 +1,313 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { harvestDebateTestedForSession, auditDebateTestedLag } from './harvestOnSave.js';
+import type { HarvestableSession } from './harvestOnSave.js';
+import type { PovNode } from './taxonomyTypes.js';
+import type { ArgumentNetworkNode, ArgumentNetworkEdge } from './types.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+function makePovNode(
+  id: string,
+  category: 'Beliefs' | 'Desires' | 'Intentions' = 'Beliefs',
+): PovNode {
+  return {
+    id,
+    label: `Label for ${id}`,
+    description: `Description for ${id}`,
+    pov: id.startsWith('acc') ? 'accelerationist' : id.startsWith('saf') ? 'safetyist' : 'skeptic',
+    category,
+    bdi_layer: category === 'Beliefs' ? 'belief' : category === 'Desires' ? 'desire' : 'intention',
+    parent_id: null,
+    children: [],
+    situation_refs: [],
+  };
+}
+
+function makeTranscriptSession(debateId: string, nodeIds: string[]): HarvestableSession {
+  return {
+    id: debateId,
+    created_at: '2026-09-05T10:00:00Z',
+    app_version: '2.0.0',
+    transcript: [
+      { speaker: 'accelerationist', taxonomy_refs: nodeIds },
+    ],
+  };
+}
+
+function makeAnSession(
+  debateId: string,
+  nodeId: string,
+  extraEdges: ArgumentNetworkEdge[] = [],
+): HarvestableSession {
+  const anNode: ArgumentNetworkNode = {
+    id: 'an-001',
+    type: 'position',
+    speaker: 'accelerationist',
+    text: 'Test claim',
+    taxonomy_refs: [nodeId],
+    strength: 0.7,
+    confidence: 0.8,
+  };
+  return {
+    id: debateId,
+    created_at: '2026-09-05T10:00:00Z',
+    app_version: '2.0.0',
+    argument_network: { nodes: [anNode], edges: extraEdges },
+  };
+}
+
+// ── Temp data-root helpers ─────────────────────────────────────────────────
+
+function makeTempDataRoot(nodes: PovNode[]): { repoRoot: string; cleanup: () => void } {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'harvest-test-'));
+  const taxonomyDir = path.join(tmpDir, 'data', 'taxonomy', 'Origin');
+  fs.mkdirSync(taxonomyDir, { recursive: true });
+
+  const acc = nodes.filter(n => n.id.startsWith('acc'));
+  const saf = nodes.filter(n => n.id.startsWith('saf'));
+  const skp = nodes.filter(n => n.id.startsWith('skp'));
+
+  fs.writeFileSync(path.join(taxonomyDir, 'accelerationist.json'), JSON.stringify({ pov: 'accelerationist', nodes: acc }, null, 2));
+  fs.writeFileSync(path.join(taxonomyDir, 'safetyist.json'), JSON.stringify({ pov: 'safetyist', nodes: saf }, null, 2));
+  fs.writeFileSync(path.join(taxonomyDir, 'skeptic.json'), JSON.stringify({ pov: 'skeptic', nodes: skp }, null, 2));
+
+  // Write a minimal .aitriad.json so resolveDataRoot finds the data dir
+  fs.writeFileSync(path.join(tmpDir, '.aitriad.json'), JSON.stringify({ data_root: './data' }));
+
+  return {
+    repoRoot: tmpDir,
+    cleanup: () => fs.rmSync(tmpDir, { recursive: true, force: true }),
+  };
+}
+
+function readHarvestedNode(repoRoot: string, filename: string, nodeId: string): PovNode | undefined {
+  const filePath = path.join(repoRoot, 'data', 'taxonomy', 'Origin', filename);
+  const data = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as { nodes: PovNode[] };
+  return data.nodes.find(n => n.id === nodeId);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+// Isolate from the real data root — AI_TRIAD_DATA_ROOT takes priority over
+// .aitriad.json in resolveDataRoot, so unset it during tests that write
+// a temp .aitriad.json (t/3330 env-override root cause).
+let _savedEnvRoot: string | undefined;
+beforeEach(() => {
+  _savedEnvRoot = process.env['AI_TRIAD_DATA_ROOT'];
+  delete process.env['AI_TRIAD_DATA_ROOT'];
+});
+afterEach(() => {
+  if (_savedEnvRoot !== undefined) {
+    process.env['AI_TRIAD_DATA_ROOT'] = _savedEnvRoot;
+  } else {
+    delete process.env['AI_TRIAD_DATA_ROOT'];
+  }
+});
+
+describe('harvestDebateTestedForSession', () => {
+  it('returns skipped=no-id for sessions without an id', () => {
+    const { repoRoot, cleanup } = makeTempDataRoot([makePovNode('acc-beliefs-001')]);
+    try {
+      const result = harvestDebateTestedForSession({}, repoRoot);
+      expect(result.skipped).toBe('no-id');
+      expect(result.entriesCreated).toBe(0);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('creates cited entry for transcript-only session', () => {
+    const node = makePovNode('acc-beliefs-001');
+    const { repoRoot, cleanup } = makeTempDataRoot([node]);
+    try {
+      const session = makeTranscriptSession('debate-001', ['acc-beliefs-001']);
+      const result = harvestDebateTestedForSession(session, repoRoot);
+
+      expect(result.skipped).toBeNull();
+      expect(result.entriesCreated).toBe(1);
+      expect(result.nodesUpdated).toContain('acc-beliefs-001');
+
+      const updated = readHarvestedNode(repoRoot, 'accelerationist.json', 'acc-beliefs-001');
+      expect(updated?.graph_attributes?.debate_tested?.tier).toBe('cited');
+      expect(updated?.graph_attributes?.debate_tested?.record).toHaveLength(1);
+      expect(updated?.graph_attributes?.debate_tested?.record[0].debate_id).toBe('debate-001');
+      expect(updated?.graph_attributes?.debate_tested?.record[0].verdict).toBe('cited');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('creates debate_tested record for AN session', () => {
+    const node = makePovNode('acc-beliefs-002');
+    const { repoRoot, cleanup } = makeTempDataRoot([node]);
+    try {
+      const session = makeAnSession('debate-002', 'acc-beliefs-002');
+      const result = harvestDebateTestedForSession(session, repoRoot);
+
+      expect(result.skipped).toBeNull();
+      expect(result.entriesCreated).toBe(1);
+
+      const updated = readHarvestedNode(repoRoot, 'accelerationist.json', 'acc-beliefs-002');
+      expect(updated?.graph_attributes?.debate_tested).toBeDefined();
+      expect(updated?.graph_attributes?.debate_tested?.record[0].debate_id).toBe('debate-002');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('is idempotent — calling twice for same session yields entriesCreated=0 on second call', () => {
+    const node = makePovNode('acc-beliefs-003');
+    const { repoRoot, cleanup } = makeTempDataRoot([node]);
+    try {
+      const session = makeTranscriptSession('debate-003', ['acc-beliefs-003']);
+      const first = harvestDebateTestedForSession(session, repoRoot);
+      expect(first.entriesCreated).toBe(1);
+
+      const second = harvestDebateTestedForSession(session, repoRoot);
+      expect(second.entriesCreated).toBe(0);
+      expect(second.skipped).toBeNull();
+
+      // Tier should still be correct
+      const updated = readHarvestedNode(repoRoot, 'accelerationist.json', 'acc-beliefs-003');
+      expect(updated?.graph_attributes?.debate_tested?.record).toHaveLength(1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('only writes dirty taxonomy files (safetyist node → only safetyist.json updated)', () => {
+    const nodes = [makePovNode('acc-beliefs-010'), makePovNode('saf-beliefs-010')];
+    const { repoRoot, cleanup } = makeTempDataRoot(nodes);
+    try {
+      const accStatBefore = fs.statSync(path.join(repoRoot, 'data', 'taxonomy', 'Origin', 'accelerationist.json')).mtimeMs;
+      const session = makeTranscriptSession('debate-010', ['saf-beliefs-010']);
+      harvestDebateTestedForSession(session, repoRoot);
+
+      const accStatAfter = fs.statSync(path.join(repoRoot, 'data', 'taxonomy', 'Origin', 'accelerationist.json')).mtimeMs;
+      expect(accStatAfter).toBe(accStatBefore);
+
+      const safNode = readHarvestedNode(repoRoot, 'safetyist.json', 'saf-beliefs-010');
+      expect(safNode?.graph_attributes?.debate_tested?.tier).toBe('cited');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('skips sit-* and cc-* nodes (non-BDI) from transcript refs', () => {
+    const node = makePovNode('acc-beliefs-020');
+    const { repoRoot, cleanup } = makeTempDataRoot([node]);
+    try {
+      const session: HarvestableSession = {
+        id: 'debate-020',
+        created_at: '2026-09-05T10:00:00Z',
+        transcript: [{ taxonomy_refs: ['sit-001', 'cc-001', 'acc-beliefs-020'] }],
+      };
+      const result = harvestDebateTestedForSession(session, repoRoot);
+      // sit-* and cc-* don't match ^(acc|saf|skp)- so they're filtered before BDI check
+      expect(result.nodesUpdated).toEqual(['acc-beliefs-020']);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('returns entriesCreated=0 and no file writes when session has no taxonomy refs', () => {
+    const node = makePovNode('acc-beliefs-030');
+    const { repoRoot, cleanup } = makeTempDataRoot([node]);
+    try {
+      const session: HarvestableSession = {
+        id: 'debate-030',
+        transcript: [{ speaker: 'acc', taxonomy_refs: [] }],
+      };
+      const result = harvestDebateTestedForSession(session, repoRoot);
+      expect(result.entriesCreated).toBe(0);
+      expect(result.nodesUpdated).toHaveLength(0);
+      expect(result.skipped).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('auditDebateTestedLag', () => {
+  it('returns lag=0 when all cited nodes have debate_tested records', () => {
+    const node = makePovNode('acc-beliefs-100');
+    node.graph_attributes = {
+      debate_tested: {
+        tier: 'cited', sort_key: 1, engagements: 1, challenges: 0,
+        held: 0, weakened: 0, revisions: [], last_tested: '2026-09-05',
+        description_hash: 'abc', record: [{ debate_id: 'd-1', date: '2026-09-05',
+          pipeline_version: 'test', verdict: 'cited',
+          strongest_attack_encountered: null,
+          claim_outcomes: { thrived: 0, survived: 0, died: 0 }, concession: null }],
+      },
+    };
+    const nodeMap = new Map([['acc-beliefs-100', node]]);
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lag-test-'));
+    try {
+      const session: HarvestableSession = {
+        id: 'd-1',
+        transcript: [{ taxonomy_refs: ['acc-beliefs-100'] }],
+      };
+      fs.writeFileSync(path.join(tmpDir, 'debate-d-1.json'), JSON.stringify(session));
+      const result = auditDebateTestedLag(nodeMap, tmpDir);
+      expect(result.lag).toBe(0);
+      expect(result.harvested).toBe(1);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns lagNodeIds for nodes cited in debates but lacking debate_tested', () => {
+    const node = makePovNode('acc-beliefs-101');
+    const nodeMap = new Map([['acc-beliefs-101', node]]);
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lag-test-'));
+    try {
+      const session: HarvestableSession = {
+        id: 'd-2',
+        transcript: [{ taxonomy_refs: ['acc-beliefs-101'] }],
+      };
+      fs.writeFileSync(path.join(tmpDir, 'debate-d-2.json'), JSON.stringify(session));
+      const result = auditDebateTestedLag(nodeMap, tmpDir);
+      expect(result.lag).toBe(1);
+      expect(result.lagNodeIds).toContain('acc-beliefs-101');
+      expect(result.harvested).toBe(0);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns lag=0 and total=0 when debates dir is empty', () => {
+    const nodeMap = new Map([['acc-beliefs-200', makePovNode('acc-beliefs-200')]]);
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lag-test-'));
+    try {
+      const result = auditDebateTestedLag(nodeMap, tmpDir);
+      expect(result.total).toBe(0);
+      expect(result.lag).toBe(0);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('skips sessions without an id in lag audit', () => {
+    const node = makePovNode('acc-beliefs-300');
+    const nodeMap = new Map([['acc-beliefs-300', node]]);
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lag-test-'));
+    try {
+      // debate-undefined.json: no id field
+      fs.writeFileSync(path.join(tmpDir, 'debate-undefined.json'),
+        JSON.stringify({ transcript: [{ taxonomy_refs: ['acc-beliefs-300'] }] }));
+      const result = auditDebateTestedLag(nodeMap, tmpDir);
+      expect(result.total).toBe(0);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/lib/debate/harvestOnSave.ts
+++ b/lib/debate/harvestOnSave.ts
@@ -1,0 +1,303 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * Incremental debate_tested harvest triggered on debate session save.
+ *
+ * Tickets: t/3330
+ *
+ * CALLERS MUST:
+ *   1. Gate behind a feature flag (default OFF) — harvest-on-save mutates
+ *      version-controlled taxonomy files and shifts WELL_TESTED_EXCLUSION
+ *      injection selection. Enable only after the coordinated corpus reconcile
+ *      has landed (see t/3330 for sequencing).
+ *   2. Run DEFERRED (setImmediate / after saveDebateSession returns) so the
+ *      synchronous file I/O does not block the save-return latency path.
+ *   3. Never propagate errors — wrap in try/catch; a harvest failure must
+ *      never cause the debate save to fail.
+ *
+ * Scope: Electron-only. The web profile uses a different save path (server →
+ * GitHub API) and requires a scheduled-sweep model instead (t/3331).
+ */
+
+import fs from 'fs';
+import path from 'path';
+import {
+  harvestDebateTested,
+  computeTierAndSortKey,
+  setDescriptionHasher,
+  categoryToBdiImpact,
+} from './debateTested.js';
+import { computeDescriptionHash } from './debateTestedHash.js';
+import { resolveDataRoot } from './taxonomyLoader.js';
+import { atomicWriteSync } from './persistence.js';
+import type { PovNode, DebateTestedEntry, DebateTestedRecord } from './taxonomyTypes.js';
+import type { ArgumentNetworkNode, ArgumentNetworkEdge } from './types.js';
+import type { InjectionManifest } from './debateTested.js';
+
+// debateTested.ts stays crypto-free for renderer bundling (t/1591).
+setDescriptionHasher(computeDescriptionHash);
+
+// In-process concurrency guard. atomicWriteSync is synchronous so this
+// protects against re-entrant calls (e.g. two rapid saves queued via
+// setImmediate). Does NOT protect cross-process races (e.g. a concurrent
+// backfill --write run from the CLI).
+let _harvesting = false;
+
+// ── Public types ──────────────────────────────────────────────────────────
+
+export interface HarvestableSession {
+  id?: string;
+  created_at?: string;
+  app_version?: string;
+  argument_network?: {
+    nodes?: ArgumentNetworkNode[];
+    edges?: ArgumentNetworkEdge[];
+  };
+  transcript?: Array<{
+    speaker?: string;
+    taxonomy_refs?: string[];
+  }>;
+}
+
+export interface HarvestOnSaveResult {
+  entriesCreated: number;
+  nodesUpdated: string[];
+  skipped: 'no-id' | 'concurrency-guard' | null;
+}
+
+export interface DebateTestedLagResult {
+  total: number;
+  harvested: number;
+  lag: number;
+  lagNodeIds: string[];
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────
+
+function nodeHasDebateEntry(node: PovNode, debateId: string): boolean {
+  const record = node.graph_attributes?.debate_tested?.record;
+  if (!record?.length) return false;
+  return record.some((e: DebateTestedEntry) => e.debate_id === debateId);
+}
+
+function createCitedEntry(
+  debateId: string,
+  date: string,
+  pipelineVersion: string,
+): DebateTestedEntry {
+  return {
+    debate_id: debateId,
+    date,
+    pipeline_version: pipelineVersion,
+    verdict: 'cited',
+    strongest_attack_encountered: null,
+    claim_outcomes: { thrived: 0, survived: 0, died: 0 },
+    concession: null,
+  };
+}
+
+function mergeCitedEntry(
+  entry: DebateTestedEntry,
+  existing: DebateTestedRecord | undefined,
+  description: string,
+): DebateTestedRecord {
+  const record = [...(existing?.record ?? []), entry];
+  const revisions = [...(existing?.revisions ?? [])];
+  const engagements = (existing?.engagements ?? 0) + 1;
+  const { tier, sort_key } = computeTierAndSortKey(record, revisions);
+  return {
+    tier,
+    sort_key,
+    engagements,
+    challenges: existing?.challenges ?? 0,
+    held: existing?.held ?? 0,
+    weakened: existing?.weakened ?? 0,
+    revisions,
+    last_tested: entry.date,
+    description_hash: existing?.description_hash ?? computeDescriptionHash(description),
+    record,
+  };
+}
+
+function extractPovTaxonomyRefs(anNodes: ReadonlyArray<ArgumentNetworkNode>): string[] {
+  const refs = new Set<string>();
+  for (const node of anNodes) {
+    for (const ref of node.taxonomy_refs ?? []) {
+      const nodeId = typeof ref === 'string' ? ref : (ref as { node_id: string }).node_id;
+      if (/^(acc|saf|skp)-/.test(nodeId)) refs.add(nodeId);
+    }
+  }
+  return [...refs];
+}
+
+function extractTranscriptTaxonomyRefs(session: HarvestableSession): string[] {
+  const refs = new Set<string>();
+  for (const entry of session.transcript ?? []) {
+    for (const ref of entry.taxonomy_refs ?? []) {
+      if (typeof ref === 'string' && /^(acc|saf|skp)-/.test(ref)) refs.add(ref);
+    }
+  }
+  return [...refs];
+}
+
+// ── Public API ────────────────────────────────────────────────────────────
+
+/**
+ * Incrementally update debate_tested records for the nodes engaged in a
+ * single saved debate session. Idempotent: calling twice for the same
+ * session yields entriesCreated=0 on the second call (nodeHasDebateEntry dedup).
+ *
+ * Only writes taxonomy files that actually changed (dirty-file optimization).
+ */
+export function harvestDebateTestedForSession(
+  session: HarvestableSession,
+  repoRoot: string,
+): HarvestOnSaveResult {
+  if (!session.id) return { entriesCreated: 0, nodesUpdated: [], skipped: 'no-id' };
+  if (_harvesting) return { entriesCreated: 0, nodesUpdated: [], skipped: 'concurrency-guard' };
+
+  _harvesting = true;
+  try {
+    const dataRoot = resolveDataRoot(repoRoot);
+    const taxonomyDir = path.join(dataRoot, 'taxonomy', 'Origin');
+    const POV_FILES = ['accelerationist.json', 'safetyist.json', 'skeptic.json'] as const;
+
+    const povFiles = new Map<string, { pov: string; nodes: PovNode[]; [k: string]: unknown }>();
+    const nodeMap = new Map<string, PovNode>();
+    const nodeToFile = new Map<string, string>();
+
+    for (const filename of POV_FILES) {
+      const filePath = path.join(taxonomyDir, filename);
+      const data = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as { pov: string; nodes: PovNode[] };
+      povFiles.set(filename, data);
+      for (const node of data.nodes) {
+        nodeMap.set(node.id, node);
+        nodeToFile.set(node.id, filename);
+      }
+    }
+
+    const debateId = session.id;
+    const date = session.created_at?.slice(0, 10) ?? new Date().toISOString().slice(0, 10);
+    const pipelineVersion = session.app_version
+      ? `harvest-on-save-v${session.app_version}-${date}`
+      : 'harvest-on-save';
+
+    const anNodes = session.argument_network?.nodes ?? [];
+    const anEdges = session.argument_network?.edges ?? [];
+    const nodesUpdated: string[] = [];
+    let entriesCreated = 0;
+
+    if (anNodes.length > 0) {
+      const povNodeIds = extractPovTaxonomyRefs(anNodes);
+      const manifest: InjectionManifest = { povNodeIds };
+      const results = harvestDebateTested({
+        debateId,
+        date,
+        pipelineVersion,
+        anNodes,
+        anEdges: anEdges as ArgumentNetworkEdge[],
+        injectionManifest: manifest,
+        taxonomyNodes: nodeMap,
+        concessions: [],
+        refinedNodeIds: new Set(),
+      });
+      for (const result of results) {
+        const node = nodeMap.get(result.nodeId);
+        if (!node || nodeHasDebateEntry(node, debateId)) continue;
+        if (!node.graph_attributes) node.graph_attributes = {};
+        node.graph_attributes.debate_tested = result.updatedRecord;
+        nodesUpdated.push(result.nodeId);
+        entriesCreated++;
+      }
+    } else {
+      const transcriptRefs = extractTranscriptTaxonomyRefs(session);
+      const bdiRefs = transcriptRefs.filter(ref => {
+        const node = nodeMap.get(ref);
+        return node ? !!categoryToBdiImpact(node.category) : false;
+      });
+      for (const nodeId of bdiRefs) {
+        const node = nodeMap.get(nodeId);
+        if (!node || nodeHasDebateEntry(node, debateId)) continue;
+        const entry = createCitedEntry(debateId, date, pipelineVersion);
+        const existing = node.graph_attributes?.debate_tested;
+        if (!node.graph_attributes) node.graph_attributes = {};
+        node.graph_attributes.debate_tested = mergeCitedEntry(entry, existing, node.description);
+        nodesUpdated.push(nodeId);
+        entriesCreated++;
+      }
+    }
+
+    if (entriesCreated > 0) {
+      const dirtyFiles = new Set(
+        nodesUpdated.map(id => nodeToFile.get(id)).filter((f): f is string => f != null),
+      );
+      for (const filename of dirtyFiles) {
+        const data = povFiles.get(filename)!;
+        atomicWriteSync(path.join(taxonomyDir, filename), JSON.stringify(data, null, 2) + '\n');
+      }
+    }
+
+    return { entriesCreated, nodesUpdated, skipped: null };
+  } finally {
+    _harvesting = false;
+  }
+}
+
+/**
+ * Audit nodes that appear in debate sessions but lack a debate_tested record.
+ *
+ * Use in backfill dry-run to surface the lag count. With harvest-on-save
+ * enabled (flag on), a persistent non-zero lag indicates harvest is silently
+ * failing — treat as an alertable condition.
+ */
+export function auditDebateTestedLag(
+  nodeMap: Map<string, PovNode>,
+  debatesDir: string,
+): DebateTestedLagResult {
+  const citedNodeIds = new Set<string>();
+
+  if (fs.existsSync(debatesDir)) {
+    const sessionFiles = fs.readdirSync(debatesDir)
+      .filter(f => f.startsWith('debate-') && f.endsWith('.json'));
+
+    for (const file of sessionFiles) {
+      let session: Record<string, unknown>;
+      try {
+        session = JSON.parse(fs.readFileSync(path.join(debatesDir, file), 'utf-8')) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+      if (!session['id']) continue;
+
+      const anNodes = (session['argument_network'] as { nodes?: ArgumentNetworkNode[] } | undefined)?.nodes ?? [];
+      for (const anNode of anNodes) {
+        for (const ref of (anNode.taxonomy_refs as (string | { node_id: string })[] | undefined) ?? []) {
+          const nodeId = typeof ref === 'string' ? ref : ref.node_id;
+          if (/^(acc|saf|skp)-/.test(nodeId)) citedNodeIds.add(nodeId);
+        }
+      }
+      const transcript = session['transcript'] as Array<{ taxonomy_refs?: string[] }> | undefined;
+      for (const entry of transcript ?? []) {
+        for (const ref of entry.taxonomy_refs ?? []) {
+          if (typeof ref === 'string' && /^(acc|saf|skp)-/.test(ref)) citedNodeIds.add(ref);
+        }
+      }
+    }
+  }
+
+  let harvested = 0;
+  const lagNodeIds: string[] = [];
+
+  for (const nodeId of citedNodeIds) {
+    const node = nodeMap.get(nodeId);
+    if (!node || !categoryToBdiImpact(node.category)) continue;
+    if (node.graph_attributes?.debate_tested) {
+      harvested++;
+    } else {
+      lagNodeIds.push(nodeId);
+    }
+  }
+
+  return { total: citedNodeIds.size, harvested, lag: lagNodeIds.length, lagNodeIds };
+}


### PR DESCRIPTION
## Summary

- `harvestOnSave.ts`: new `harvestDebateTestedForSession()` — incremental harvest triggered on debate session save; `auditDebateTestedLag()` — backfill observability function for lag detection
- `harvestOnSave.test.ts`: 11 tests covering transcript-only, AN session, idempotency, dirty-file-only writes, non-BDI filtering, and lag audit
- `backfillDebateTested.ts`: lag audit report added to dry-run summary output

**Design per t/3330#2 (TL approved):**
- Concurrency-guarded (`_harvesting` flag, in-process)
- Callers MUST gate behind default-OFF feature flag
- Callers MUST run deferred (`setImmediate`) — never blocks save latency
- Callers MUST never propagate errors — harvest failure must not fail save
- Electron-only scope; web-profile follow-up: t/3331

## Test plan

- [x] `npx vitest run harvestOnSave.test.ts` — 11/11 pass
- [x] Env-var isolation (`AI_TRIAD_DATA_ROOT` save/clear/restore) prevents false `entriesCreated=0`

Closes t/3330

Co-Authored-By: DebateTool (Orca) <main.lib-debate@ai-triad-research.orca.local>