### PR TITLE
fix(grounding): hard-guard sweep silent-no-op trap on github-api profile (t/3333)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/groundingSweep.test.ts
+++ b/taxonomy-editor/src/server/__tests__/groundingSweep.test.ts
@@ -23,9 +23,18 @@ vi.mock('../../../../lib/flight-recorder/index.js', () => ({
   setGlobalRecorder: vi.fn(),
 }));
 
+// t/3333: make STORAGE_MODE controllable so the github-api hard-guard arm is exercised. Defaults to
+// 'filesystem' (the real test-env value) so every existing test is unaffected; one test flips it.
+const cfgMock = vi.hoisted(() => ({ storageMode: 'filesystem' as string }));
+vi.mock('../config.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../config.js')>();
+  return { ...actual, get STORAGE_MODE() { return cfgMock.storageMode; } };
+});
+
 import {
   startGroundingSweep,
   stopGroundingSweep,
+  decideSweepArm,
   __setSweepRunnerForTest,
   __runSweepOnceForTest,
   __resetSweepForTest,
@@ -47,6 +56,7 @@ describe('G8b groundingSweepScheduler (t/3172)', () => {
     __resetSweepForTest();
     __setSweepRunnerForTest(null); // restore default; individual tests inject their own
     delete process.env.GROUNDING_SWEEP_ENABLED;
+    cfgMock.storageMode = 'filesystem'; // t/3333: default profile is FS-visible; one test flips it
   });
   afterEach(() => {
     stopGroundingSweep();
@@ -144,5 +154,34 @@ describe('G8b groundingSweepScheduler (t/3172)', () => {
     expect(__stateForTest().armed).toBe(true);
     stop();
     expect(__stateForTest().armed).toBe(false);
+  });
+
+  // ── t/3333: hard-guard the silent-no-op trap on the github-api profile ────────
+  describe('decideSweepArm (t/3333 pure predicate)', () => {
+    it('flag OFF → disabled (regardless of storage mode)', () => {
+      expect(decideSweepArm('filesystem', false)).toBe('disabled');
+      expect(decideSweepArm('github-api', false)).toBe('disabled');
+    });
+    it('flag ON + filesystem → arm', () => {
+      expect(decideSweepArm('filesystem', true)).toBe('arm');
+    });
+    it('flag ON + github-api → blocked-github-api (writes invisible to the read path)', () => {
+      expect(decideSweepArm('github-api', true)).toBe('blocked-github-api');
+    });
+  });
+
+  it('t/3333 hard-guard: flag ON + STORAGE_MODE=github-api → REFUSES to arm + records a loud error (not a silent no-op)', () => {
+    process.env.GROUNDING_SWEEP_ENABLED = '1';
+    cfgMock.storageMode = 'github-api';
+    const stop = startGroundingSweep(50);
+    // Refused to arm — no timer, so the reconciler can never run + silently no-op.
+    expect(__stateForTest().armed).toBe(false);
+    expect(typeof stop).toBe('function');
+    stop(); // no-op stop must not throw
+    // Loud: a grounding-sweep error names the refusal + the discriminating storageMode.
+    const refusal = sweepEvents().find((e) => e.level === 'error' && String(e.message).includes('refused to arm'));
+    expect(refusal).toBeDefined();
+    expect(refusal?.data?.storageMode).toBe('github-api');
+    expect(refusal?.data?.armed).toBe(false);
   });
 });

--- a/taxonomy-editor/src/server/groundingSweepScheduler.ts
+++ b/taxonomy-editor/src/server/groundingSweepScheduler.ts
@@ -27,9 +27,9 @@
  */
 
 import { execFile } from 'child_process';
-import { RECONCILE_SCRIPT, getProjectRoot, isGroundingSweepEnabled } from './config.js';
+import { RECONCILE_SCRIPT, getProjectRoot, isGroundingSweepEnabled, STORAGE_MODE } from './config.js';
 import { getGlobalRecorder } from '../../../lib/flight-recorder/index.js';
-import { errorMessage } from '../../../lib/debate/errors.js';
+import { ActionableError, errorMessage } from '../../../lib/debate/errors.js';
 import { parseStats, type ReconcilerStats } from './groundingReconcileHook.js';
 import { log } from './logger.js';
 
@@ -139,6 +139,20 @@ async function runSweep(): Promise<void> {
   }
 }
 
