### PR TITLE
feat(server): READYZ_FORCE_DATA_ROOT_FAILED test-only fault knob (t/3236/t/3340)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/readyz.test.ts
+++ b/taxonomy-editor/src/server/__tests__/readyz.test.ts
@@ -160,7 +160,7 @@ describe('/readyz shared body-contract fixture (t/3114)', () => {
   });
 });
 
-// ── t/3236: READYZ_FORCE_DATA_ROOT_FAILED test-only fault knob ────────────────
+// ── t/3236 / t/3340: READYZ_FORCE_DATA_ROOT_FAILED test-only fault knob ───────
 // Lets DevOps exercise the deploy warm-gate's FIRE arm (503 'failed' → block traffic-shift →
 // fail+rollback) against a REAL staging revision with real data, no 700M throwaway repo.
 // TL cond 1: forces the DEFINITIVE 'failed' state (NOT 'validating'). TL cond 2: gated

--- a/taxonomy-editor/src/server/__tests__/readyz.test.ts
+++ b/taxonomy-editor/src/server/__tests__/readyz.test.ts
@@ -6,7 +6,7 @@
 // (TL-approved contract, p/542#55); 503 while warming. Anon (deploy probe polls pre-auth).
 // Covers: publicPaths inclusion + handler response shape.
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { PUBLIC_EXACT_PATHS, computeIsPublicPath } from '../publicPaths.js';
 
 // t/3114 shared body-contract fixture. This SAME file is read by the deploy warm-gate's
@@ -47,10 +47,16 @@ type HandlerResult = { statusCode: number; body: Record<string, unknown> };
 // t/3309: the data-root gate composes AHEAD of the embeddings gate. Default 'ready' so the
 // existing embeddings-branch cases below are unaffected (data-root ready → falls through).
 function simulateReadyz(r: Resolution, dataRoot: DataRoot = { state: 'ready' }): HandlerResult {
-  if (dataRoot.state === 'failed') {
-    return { statusCode: 503, body: { status: 'failed', reason: `data-root-failed: ${dataRoot.reason ?? 'unknown'}` } };
+  // t/3236: test-only fault knob — force the definitive data-root-FAILED state, gated non-prod.
+  // In lockstep with routes/meta.ts. Runtime-scoped: overrides only this response, not boot.
+  const forceDataRootFailed = process.env.NODE_ENV !== 'production' && process.env.READYZ_FORCE_DATA_ROOT_FAILED === '1';
+  const dr: DataRoot = forceDataRootFailed
+    ? { state: 'failed', reason: 'forced (READYZ_FORCE_DATA_ROOT_FAILED test knob, t/3236)' }
+    : dataRoot;
+  if (dr.state === 'failed') {
+    return { statusCode: 503, body: { status: 'failed', reason: `data-root-failed: ${dr.reason ?? 'unknown'}` } };
   }
-  if (dataRoot.state === 'validating') {
+  if (dr.state === 'validating') {
     return { statusCode: 503, body: { status: 'warming', reason: 'data-root-validating' } };
   }
   const { present, nodeCount, resolves } = r;
@@ -151,5 +157,45 @@ describe('/readyz shared body-contract fixture (t/3114)', () => {
     expect(readyBody.status).toBe('ready');
     expect(readyBody.nodeCount).toBeGreaterThan(0);
     expect(readyBody.resolves).toBe(true); // t/3165: resolution is now part of the 200 contract
+  });
+});
+
+// ── t/3236: READYZ_FORCE_DATA_ROOT_FAILED test-only fault knob ────────────────
+// Lets DevOps exercise the deploy warm-gate's FIRE arm (503 'failed' → block traffic-shift →
+// fail+rollback) against a REAL staging revision with real data, no 700M throwaway repo.
+// TL cond 1: forces the DEFINITIVE 'failed' state (NOT 'validating'). TL cond 2: gated
+// NODE_ENV!=='production' so it can NEVER force a false-negative /readyz in prod.
+describe('GET /readyz — READYZ_FORCE_DATA_ROOT_FAILED knob (t/3236)', () => {
+  const RESOLVING: Resolution = { present: true, nodeCount: 4144, resolves: true };
+  const ORIG_NODE_ENV = process.env.NODE_ENV;
+  beforeEach(() => { delete process.env.READYZ_FORCE_DATA_ROOT_FAILED; process.env.NODE_ENV = 'test'; });
+  afterEach(() => { delete process.env.READYZ_FORCE_DATA_ROOT_FAILED; process.env.NODE_ENV = ORIG_NODE_ENV; });
+
+  it('knob ON + non-production: forces definitive 503 failed even when data-root ready AND embeddings resolve', () => {
+    process.env.READYZ_FORCE_DATA_ROOT_FAILED = '1';
+    const { statusCode, body } = simulateReadyz(RESOLVING, { state: 'ready' });
+    expect(statusCode).toBe(503);
+    expect(body.status).toBe('failed'); // TL cond 1: definitive failed, NOT 'warming'
+    expect(String(body.reason)).toMatch(/^data-root-failed:/);
+    expect(String(body.reason)).toContain('READYZ_FORCE_DATA_ROOT_FAILED');
+  });
+
+  it('knob ON + NODE_ENV=production: INERT — falls through to the real ready 200 (no prod false-negative)', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.READYZ_FORCE_DATA_ROOT_FAILED = '1';
+    const { statusCode, body } = simulateReadyz(RESOLVING, { state: 'ready' });
+    expect(statusCode).toBe(200);
+    expect(body.status).toBe('ready');
+  });
+
+  it('knob value other than "1" is ignored', () => {
+    process.env.READYZ_FORCE_DATA_ROOT_FAILED = 'true'; // only exactly "1" enables
+    expect(simulateReadyz(RESOLVING, { state: 'ready' }).statusCode).toBe(200);
+  });
+
+  it('knob unset: real data-root state governs (unchanged behavior)', () => {
+    const { statusCode, body } = simulateReadyz(RESOLVING, { state: 'ready' });
+    expect(statusCode).toBe(200);
+    expect(body.status).toBe('ready');
   });
 });

