### PR TITLE
fix(qbaf): forward AI keys to the contradiction-classifier subprocess (t/3336)

### DIFF
--- a/scripts/enrich_conflicts_qbaf.py
+++ b/scripts/enrich_conflicts_qbaf.py
@@ -314,12 +314,24 @@ def _qbaf_testedness(qbaf, instances):
     }
 
 
-def _safe_env():
-    """Build a minimal environment for subprocess calls — no API keys leaked."""
+_AI_KEY_VARS = ("GEMINI_API_KEY", "ANTHROPIC_API_KEY", "GROQ_API_KEY", "AI_API_KEY")
+
+
+def _safe_env(include_ai_keys=False):
+    """Build a minimal environment for subprocess calls. By default NO API keys are forwarded (the
+    Node qbaf-bridge needs none). include_ai_keys=True additionally forwards the AI backend key vars —
+    REQUIRED for the contradiction-classifier subprocess (_run_cc_shim), which authenticates the LLM
+    call; without them every pair returns 'unresolved' (t/3336 live-run failure). Keys still never reach
+    the bridge call, so this is a scoped forward, not a blanket leak."""
     import os
     allowed = {"PATH", "NODE_PATH", "HOME", "USER", "LANG", "TERM", "SHELL",
                "TMPDIR", "XDG_RUNTIME_DIR", "SYSTEMROOT", "COMSPEC"}
-    return {k: v for k, v in os.environ.items() if k in allowed}
+    env = {k: v for k, v in os.environ.items() if k in allowed}
+    if include_ai_keys:
+        for k in _AI_KEY_VARS:
+            if os.environ.get(k):
+                env[k] = os.environ[k]
+    return env
 
 
 def _run_qbaf_bridge(nodes, edges):
@@ -625,7 +637,8 @@ def _run_cc_shim(batch_conflicts, mode="per-conflict", temperature=0.0):
         result = subprocess.run(
             ["pwsh", "-NoProfile", "-NonInteractive", "-File", str(_CC_SHIM),
              "-InputPath", tmp, "-Mode", mode, "-Temperature", str(temperature), "-OutPath", out_tmp],
-            capture_output=True, text=True, timeout=600, cwd=str(_PROJECT_ROOT), env=_safe_env(),
+            capture_output=True, text=True, timeout=600, cwd=str(_PROJECT_ROOT),
+            env=_safe_env(include_ai_keys=True),  # classifier authenticates the LLM call (t/3336)
         )
         if result.returncode != 0:
             _log(f"  WARN: contradiction-classifier exited {result.returncode} "

--- a/scripts/test_enrich_conflicts_qbaf.py
+++ b/scripts/test_enrich_conflicts_qbaf.py
@@ -373,6 +373,35 @@ def test_cosine_basic():
     assert eq._cosine([0.0, 0.0], [1.0, 1.0]) == 0.0  # degenerate -> 0
 
 
+# _safe_env AI-key forwarding — classifier auth path (t/3336 live-run failure: keys stripped -> unresolved)
+
+def test_safe_env_default_strips_ai_keys_but_forwards_on_request():
+    import os
+    key = "GEMINI_API_KEY"
+    saved = os.environ.get(key)
+    try:
+        os.environ[key] = "test-sentinel-not-a-real-key"
+        assert key not in eq._safe_env()                       # default: bridge gets no AI keys
+        assert eq._safe_env(include_ai_keys=True).get(key) == "test-sentinel-not-a-real-key"
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+
+
+def test_safe_env_does_not_inject_absent_ai_keys():
+    import os
+    key = "GROQ_API_KEY"
+    saved = os.environ.get(key)
+    try:
+        os.environ.pop(key, None)
+        assert key not in eq._safe_env(include_ai_keys=True)   # absent key not fabricated
+    finally:
+        if saved is not None:
+            os.environ[key] = saved
+
+
 if __name__ == "__main__":
     import pytest
 


### PR DESCRIPTION
Live-run bug: the same-doc measure returned 622/676 pairs `unresolved` (no LLM calls). Root cause: enrich's `_run_cc_shim` passed `_safe_env()` (strips ALL API keys — correct for the Node qbaf-bridge) to the **classifier** subprocess, which needs the key. The enrich→classifier path could never authenticate — and this would have silently produced **zero LLM edges on the real `--write`** too.

GV t/3302#23 unaffected: the golden runner invokes the classifier via `& pwsh` (full parent env), not `_safe_env` — hence its 110 `llm-batch` labels.

Fix: `_safe_env(include_ai_keys=False)` (default unchanged, bridge key-free); `_run_cc_shim` passes `include_ai_keys=True`, forwarding GEMINI/ANTHROPIC/GROQ/AI_API_KEY when present. Scoped forward. Tests +2 → **31 pytest green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)