### PR TITLE
feat(debateIO): wire harvest-on-save into saveDebateSession (t/3330)

### DIFF
--- a/taxonomy-editor/src/main/debateIO.ts
+++ b/taxonomy-editor/src/main/debateIO.ts
@@ -4,7 +4,8 @@
 import fs from 'fs';
 import path from 'path';
 
-import { resolveDataPath } from './fileIO.js';
+import { resolveDataPath, PROJECT_ROOT } from './fileIO.js';
+import { harvestDebateTestedForSession, type HarvestableSession } from '../../../lib/debate/harvestOnSave.js';
 import { assertSafeId } from '../../../lib/electron-shared/safeId.js';
 import { extractCalibrationData, appendCalibrationLog } from '../../../lib/debate/calibrationLogger.js';
 import { safeSerialize, atomicWriteSync, renameSyncWithRetry } from '../../../lib/debate/persistence.js';
@@ -285,6 +286,23 @@ export function saveDebateSession(session: unknown, caller: string): void {
     type: 'state.save', component: 'debateIO', level: 'info',
     message: 'Debate saved',
     data: { debate_id: data.id, caller, save_mode: 'electron-main' },
+  });
+
+  // Harvest debate_tested tier increments after save (t/3330). Deferred so harvest never
+  // blocks save latency. Flag default-OFF until coordinated corpus reconcile (t/3330#2).
+  const _session = session;
+  const _id = data.id;
+  setImmediate(() => {
+    if (process.env.HARVEST_DEBATE_TESTED_ON_SAVE !== '1') return;
+    try {
+      harvestDebateTestedForSession(_session as HarvestableSession, PROJECT_ROOT);
+    } catch (err) {
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'debateIO', level: 'warn',
+        message: `debate_tested auto-harvest failed for ${_id}`,
+        error: { name: (err as Error).name ?? 'Error', message: String(err) },
+      });
+    }
   });
 }
 


### PR DESCRIPTION
## Summary

- Wires `harvestDebateTestedForSession` into `saveDebateSession` after each successful atomic write
- Deferred via `setImmediate` — harvest never blocks save latency
- Gated by `HARVEST_DEBATE_TESTED_ON_SAVE !== '1'` (default OFF) — safe to land now; flag flipped after coordinated corpus reconcile (t/3330#2)
- Harvest failure recorded to flight recorder but never propagated — save path is unaffected

## Test plan

- [ ] CI green
- [ ] Verify flag gate: with env var unset, no harvest runs on save
- [ ] Verify harvest runs when `HARVEST_DEBATE_TESTED_ON_SAVE=1` is set

Depends on #1975 (already merged at 8a2122db).

Closes ElectronMain callsite item from t/3330.

🤖 Generated with [Claude Code](https://claude.com/claude-code)