--- a/taxonomy-editor/src/server/__tests__/readyz.test.ts
+++ b/taxonomy-editor/src/server/__tests__/readyz.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { PUBLIC_EXACT_PATHS, computeIsPublicPath } from '../publicPaths.js';
+import { isStagingIdentity } from '../config.js'; // t/3340: the real enable-guard predicate (no drift)
 
 // t/3114 shared body-contract fixture. This SAME file is read by the deploy warm-gate's
 // Pester (tests/ReadyzWarmGate.Tests.ps1) as the "real 200 body" it feeds to the predicate.
@@ -47,9 +48,10 @@ type HandlerResult = { statusCode: number; body: Record<string, unknown> };
 // t/3309: the data-root gate composes AHEAD of the embeddings gate. Default 'ready' so the
 // existing embeddings-branch cases below are unaffected (data-root ready → falls through).
 function simulateReadyz(r: Resolution, dataRoot: DataRoot = { state: 'ready' }): HandlerResult {
-  // t/3236: test-only fault knob — force the definitive data-root-FAILED state, gated non-prod.
-  // In lockstep with routes/meta.ts. Runtime-scoped: overrides only this response, not boot.
-  const forceDataRootFailed = process.env.NODE_ENV !== 'production' && process.env.READYZ_FORCE_DATA_ROOT_FAILED === '1';
+  // t/3236: test-only fault knob — force the definitive data-root-FAILED state. Enable-guard is the
+  // REAL isStagingIdentity() predicate (fail-closed, prod-excluded). In lockstep with routes/meta.ts.
+  // Runtime-scoped: overrides only this response, not boot.
+  const forceDataRootFailed = isStagingIdentity() && process.env.READYZ_FORCE_DATA_ROOT_FAILED === '1';
   const dr: DataRoot = forceDataRootFailed
     ? { state: 'failed', reason: 'forced (READYZ_FORCE_DATA_ROOT_FAILED test knob, t/3236)' }
     : dataRoot;
@@ -163,15 +165,31 @@ describe('/readyz shared body-contract fixture (t/3114)', () => {
 // ── t/3236 / t/3340: READYZ_FORCE_DATA_ROOT_FAILED test-only fault knob ───────
 // Lets DevOps exercise the deploy warm-gate's FIRE arm (503 'failed' → block traffic-shift →
 // fail+rollback) against a REAL staging revision with real data, no 700M throwaway repo.
-// TL cond 1: forces the DEFINITIVE 'failed' state (NOT 'validating'). TL cond 2: gated
-// NODE_ENV!=='production' so it can NEVER force a false-negative /readyz in prod.
-describe('GET /readyz — READYZ_FORCE_DATA_ROOT_FAILED knob (t/3236)', () => {
+// TL cond 1: forces the DEFINITIVE 'failed' state (NOT 'validating'). Enable-guard (TL re-GV,
+// t/3340#4/#5): FAIL-CLOSED on isStagingIdentity() (ACA CONTAINER_APP_NAME=/staging/i, prod
+// cannot spoof) AND the flag — both default-absent → inert; prod-excluded by construction.
+describe('GET /readyz — READYZ_FORCE_DATA_ROOT_FAILED knob (t/3236, staging-gated)', () => {
   const RESOLVING: Resolution = { present: true, nodeCount: 4144, resolves: true };
-  const ORIG_NODE_ENV = process.env.NODE_ENV;
-  beforeEach(() => { delete process.env.READYZ_FORCE_DATA_ROOT_FAILED; process.env.NODE_ENV = 'test'; });
-  afterEach(() => { delete process.env.READYZ_FORCE_DATA_ROOT_FAILED; process.env.NODE_ENV = ORIG_NODE_ENV; });
+  const ORIG_APP = process.env.CONTAINER_APP_NAME;
+  const ORIG_ENV = process.env.AI_TRIAD_ENV;
+  beforeEach(() => {
+    delete process.env.READYZ_FORCE_DATA_ROOT_FAILED;
+    delete process.env.AI_TRIAD_ENV;
+    process.env.CONTAINER_APP_NAME = 'taxonomy-editor-staging'; // staging identity by default
+  });
+  afterEach(() => {
+    delete process.env.READYZ_FORCE_DATA_ROOT_FAILED;
+    if (ORIG_APP === undefined) delete process.env.CONTAINER_APP_NAME; else process.env.CONTAINER_APP_NAME = ORIG_APP;
+    if (ORIG_ENV === undefined) delete process.env.AI_TRIAD_ENV; else process.env.AI_TRIAD_ENV = ORIG_ENV;
+  });
 
-  it('knob ON + non-production: forces definitive 503 failed even when data-root ready AND embeddings resolve', () => {
+  it('sanity: isStagingIdentity() reflects CONTAINER_APP_NAME', () => {
+    expect(isStagingIdentity()).toBe(true); // set to *-staging in beforeEach
+    process.env.CONTAINER_APP_NAME = 'taxonomy-editor'; // prod app name
+    expect(isStagingIdentity()).toBe(false);
+  });
+
+  it('knob ON + staging identity: forces definitive 503 failed even when data-root ready AND embeddings resolve', () => {
     process.env.READYZ_FORCE_DATA_ROOT_FAILED = '1';
     const { statusCode, body } = simulateReadyz(RESOLVING, { state: 'ready' });
     expect(statusCode).toBe(503);
@@ -180,20 +198,33 @@ describe('GET /readyz — READYZ_FORCE_DATA_ROOT_FAILED knob (t/3236)', () => {
     expect(String(body.reason)).toContain('READYZ_FORCE_DATA_ROOT_FAILED');
   });
 
-  it('knob ON + NODE_ENV=production: INERT — falls through to the real ready 200 (no prod false-negative)', () => {
-    process.env.NODE_ENV = 'production';
+  it('knob ON + AI_TRIAD_ENV=staging belt (no matching app name): still active', () => {
+    process.env.CONTAINER_APP_NAME = 'taxonomy-editor'; // non-staging app name
+    process.env.AI_TRIAD_ENV = 'staging';               // belt un-gates
+    process.env.READYZ_FORCE_DATA_ROOT_FAILED = '1';
+    expect(simulateReadyz(RESOLVING, { state: 'ready' }).statusCode).toBe(503);
+  });
+
+  it('knob ON + PROD identity (no staging signal): INERT — real ready 200 (fail-closed, no prod false-negative)', () => {
+    process.env.CONTAINER_APP_NAME = 'taxonomy-editor'; // prod app name, no /staging/
     process.env.READYZ_FORCE_DATA_ROOT_FAILED = '1';
     const { statusCode, body } = simulateReadyz(RESOLVING, { state: 'ready' });
     expect(statusCode).toBe(200);
     expect(body.status).toBe('ready');
   });
 
-  it('knob value other than "1" is ignored', () => {
+  it('knob ON + CONTAINER_APP_NAME unset (no signal at all): INERT — fail-closed', () => {
+    delete process.env.CONTAINER_APP_NAME; // neither signal present
+    process.env.READYZ_FORCE_DATA_ROOT_FAILED = '1';
+    expect(simulateReadyz(RESOLVING, { state: 'ready' }).statusCode).toBe(200);
+  });
+
+  it('staging identity + knob value other than "1": ignored', () => {
     process.env.READYZ_FORCE_DATA_ROOT_FAILED = 'true'; // only exactly "1" enables
     expect(simulateReadyz(RESOLVING, { state: 'ready' }).statusCode).toBe(200);
   });
 
-  it('knob unset: real data-root state governs (unchanged behavior)', () => {
+  it('staging identity + knob unset: real data-root state governs (unchanged behavior)', () => {
     const { statusCode, body } = simulateReadyz(RESOLVING, { state: 'ready' });
     expect(statusCode).toBe(200);
     expect(body.status).toBe('ready');

--- a/taxonomy-editor/src/server/routes/meta.ts
+++ b/taxonomy-editor/src/server/routes/meta.ts
@@ -17,7 +17,7 @@ import { json, error } from '../httpKit.js';
 import { classifyDataUnavailable, type ReadinessState } from './readiness.js';
 import { getDataRootReadyState } from './dataRootReadiness.js'; // t/3309: cache-once data-root readiness
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
-import { getProjectRoot, getDataRoot, hasApiKey, STORAGE_MODE } from '../config.js';
+import { getProjectRoot, getDataRoot, hasApiKey, STORAGE_MODE, isStagingIdentity } from '../config.js';
 import { getConfig } from '../runtimeConfig.js';
 import * as proxyTiers from '../ai/proxyTiers.js';
 import { getEmbeddingsCacheStatus, getEmbeddingsResolution } from '../ai/aiBackends.js';
@@ -117,14 +117,17 @@ export function registerMetaRoutes(r: Router, ctx: ServerCtx): void {
     // 'failed' is a hard 503 (not masked as a slow warm-up, cond 3); 'validating' is warming.
     // The 200-ready body is unchanged (data-root 'ready' falls through to the existing embeddings
     // gate), preserving the shared warm-gate body-contract fixture (t/3114).
-    // t/3236 (server half tracked t/3340): test-only fault knob — force the DEFINITIVE data-root-FAILED readiness so DevOps can
-    // exercise the deploy warm-gate's FIRE arm (503 'failed' → block traffic-shift → fail+rollback)
-    // against a REAL staging revision with real data, no 700M throwaway repo. TL cond 1: forces the
-    // definitive 'failed' state (NOT 'validating'), so the warm-gate sees a definitive failure.
-    // TL cond 2: gated NODE_ENV!=='production' so it can NEVER force a false-negative /readyz in prod
-    // (mirrors READYZ_FORCE_RESOLVES_FALSE, t/3192). RUNTIME-scoped to this response only: boot
-    // validateDataRoot runs against real data, unaffected — so no ENFORCE change is required for boot.
-    const forceDataRootFailed = process.env.NODE_ENV !== 'production' && process.env.READYZ_FORCE_DATA_ROOT_FAILED === '1';
+    // t/3236 (server half tracked t/3340): test-only fault knob — force the DEFINITIVE data-root-FAILED
+    // readiness so DevOps can exercise the deploy warm-gate's FIRE arm (503 'failed' → block traffic-
+    // shift → fail+rollback) against a REAL staging revision with real data, no 700M throwaway repo.
+    // TL cond 1: forces the definitive 'failed' state (NOT 'validating'), so the warm-gate sees a
+    // definitive failure. ENABLE-GUARD (TL re-GV, t/3340#4/#5): gated on isStagingIdentity() — ACA
+    // auto-injects CONTAINER_APP_NAME=/staging/i (drift-proof; prod's app name CANNOT match) — AND the
+    // explicit flag. FAIL-CLOSED: both signals default-absent → inert; prod-excluded by construction
+    // (not a fail-open NODE_ENV/branch check). So DevOps arms it with a SINGLE var on NORMAL staging
+    // (no NODE_ENV flip → none of the HOST/STORAGE_MODE/ALLOWED_ORIGINS confounds). RUNTIME-scoped to
+    // this response only: boot validateDataRoot runs against real data, unaffected — no ENFORCE change.
+    const forceDataRootFailed = isStagingIdentity() && process.env.READYZ_FORCE_DATA_ROOT_FAILED === '1';
     const dr = forceDataRootFailed
       ? { state: 'failed' as const, reason: 'forced (READYZ_FORCE_DATA_ROOT_FAILED test knob, t/3236)' }
       : getDataRootReadyState();

--- a/taxonomy-editor/src/server/routes/meta.ts
+++ b/taxonomy-editor/src/server/routes/meta.ts
@@ -117,7 +117,17 @@ export function registerMetaRoutes(r: Router, ctx: ServerCtx): void {
     // 'failed' is a hard 503 (not masked as a slow warm-up, cond 3); 'validating' is warming.
     // The 200-ready body is unchanged (data-root 'ready' falls through to the existing embeddings
     // gate), preserving the shared warm-gate body-contract fixture (t/3114).
-    const dr = getDataRootReadyState();
+    // t/3236: test-only fault knob — force the DEFINITIVE data-root-FAILED readiness so DevOps can
+    // exercise the deploy warm-gate's FIRE arm (503 'failed' → block traffic-shift → fail+rollback)
+    // against a REAL staging revision with real data, no 700M throwaway repo. TL cond 1: forces the
+    // definitive 'failed' state (NOT 'validating'), so the warm-gate sees a definitive failure.
+    // TL cond 2: gated NODE_ENV!=='production' so it can NEVER force a false-negative /readyz in prod
+    // (mirrors READYZ_FORCE_RESOLVES_FALSE, t/3192). RUNTIME-scoped to this response only: boot
+    // validateDataRoot runs against real data, unaffected — so no ENFORCE change is required for boot.
+    const forceDataRootFailed = process.env.NODE_ENV !== 'production' && process.env.READYZ_FORCE_DATA_ROOT_FAILED === '1';
+    const dr = forceDataRootFailed
+      ? { state: 'failed' as const, reason: 'forced (READYZ_FORCE_DATA_ROOT_FAILED test knob, t/3236)' }
+      : getDataRootReadyState();
     if (dr.state === 'failed') {
       logDataRootReadyzFailure(dr.reason); // cond 4: WARN→Log_s once per failure episode
       json(res, { status: 'failed', reason: `data-root-failed: ${dr.reason ?? 'unknown'}` }, 503);

--- a/taxonomy-editor/src/server/routes/meta.ts
+++ b/taxonomy-editor/src/server/routes/meta.ts
@@ -127,6 +127,11 @@ export function registerMetaRoutes(r: Router, ctx: ServerCtx): void {
     // (not a fail-open NODE_ENV/branch check). So DevOps arms it with a SINGLE var on NORMAL staging
     // (no NODE_ENV flip → none of the HOST/STORAGE_MODE/ALLOWED_ORIGINS confounds). RUNTIME-scoped to
     // this response only: boot validateDataRoot runs against real data, unaffected — no ENFORCE change.
+    // GATE CO-LOCATION (TL t/3340#6): isStagingIdentity()'s own doc says "used only by the state-root
+    // isolation guard — never an auth/security decision." This call is a DELIBERATE, TL-approved
+    // exception — it's staging-only FEATURE-scoping of a fail-safe test knob (worst case = a self-DoS
+    // behind the flag on staging only), NOT an access-control decision. A future isStagingIdentity
+    // doc-usage sweep should read this as a justified exception, not drift.
     const forceDataRootFailed = isStagingIdentity() && process.env.READYZ_FORCE_DATA_ROOT_FAILED === '1';
     const dr = forceDataRootFailed
       ? { state: 'failed' as const, reason: 'forced (READYZ_FORCE_DATA_ROOT_FAILED test knob, t/3236)' }

--- a/taxonomy-editor/src/server/routes/meta.ts
+++ b/taxonomy-editor/src/server/routes/meta.ts
@@ -117,7 +117,7 @@ export function registerMetaRoutes(r: Router, ctx: ServerCtx): void {
     // 'failed' is a hard 503 (not masked as a slow warm-up, cond 3); 'validating' is warming.
     // The 200-ready body is unchanged (data-root 'ready' falls through to the existing embeddings
     // gate), preserving the shared warm-gate body-contract fixture (t/3114).
-    // t/3236: test-only fault knob — force the DEFINITIVE data-root-FAILED readiness so DevOps can
+    // t/3236 (server half tracked t/3340): test-only fault knob — force the DEFINITIVE data-root-FAILED readiness so DevOps can
     // exercise the deploy warm-gate's FIRE arm (503 'failed' → block traffic-shift → fail+rollback)
     // against a REAL staging revision with real data, no 700M throwaway repo. TL cond 1: forces the
     // definitive 'failed' state (NOT 'validating'), so the warm-gate sees a definitive failure.


### PR DESCRIPTION
## Summary (t/3236 Arm-B, path c — TL-directed)

DevOps hit a feasibility wall crafting a faithful taxonomy-present/dictionary-missing repo (~700M, blob-fork unsupported — p/526#141). TL proposed path (c): **fault-inject** the definitive failed readiness instead. This adds the server knob.

`/readyz` handler (`routes/meta.ts`): when `NODE_ENV !== 'production'` **AND** `READYZ_FORCE_DATA_ROOT_FAILED === '1'`, force the **definitive** data-root `'failed'` state → `503 {status:'failed', reason:'data-root-failed: forced (…test knob, t/3236)'}`. Mirrors the existing `READYZ_FORCE_RESOLVES_FALSE` knob (t/3192).

## TL conditions (#1098) — both met
- **Cond 1** — forces the **definitive `'failed'`** state (NOT `'validating'`), so the warm-gate sees a definitive failure (design cond 3). Verified: the knob-ON test asserts `body.status === 'failed'`, not warming.
- **Cond 2** — gated `NODE_ENV !== 'production'` → can NEVER force a false-negative `/readyz` in prod. Verified: the `NODE_ENV=production` test asserts it's INERT (200 ready).

## Scope (answers DevOps confirm #2)
**RUNTIME-scoped to the `/readyz` response only.** It does NOT trip boot `validateDataRoot` (which runs against real data and passes → `setDataRootReady()`). So **no ENFORCE change is required for boot**; DevOps sets `DATA_ROOT_VALIDATION_ENFORCE=0` purely as a belt. Result: boot succeeds on real data → smoke stays green → `/readyz` forced-503 → warm-gate FIRES → fail+rollback+RED, isolating the warm-gate.

## Tests
`readyz.test.ts` +4 (18/18 green): knob ON+non-prod → definitive 503 failed even when data-root ready AND embeddings resolve; knob ON+`NODE_ENV=production` → INERT/200; value≠'1' ignored; unset → real state. The inline `simulateReadyz` mirror is kept in lockstep with the handler (existing t/3114 coupling). tsc + eslint clean.

**Deploy config for DevOps:** the Arm-B rev must NOT run `NODE_ENV=production` (same as how you exercise `READYZ_FORCE_RESOLVES_FALSE`) or the knob is inert.

**Draft → requesting Main GV** (deploy-gate surface, TL-directed path c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)