### PR TITLE
feat(community): operator-visible WARN on op-ed share mint refusals (t/3334)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/communityOpedShareRoute.test.ts
+++ b/taxonomy-editor/src/server/__tests__/communityOpedShareRoute.test.ts
@@ -20,6 +20,7 @@ const writePublicCommunityOpEd = vi.fn(async () => {});
 const deletePublicCommunityOpEd = vi.fn(async () => {});
 const checkRate = vi.fn(() => ({ allowed: true, retryAfterMs: 0 }));
 const getStorageUserId = vi.fn(() => 'user-1');
+const logServerWarn = vi.fn(); // t/3334: capture the mint-refusal WARN→Log_s
 
 vi.mock('../community/community.js', () => ({ getCommunityOpEd: (...a: unknown[]) => getCommunityOpEd(...a), isAdmin: (...a: unknown[]) => isAdmin(...a) }));
 vi.mock('../community/communityOpedShares.js', () => ({
@@ -36,9 +37,11 @@ vi.mock('../security/userContext.js', () => ({ getStorageUserId: () => getStorag
 vi.mock('../security/rateLimitResponse.js', () => ({ rateLimitResponseBody: () => ({ error: 'rate_limited', retryAfter: 1 }) }));
 vi.mock('../../../../lib/flight-recorder/index.js', () => ({ getGlobalRecorder: () => ({ record: vi.fn() }) }));
 vi.mock('../logger.js', () => ({
-  log: { api: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }, server: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } },
+  log: { api: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }, server: { info: vi.fn(), warn: (...a: unknown[]) => logServerWarn(...a), error: vi.fn(), debug: vi.fn() } },
   getRequestId: () => 'test-req', getRequestContext: () => undefined,
 }));
+// t/3334: deterministic backend name for the mint-refusal WARN's discriminating data.
+vi.mock('../storage/fileIO.js', () => ({ getUserContentBackend: () => ({ constructor: { name: 'FilesystemBackend' } }) }));
 
 import { registerCommunityRoutes } from '../routes/community.js';
 import type { ServerCtx } from '../routes/context.js';
@@ -85,23 +88,37 @@ describe('POST/DELETE /api/community/opeds/:id/share (t/3315)', () => {
     expect(writePublicCommunityOpEd).toHaveBeenCalledWith(GOOD_ITEM, 'share-xyz');
     // no identity/metadata leaked in the response
     expect(JSON.stringify(res._body)).not.toContain('author-9');
+    // t/3334: the happy path must NOT emit the operator WARN.
+    expect(logServerWarn).not.toHaveBeenCalled();
   });
 
-  it('404 when the community item does not exist', async () => {
+  it('404 when the community item does not exist — WARNs (operator-visible) with id + backend (t/3334)', async () => {
     getCommunityOpEd.mockResolvedValue(null);
     const res = fakeRes();
     await post(req('/api/community/opeds/missing/share'), res, {});
     expect(res._status).toBe(404);
     expect(mintCommunityOpedShare).not.toHaveBeenCalled();
+    // t/3334: mint-path empty/absent → WARN→Log_s with discriminating data (NOT silent).
+    expect(logServerWarn).toHaveBeenCalledTimes(1);
+    expect(logServerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'missing', backend: 'FilesystemBackend', path: 'mint' }),
+      expect.stringContaining('empty/absent'),
+    );
   });
 
-  it('422 (assert-presence) when the item is empty/malformed — never mints a shareId for it', async () => {
+  it('422 (assert-presence) when the item is empty/malformed — never mints a shareId, and WARNs (t/3334)', async () => {
     getCommunityOpEd.mockResolvedValue({ topic: '', opeds: [] });
     const res = fakeRes();
     await post(req('/api/community/opeds/empty/share'), res, {});
     expect(res._status).toBe(422);
     expect(mintCommunityOpedShare).not.toHaveBeenCalled();
     expect(writePublicCommunityOpEd).not.toHaveBeenCalled();
+    // t/3334: malformed = unambiguous corruption → WARN→Log_s with id + backend.
+    expect(logServerWarn).toHaveBeenCalledTimes(1);
+    expect(logServerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'empty', backend: 'FilesystemBackend' }),
+      expect.stringContaining('malformed'),
+    );
   });
 
   it('429 when rate-limited (mint = any authed user, RATE-LIMITED)', async () => {

--- a/taxonomy-editor/src/server/routes/community.ts
+++ b/taxonomy-editor/src/server/routes/community.ts
@@ -14,6 +14,8 @@ import type { Router } from '../httpKit.js';
 import type { ServerCtx } from './context.js';
 import { json, error, param } from '../httpKit.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
+import { log } from '../logger.js';
+import { getUserContentBackend } from '../storage/fileIO.js';
 import { rateLimitResponseBody } from '../security/rateLimitResponse.js';
 import * as rateLimiter from '../security/rateLimiter.js';
 import { getStorageUserId } from '../security/userContext.js';
@@ -184,12 +186,28 @@ export function registerCommunityRoutes(r: Router, ctx: ServerCtx): void {
       }
 
       const item = await community.getCommunityOpEd(id);
-      if (!item) { error(res, 'not_found', 404); return; }
+      if (!item) {
+        // t/3334: a 404 here is client-loud but operator-SILENT — an authed user minting a share for an
+        // item that read empty/absent is low-frequency + suspicious (possible silent-empty/corruption),
+        // so WARN→Log_s with discriminating data. Scoped to the MINT path only (NOT the public GET
+        // not-found, which is ordinary). getCommunityOpEd returns null for both absent and empty-`opeds`.
+        log.server.warn(
+          { id, backend: getUserContentBackend().constructor.name, path: 'mint' },
+          'Community op-ed share mint: getCommunityOpEd returned empty/absent — refusing to mint (possible silent-empty/corruption)',
+        );
+        error(res, 'not_found', 404);
+        return;
+      }
 
       // Condition 4: assert PRESENCE before minting — never register a shareId for an empty/partial
       // read (ADR-001 silent-empty guard on the hosted github-api path). writePublicCommunityOpEd re-checks.
       const it = item as { topic?: unknown; opeds?: unknown; community_metadata?: { submitted_by_display?: string } };
       if (!it.topic || !Array.isArray(it.opeds) || it.opeds.length === 0) {
+        // t/3334: malformed (has a file but no topic / empty opeds) = unambiguous corruption → always WARN→Log_s.
+        log.server.warn(
+          { id, backend: getUserContentBackend().constructor.name, topicPresent: !!it.topic, opedsLen: Array.isArray(it.opeds) ? it.opeds.length : null },
+          'Community op-ed share mint: item malformed (missing topic / empty opeds) — refusing to mint (corruption)',
+        );
         error(res, 'Community op-ed is empty or malformed — cannot mint a public copy', 422);
         return;
       }


### PR DESCRIPTION
Follow-up to t/3326 (TL-approved, p/522#277). The community op-ed share MINT handler already refuses to project from an empty/malformed read, but the refusal was client-loud / operator-silent. Adds a scoped WARN→Log_s: malformed→422 (always), empty/absent→404 on the MINT path (suspicious, low-freq) — NOT on ordinary public not-founds. Discriminating data: item id + user-content backend name. Tests extended (404+422 arms WARN with id+backend; 200 does not). 8/8 pass, lint+tsc clean, verify:config 7/7. Self-cert: observability+test, single-scope (routes/community.ts), Fallback-Path Logging convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)