+/** t/3333: arm-decision for the sweep. PURE (no I/O) so both arms are unit-tested without config/env
+ *  mocking. The sweep's `--apply` writes the LOCAL filesystem; on the `github-api` read profile those
+ *  writes are invisible to the read path, so arming it there would SILENTLY no-op (t/2648 class) — a
+ *  hard architectural constraint, not the soft default-OFF. Returns:
+ *   - 'disabled'            — flag OFF (inert by design; the default).
+ *   - 'blocked-github-api'  — flag ON but STORAGE_MODE=github-api → refuse to arm + fail LOUD.
+ *   - 'arm'                 — flag ON and a filesystem-visible profile → arm normally. */
+export type SweepArmDecision = 'arm' | 'disabled' | 'blocked-github-api';
+export function decideSweepArm(storageMode: string, enabled: boolean): SweepArmDecision {
+  if (!enabled) return 'disabled';
+  if (storageMode === 'github-api') return 'blocked-github-api';
+  return 'arm';
+}
+
 /**
  * Start the recurring grounding sweep. Idempotent (a second call is a no-op while running). The
  * interval is `unref()`d so it never keeps the process alive. Returns the stop fn.
@@ -146,12 +160,39 @@ async function runSweep(): Promise<void> {
  * Gated on `isGroundingSweepEnabled()`: when the flag is OFF the timer is NEVER armed — the sweep is
  * completely inert (this is the default, pending the sequenced enable). Returns a no-op stop fn in
  * that case so the caller contract is identical either way.
+ *
+ * t/3333 hard-guard: even when the flag is ON, on the `github-api` profile the timer is REFUSED (not
+ * armed) with a loud ActionableError → Log_s, because the reconciler's local-FS writes are invisible
+ * to the github-api read path (silent no-op / t/2648 class). Loud-and-refuse, never a throw — this is
+ * called at boot and a misconfigured flag must not crash the host (the module's non-fatal contract).
  */
 export function startGroundingSweep(intervalMs: number = resolveIntervalMs()): () => void {
-  if (!isGroundingSweepEnabled()) {
+  const decision = decideSweepArm(STORAGE_MODE, isGroundingSweepEnabled());
+  if (decision === 'disabled') {
     // Log-once so an operator can see the sweep is present-but-disabled (vs. silently absent).
     log.server.info({ component: 'grounding-sweep' }, 'Grounding sweep disabled (GROUNDING_SWEEP_ENABLED off) — timer not armed');
     return () => { /* no-op: nothing was armed */ };
+  }
+  if (decision === 'blocked-github-api') {
+    const err = new ActionableError({
+      goal: 'Run the scheduled grounding sweep so batch/PS/Python taxonomy writes stay grounded',
+      problem: `GROUNDING_SWEEP_ENABLED is set but STORAGE_MODE=${STORAGE_MODE}. The sweep shells reconcile_grounding.py --apply, which writes the LOCAL filesystem — invisible to the github-api read path. Arming it here would SILENTLY no-op (t/2648 class), so the timer is refused.`,
+      location: 'server/groundingSweepScheduler.ts → startGroundingSweep',
+      nextSteps: [
+        'Do NOT set GROUNDING_SWEEP_ENABLED on the hosted github-api profile.',
+        'To keep hosted taxonomy grounded, run the sweep in the CI-commit model (a scheduled Action that commits to ai-triad-data) — see t/3333 Option A.',
+        'Unset GROUNDING_SWEEP_ENABLED, or run the sweep only on a filesystem-backed profile.',
+      ],
+    });
+    // Fail LOUD (not a silent no-op): both Log_s (Pino error) and the flight recorder name the refusal.
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'grounding-sweep', level: 'error',
+      message: 'Grounding sweep refused to arm — GROUNDING_SWEEP_ENABLED set on the github-api profile (would silently no-op)',
+      data: { storageMode: STORAGE_MODE, armed: false },
+      error: { name: err.name, message: errorMessage(err) },
+    });
+    log.server.error({ component: 'grounding-sweep', storageMode: STORAGE_MODE }, errorMessage(err));
+    return () => { /* no-op: refused to arm on the github-api profile */ };
   }
   if (timer) return stopGroundingSweep;
   log.server.info({ component: 'grounding-sweep', intervalMs }, 'Grounding sweep enabled — arming timer');


### PR DESCRIPTION
Option B (ticket choice) for t/3333. The scheduled grounding sweep's reconcile_grounding.py --apply writes local FS; on the hosted github-api read profile those writes are invisible → enabling it would silently no-op (t/2648 class). startGroundingSweep now hard-guards: on github-api + flag ON it fails LOUD (ActionableError→Log_s + FR) and REFUSES to arm (no throw — never-crash-the-host contract). New pure predicate decideSweepArm() unit-tested all 3 arms; integration test asserts refuse-to-arm + loud error on github-api. 10/10 pass, lint+tsc clean, verify:config 7/7. Option A (CI-commit port) deferred (bigger cross-role feature, no current demand). Self-cert: single-scope, fail-loud + Fallback-Path Logging conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)