### PR TITLE
fix(debate): harvest transcript-only refs in AN sessions via shared collectSessionTaxonomyRefs (t/3331)

### DIFF
--- a/lib/debate/backfillDebateTested.ts
+++ b/lib/debate/backfillDebateTested.ts
@@ -18,7 +18,7 @@ import fs from 'fs';
 import path from 'path';
 import { harvestDebateTested, computeTierAndSortKey, setDescriptionHasher, categoryToBdiImpact } from './debateTested.js';
 import { computeDescriptionHash } from './debateTestedHash.js';
-import { auditDebateTestedLag } from './harvestOnSave.js';
+import { auditDebateTestedLag, collectSessionTaxonomyRefs } from './harvestOnSave.js';
 import type { HarvestResult } from './debateTested.js';
 import type {
   PovNode,
@@ -95,17 +95,6 @@ function extractPovTaxonomyRefs(anNodes: ArgumentNetworkNode[]): string[] {
   return [...refs];
 }
 
-function extractTranscriptTaxonomyRefs(session: DebateSession): string[] {
-  const refs = new Set<string>();
-  for (const entry of session.transcript ?? []) {
-    for (const ref of entry.taxonomy_refs ?? []) {
-      if (typeof ref === 'string' && ref.match(/^(acc|saf|skp)-/)) {
-        refs.add(ref);
-      }
-    }
-  }
-  return [...refs];
-}
 
 function nodeHasDebateEntry(node: PovNode, debateId: string): boolean {
   const record = node.graph_attributes?.debate_tested?.record;
@@ -227,12 +216,15 @@ export function runBackfill(repoRoot: string, writeMode: boolean): BackfillStats
     const anEdges = session.argument_network?.edges ?? [];
     const hasAN = anNodes.length > 0;
 
+    // All POV refs this session touches — union of AN + transcript, deduped.
+    // The shared helper ensures backfill and auditDebateTestedLag agree on coverage (t/3331).
+    const allRefs = collectSessionTaxonomyRefs(session);
+
     if (hasAN) {
       stats.sessionsWithAN++;
 
-      // Synthesize injection_manifest from AN taxonomy_refs (historical sessions lack it)
+      // AN harvest: nodes in the argument network get full strength/verdict data.
       const povNodeIds = extractPovTaxonomyRefs(anNodes);
-
       const results = harvestDebateTested({
         debateId,
         date,
@@ -247,31 +239,46 @@ export function runBackfill(repoRoot: string, writeMode: boolean): BackfillStats
 
       let created = 0;
       let deduped = 0;
+      const harvestedByAN = new Set<string>();
       for (const result of results) {
         if (nodeHasDebateEntry(nodeMap.get(result.nodeId)!, debateId)) {
           deduped++;
           continue;
         }
-        // Apply the updated record to the node
         const node = nodeMap.get(result.nodeId)!;
         if (!node.graph_attributes) node.graph_attributes = {};
         node.graph_attributes.debate_tested = result.updatedRecord;
         stats.nodesUpdated.add(result.nodeId);
         stats.verdictCounts[result.entry.verdict] = (stats.verdictCounts[result.entry.verdict] ?? 0) + 1;
         created++;
+        harvestedByAN.add(result.nodeId);
       }
+
+      // Cited entries for transcript refs not covered by AN harvest (t/3331).
+      for (const nodeId of allRefs) {
+        if (harvestedByAN.has(nodeId)) continue;
+        const node = nodeMap.get(nodeId);
+        if (!node || !categoryToBdiImpact(node.category)) continue;
+        if (nodeHasDebateEntry(node, debateId)) { deduped++; continue; }
+        const entry = createCitedEntry(debateId, date, pipelineVersion);
+        const existing = node.graph_attributes?.debate_tested;
+        const updatedRecord = mergeCitedEntry(entry, existing, node.description);
+        if (!node.graph_attributes) node.graph_attributes = {};
+        node.graph_attributes.debate_tested = updatedRecord;
+        stats.nodesUpdated.add(nodeId);
+        stats.verdictCounts['cited'] = (stats.verdictCounts['cited'] ?? 0) + 1;
+        created++;
+      }
+
       stats.entriesCreated += created;
       stats.entriesDeduplicated += deduped;
-
       if (created > 0 || deduped > 0) {
-        console.log(`  ${file}: AN harvest — ${created} entries created, ${deduped} deduped, ${results.length - created - deduped} skipped (non-BDI / situation)`);
+        console.log(`  ${file}: AN harvest — ${created} entries created, ${deduped} deduped`);
       }
     } else {
-      // No argument_network — check transcript for taxonomy_refs → cited entries.
-      // All three BDI categories qualify; situation nodes (sit-*/cc-*) have no BDI
-      // category and coerce to undefined via categoryToBdiImpact, staying excluded (t/1660).
-      const transcriptRefs = extractTranscriptTaxonomyRefs(session);
-      const bdiRefs = transcriptRefs.filter(ref => {
+      // No argument_network — cited entries for all BDI refs (transcript or AN union = transcript here).
+      // Situation nodes (sit-*/cc-*) coerce to undefined via categoryToBdiImpact, excluded (t/1660).
+      const bdiRefs = allRefs.filter(ref => {
         const node = nodeMap.get(ref);
         return node ? !!categoryToBdiImpact(node.category) : false;
       });
@@ -288,10 +295,7 @@ export function runBackfill(repoRoot: string, writeMode: boolean): BackfillStats
 
       for (const nodeId of bdiRefs) {
         const node = nodeMap.get(nodeId)!;
-        if (nodeHasDebateEntry(node, debateId)) {
-          deduped++;
-          continue;
-        }
+        if (nodeHasDebateEntry(node, debateId)) { deduped++; continue; }
         const entry = createCitedEntry(debateId, date, pipelineVersion);
         const existing = node.graph_attributes?.debate_tested;
         const updatedRecord = mergeCitedEntry(entry, existing, node.description);
@@ -303,7 +307,6 @@ export function runBackfill(repoRoot: string, writeMode: boolean): BackfillStats
       }
       stats.entriesCreated += created;
       stats.entriesDeduplicated += deduped;
-
       if (created > 0 || deduped > 0) {
         console.log(`  ${file}: transcript-only — ${created} cited entries, ${deduped} deduped`);
       }

--- a/lib/debate/harvestOnSave.test.ts
+++ b/lib/debate/harvestOnSave.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { harvestDebateTestedForSession, auditDebateTestedLag } from './harvestOnSave.js';
+import { harvestDebateTestedForSession, auditDebateTestedLag, collectSessionTaxonomyRefs } from './harvestOnSave.js';
 import type { HarvestableSession } from './harvestOnSave.js';
 import type { PovNode } from './taxonomyTypes.js';
 import type { ArgumentNetworkNode, ArgumentNetworkEdge } from './types.js';
@@ -231,6 +231,66 @@ describe('harvestDebateTestedForSession', () => {
     } finally {
       cleanup();
     }
+  });
+
+  it('harvests transcript-only refs in AN sessions (t/3331 gap fix)', () => {
+    // anNode references acc-beliefs-040; transcript also references saf-beliefs-040 which is NOT in the AN.
+    // Before the fix, saf-beliefs-040 would be silently dropped. After the fix it gets a cited entry.
+    const nodes = [makePovNode('acc-beliefs-040'), makePovNode('saf-beliefs-040')];
+    const { repoRoot, cleanup } = makeTempDataRoot(nodes);
+    try {
+      const anNode: ArgumentNetworkNode = {
+        id: 'an-040',
+        type: 'position',
+        speaker: 'accelerationist',
+        text: 'AN claim',
+        taxonomy_refs: ['acc-beliefs-040'],
+        strength: 0.7,
+        confidence: 0.8,
+      };
+      const session: HarvestableSession = {
+        id: 'debate-040',
+        created_at: '2026-09-05T10:00:00Z',
+        argument_network: { nodes: [anNode], edges: [] },
+        transcript: [{ taxonomy_refs: ['acc-beliefs-040', 'saf-beliefs-040'] }],
+      };
+      const result = harvestDebateTestedForSession(session, repoRoot);
+      // Both AN ref and transcript-only ref must be harvested
+      expect(result.nodesUpdated).toContain('acc-beliefs-040');
+      expect(result.nodesUpdated).toContain('saf-beliefs-040');
+      expect(result.entriesCreated).toBe(2);
+
+      const safNode = readHarvestedNode(repoRoot, 'safetyist.json', 'saf-beliefs-040');
+      expect(safNode?.graph_attributes?.debate_tested?.tier).toBe('cited');
+      expect(safNode?.graph_attributes?.debate_tested?.record[0].debate_id).toBe('debate-040');
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('collectSessionTaxonomyRefs', () => {
+  it('returns union of AN and transcript refs, deduped', () => {
+    const session: HarvestableSession = {
+      id: 'test',
+      argument_network: { nodes: [{ id: 'n1', type: 'position', speaker: 'acc', text: 't',
+        taxonomy_refs: ['acc-beliefs-500', 'saf-beliefs-500'], strength: 0.5, confidence: 0.5 }] },
+      transcript: [{ taxonomy_refs: ['saf-beliefs-500', 'skp-beliefs-500'] }],
+    };
+    const refs = collectSessionTaxonomyRefs(session);
+    expect(refs).toHaveLength(3);
+    expect(refs).toContain('acc-beliefs-500');
+    expect(refs).toContain('saf-beliefs-500');
+    expect(refs).toContain('skp-beliefs-500');
+  });
+
+  it('filters non-POV refs (sit-*, cc-*, pol-*)', () => {
+    const session: HarvestableSession = {
+      id: 'test',
+      transcript: [{ taxonomy_refs: ['sit-001', 'cc-001', 'pol-001', 'acc-beliefs-501'] }],
+    };
+    const refs = collectSessionTaxonomyRefs(session);
+    expect(refs).toEqual(['acc-beliefs-501']);
   });
 });
 

--- a/lib/debate/harvestOnSave.ts
+++ b/lib/debate/harvestOnSave.ts
@@ -131,8 +131,22 @@ function extractPovTaxonomyRefs(anNodes: ReadonlyArray<ArgumentNetworkNode>): st
   return [...refs];
 }
 
-function extractTranscriptTaxonomyRefs(session: HarvestableSession): string[] {
+// ── Public API ────────────────────────────────────────────────────────────
+
+/**
+ * Canonical "all refs" for a session — union of argument_network node refs and
+ * transcript refs, deduped. Consumed by harvest (both backfill and harvestOnSave)
+ * AND auditDebateTestedLag so the assertion and the harvest can never disagree on
+ * what "all refs" means (t/3331).
+ */
+export function collectSessionTaxonomyRefs(session: HarvestableSession): string[] {
   const refs = new Set<string>();
+  for (const anNode of session.argument_network?.nodes ?? []) {
+    for (const ref of anNode.taxonomy_refs ?? []) {
+      const nodeId = typeof ref === 'string' ? ref : (ref as { node_id: string }).node_id;
+      if (/^(acc|saf|skp)-/.test(nodeId)) refs.add(nodeId);
+    }
+  }
   for (const entry of session.transcript ?? []) {
     for (const ref of entry.taxonomy_refs ?? []) {
       if (typeof ref === 'string' && /^(acc|saf|skp)-/.test(ref)) refs.add(ref);
@@ -140,8 +154,6 @@ function extractTranscriptTaxonomyRefs(session: HarvestableSession): string[] {
   }
   return [...refs];
 }
-
-// ── Public API ────────────────────────────────────────────────────────────
 
 /**
  * Incrementally update debate_tested records for the nodes engaged in a
@@ -188,7 +200,14 @@ export function harvestDebateTestedForSession(
     const nodesUpdated: string[] = [];
     let entriesCreated = 0;
 
+    // All POV refs this session touches — union of AN + transcript, deduped.
+    // Used for both the AN strength harvest and the cited-fallback below so
+    // transcript-only refs in an AN session are never silently dropped (t/3331).
+    const allRefs = collectSessionTaxonomyRefs(session);
+    const harvestedByAN = new Set<string>();
+
     if (anNodes.length > 0) {
+      // AN harvest: nodes in the argument network get full strength/verdict data.
       const povNodeIds = extractPovTaxonomyRefs(anNodes);
       const manifest: InjectionManifest = { povNodeIds };
       const results = harvestDebateTested({
@@ -209,23 +228,23 @@ export function harvestDebateTestedForSession(
         node.graph_attributes.debate_tested = result.updatedRecord;
         nodesUpdated.push(result.nodeId);
         entriesCreated++;
+        harvestedByAN.add(result.nodeId);
       }
-    } else {
-      const transcriptRefs = extractTranscriptTaxonomyRefs(session);
-      const bdiRefs = transcriptRefs.filter(ref => {
-        const node = nodeMap.get(ref);
-        return node ? !!categoryToBdiImpact(node.category) : false;
-      });
-      for (const nodeId of bdiRefs) {
-        const node = nodeMap.get(nodeId);
-        if (!node || nodeHasDebateEntry(node, debateId)) continue;
-        const entry = createCitedEntry(debateId, date, pipelineVersion);
-        const existing = node.graph_attributes?.debate_tested;
-        if (!node.graph_attributes) node.graph_attributes = {};
-        node.graph_attributes.debate_tested = mergeCitedEntry(entry, existing, node.description);
-        nodesUpdated.push(nodeId);
-        entriesCreated++;
-      }
+    }
+
+    // Cited entries for refs not covered by AN harvest (includes transcript-only
+    // refs in AN sessions and all refs in transcript-only sessions).
+    for (const nodeId of allRefs) {
+      if (harvestedByAN.has(nodeId)) continue;
+      const node = nodeMap.get(nodeId);
+      if (!node || !categoryToBdiImpact(node.category)) continue;
+      if (nodeHasDebateEntry(node, debateId)) continue;
+      const entry = createCitedEntry(debateId, date, pipelineVersion);
+      const existing = node.graph_attributes?.debate_tested;
+      if (!node.graph_attributes) node.graph_attributes = {};
+      node.graph_attributes.debate_tested = mergeCitedEntry(entry, existing, node.description);
+      nodesUpdated.push(nodeId);
+      entriesCreated++;
     }
 
     if (entriesCreated > 0) {
@@ -262,26 +281,15 @@ export function auditDebateTestedLag(
       .filter(f => f.startsWith('debate-') && f.endsWith('.json'));
 
     for (const file of sessionFiles) {
-      let session: Record<string, unknown>;
+      let session: HarvestableSession;
       try {
-        session = JSON.parse(fs.readFileSync(path.join(debatesDir, file), 'utf-8')) as Record<string, unknown>;
+        session = JSON.parse(fs.readFileSync(path.join(debatesDir, file), 'utf-8')) as HarvestableSession;
       } catch {
         continue;
       }
-      if (!session['id']) continue;
-
-      const anNodes = (session['argument_network'] as { nodes?: ArgumentNetworkNode[] } | undefined)?.nodes ?? [];
-      for (const anNode of anNodes) {
-        for (const ref of (anNode.taxonomy_refs as (string | { node_id: string })[] | undefined) ?? []) {
-          const nodeId = typeof ref === 'string' ? ref : ref.node_id;
-          if (/^(acc|saf|skp)-/.test(nodeId)) citedNodeIds.add(nodeId);
-        }
-      }
-      const transcript = session['transcript'] as Array<{ taxonomy_refs?: string[] }> | undefined;
-      for (const entry of transcript ?? []) {
-        for (const ref of entry.taxonomy_refs ?? []) {
-          if (typeof ref === 'string' && /^(acc|saf|skp)-/.test(ref)) citedNodeIds.add(ref);
-        }
+      if (!session.id) continue;
+      for (const nodeId of collectSessionTaxonomyRefs(session)) {
+        citedNodeIds.add(nodeId);
       }
     }
   }


### PR DESCRIPTION
## Summary

- **Root cause (t/3331 lag=4):** both `backfillDebateTested` and `harvestOnSave` extracted refs only from `argument_network.nodes[].taxonomy_refs` for AN sessions, silently dropping nodes referenced only in transcript refs of the same session. `auditDebateTestedLag` read both AN and transcript refs, so those 4 nodes appeared as lag but backfill never created records for them.
- **Fix:** extracted `collectSessionTaxonomyRefs()` as a single exported helper — union of AN + transcript refs, deduped — consumed by both harvest paths and `auditDebateTestedLag`. The assert and the harvest now use identical "all refs" definitions and can never drift.
- **Scope:** `harvestOnSave.ts` (Electron) + `backfillDebateTested.ts` + `harvestOnSave.test.ts`. The `push:[main]` trigger on the DevOps CI job will fire on merge and confirm lag=0 with Entries created ≥ 4.

## Test plan

- [x] `harvestDebateTestedForSession`: new regression test for AN session with transcript-only ref (t/3331 gap)
- [x] `collectSessionTaxonomyRefs`: new unit tests (union dedup, non-POV filter)
- [x] All 3084 `lib/debate` tests passing
- [ ] CI job on-merge run: expect lag=0, entriesCreated ≥ 4 (the 4 lagging nodes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gpput6pLsxuLHARuD6kbF