### PR TITLE
feat(qbaf): cross-conflict candidate classifier runner (t/3339)

### DIFF
--- a/scripts/run-xconflict-classifier.ps1
+++ b/scripts/run-xconflict-classifier.ps1
@@ -1,0 +1,224 @@
+#Requires -Version 7
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+#
+# Cross-conflict candidate classifier (t/3339 classify-before-merge). Reads CL's candidate pairs
+# (research/comp-linguist/analyses/xconflict-pairing/candidates.json — 1055 rows of {pair_id,
+# stance_text (A), cand_text (B), stance_conflict_id, cand_conflict_id, cosine}), runs each A-vs-B pair
+# through the SAME contradiction classifier as the same-doc/golden runs (invoke-contradiction-classifier.ps1,
+# per-conflict batch + per-pair fallback), and writes predictions {pair_id, predicted, confidence, method}
+# (carrying the conflict ids + cosine for CL's join). CL builds a BLIND precision golden on this output
+# (Wilson LB >= 0.85, TL-GV'd) before any contradict is counted; only confirmed contradict@>=0.90 merges.
+#
+# Pairs are chunked into synthetic "conflicts" of -BatchSize so each classifier batch stays within the
+# usage maxTokens; grouping is arbitrary (each pair is judged independently). A pair is never dropped:
+# a missing/unresolved verdict -> predicted 'unresolved'/'missing' (no merge).
+#
+# PAID: classifier calls the AI backend. Set GEMINI_API_KEY (invoked via `& pwsh`, full env inherited —
+# NOT enrich's key-stripped _safe_env path, t/3336#1994). Bounded to the candidate count.
+#
+#   pwsh -File scripts/run-xconflict-classifier.ps1 -OutPath xconflict-predictions.json
+#
+# Pure transforms (ConvertTo-XcInput / Join-XcPredictions) are dot-source unit-tested with
+# $env:XC_RUNNER_NOEXEC set (no AI, no subprocess).
+[CmdletBinding()]
+param(
+    [string]$CandidatesPath = '',
+    [string]$OutPath = '',
+    [ValidateRange(1, 100)][int]$BatchSize = 15,
+    [ValidateSet('per-conflict', 'per-pair')][string]$Mode = 'per-conflict'
+)
+
+Set-StrictMode -Version Latest
+
+function Get-XcField {
+    param([object]$Obj, [string]$Name, $Default = $null)
+    if ($Obj.PSObject.Properties[$Name]) { return $Obj.$Name }
+    return $Default
+}
+
+function ConvertTo-XcInput {
+    <#
+    .SYNOPSIS
+        Map candidate rows -> the classifier's frozen input, chunked into synthetic conflicts of BatchSize
+        so each per-conflict batch stays within maxTokens. Pure; no AI, no I/O.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param([Parameter(Mandatory)][object[]]$Candidates, [int]$BatchSize = 15)
+
+    $conflicts = [System.Collections.Generic.List[object]]::new()
+    $batch = [System.Collections.Generic.List[object]]::new()
+    $n = 0
+    foreach ($c in $Candidates) {
+        $batch.Add([ordered]@{
+                id = [string](Get-XcField $c 'pair_id')
+                a  = [string](Get-XcField $c 'stance_text')
+                b  = [string](Get-XcField $c 'cand_text')
+            })
+        if ($batch.Count -ge $BatchSize) {
+            $conflicts.Add([ordered]@{ cid = "xc-batch-$n"; pairs = @($batch) })
+            $batch = [System.Collections.Generic.List[object]]::new()
+            $n++
+        }
+    }
+    if ($batch.Count -gt 0) {
+        $conflicts.Add([ordered]@{ cid = "xc-batch-$n"; pairs = @($batch) })
+    }
+    return @{ conflicts = @($conflicts) }
+}
+
+function Join-XcPredictions {
+    <#
+    .SYNOPSIS
+        Join classifier results (keyed by pair id) back onto the candidate rows. A pair with no result
+        -> predicted 'missing' (never dropped). Pure; no AI, no I/O.
+    #>
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory)][object[]]$Candidates,
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Results
+    )
+    $map = @{}
+    foreach ($r in $Results) {
+        $id = [string](Get-XcField $r 'id')
+        if (-not [string]::IsNullOrWhiteSpace($id)) { $map[$id] = $r }
+    }
+    $out = [System.Collections.Generic.List[object]]::new()
+    foreach ($c in $Candidates) {
+        $pid2 = [string](Get-XcField $c 'pair_id')
+        if ($map.ContainsKey($pid2)) {
+            $r = $map[$pid2]
+            $predicted = [string](Get-XcField $r 'label' 'unresolved')
+            $confidence = [double](Get-XcField $r 'confidence' 0.0)
+            $method = [string](Get-XcField $r 'method' 'unknown')
+        }
+        else {
+            $predicted = 'missing'; $confidence = 0.0; $method = 'missing'
+        }
+        $out.Add([ordered]@{
+                pair_id            = $pid2
+                predicted          = $predicted
+                confidence         = $confidence
+                method             = $method
+                stance_conflict_id = [string](Get-XcField $c 'stance_conflict_id')
+                cand_conflict_id   = [string](Get-XcField $c 'cand_conflict_id')
+                cosine             = (Get-XcField $c 'cosine')
+            })
+    }
+    return @($out)
+}
+
+function Invoke-CCClassifier {
+    # Run the classifier as a child pwsh process (full parent env — key inherited; NOT enrich's _safe_env).
+    # Results come back via a FILE (-OutPath), not stdout (warnings would corrupt stdout JSON, t/3302).
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param([Parameter(Mandatory)][string]$InputPath, [string]$Mode = 'per-conflict')
+
+    $classifier = Join-Path $PSScriptRoot 'invoke-contradiction-classifier.ps1'
+    if (-not (Test-Path -LiteralPath $classifier -PathType Leaf)) {
+        throw (New-ActionableError -PassThru -ErrorType 'ClassifierMissing' `
+                -Goal 'Classify cross-conflict candidate pairs' `
+                -Problem "invoke-contradiction-classifier.ps1 not found next to this runner ('$classifier')" `
+                -Location 'run-xconflict-classifier.ps1' `
+                -NextSteps @('Run from a checkout that includes scripts/invoke-contradiction-classifier.ps1'))
+    }
+    $resultsFile = [System.IO.Path]::GetTempFileName()
+    $exit = 0
+    $text = ''
+    try {
+        $null = & pwsh -NoProfile -NonInteractive -File $classifier -InputPath $InputPath -Mode $Mode -OutPath $resultsFile
+        $exit = $LASTEXITCODE
+        if (Test-Path -LiteralPath $resultsFile) { $text = [string](Get-Content -LiteralPath $resultsFile -Raw) }
+    }
+    finally {
+        Remove-Item -LiteralPath $resultsFile -Force -ErrorAction SilentlyContinue
+    }
+    if ($exit -ne 0 -or [string]::IsNullOrWhiteSpace($text)) {
+        throw (New-ActionableError -PassThru -ErrorType 'ClassifierNoOutput' `
+                -Goal 'Classify cross-conflict candidate pairs' `
+                -Problem "the classifier wrote no results (exit $exit) — likely a missing API key or backend error" `
+                -Location 'run-xconflict-classifier.ps1' `
+                -NextSteps @('Set GEMINI_API_KEY (or Register-AIBackend) and retry', 'Check the classifier warnings above'))
+    }
+    $parsed = $null
+    try { $parsed = $text | ConvertFrom-Json } catch { $parsed = $null }
+    if ($null -eq $parsed -or -not $parsed.PSObject.Properties['results']) {
+        $snip = $text.Substring(0, [Math]::Min(200, $text.Length))
+        throw (New-ActionableError -PassThru -ErrorType 'ClassifierBadOutput' `
+                -Goal 'Classify cross-conflict candidate pairs' `
+                -Problem "the classifier output was not the expected { results: [...] } shape. First 200 chars: $snip" `
+                -Location 'run-xconflict-classifier.ps1' `
+                -NextSteps @('Inspect the results file content shown above'))
+    }
+    return @($parsed.results)
+}
+
+# ── main (skipped when dot-sourced for unit tests: $env:XC_RUNNER_NOEXEC) ──
+if (-not $env:XC_RUNNER_NOEXEC) {
+    $ErrorActionPreference = 'Stop'
+    Import-Module (Join-Path $PSScriptRoot 'AITriad' 'AITriad.psd1') -Force -ErrorAction Stop
+
+    if ([string]::IsNullOrWhiteSpace($CandidatesPath)) {
+        $CandidatesPath = Join-Path $PSScriptRoot '..' 'research' 'comp-linguist' 'analyses' 'xconflict-pairing' 'candidates.json'
+    }
+    if (-not (Test-Path -LiteralPath $CandidatesPath -PathType Leaf)) {
+        throw (New-ActionableError -PassThru -ErrorType 'CandidatesMissing' `
+                -Goal 'Classify cross-conflict candidate pairs' `
+                -Problem "candidates file not found: '$CandidatesPath'" `
+                -Location 'run-xconflict-classifier.ps1' `
+                -NextSteps @('Pass -CandidatesPath, or run from a checkout with research/comp-linguist/analyses/xconflict-pairing/candidates.json'))
+    }
+    if ([string]::IsNullOrWhiteSpace($OutPath)) { $OutPath = 'xconflict-predictions.json' }
+    if (-not [System.IO.Path]::IsPathRooted($OutPath)) { $OutPath = Join-Path (Get-Location).Path $OutPath }
+
+    $doc = Get-Content -LiteralPath $CandidatesPath -Raw | ConvertFrom-Json
+    $cands = @(Get-XcField $doc 'candidates' @())
+    if (@($cands).Count -eq 0) {
+        throw (New-ActionableError -PassThru -ErrorType 'CandidatesEmpty' `
+                -Goal 'Classify cross-conflict candidate pairs' `
+                -Problem "no 'candidates' in '$CandidatesPath'" `
+                -Location 'run-xconflict-classifier.ps1' `
+                -NextSteps @('Confirm the file has a top-level candidates[] array'))
+    }
+
+    $ccInput = ConvertTo-XcInput -Candidates $cands -BatchSize $BatchSize
+    Write-Host "Candidates: $(@($cands).Count) pairs -> $(@($ccInput.conflicts).Count) batch(es) of <=$BatchSize; mode=$Mode. Calling classifier (PAID)..." -ForegroundColor Cyan
+
+    $tmpIn = [System.IO.Path]::GetTempFileName()
+    try {
+        $ccInput | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $tmpIn -Encoding utf8
+        $results = Invoke-CCClassifier -InputPath $tmpIn -Mode $Mode
+    }
+    finally {
+        Remove-Item -LiteralPath $tmpIn -Force -ErrorAction SilentlyContinue
+    }
+
+    $preds = Join-XcPredictions -Candidates $cands -Results $results
+    $outDoc = [ordered]@{
+        _meta       = [ordered]@{
+            ticket         = 't/3339'
+            purpose        = 'cross-conflict classify-before-merge predictions (CL builds the blind precision golden)'
+            candidates     = $CandidatesPath
+            classifier     = 'enrichment.contradiction-classify'
+            mode           = $Mode
+            batch_size     = $BatchSize
+            n_predictions  = @($preds).Count
+            note           = 'Only confirmed contradict@>=0.90 merges (<=1/stance), after CL golden precision LB>=0.85.'
+        }
+        predictions = @($preds)
+    }
+    $outDoc | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $OutPath -Encoding utf8
+
+    $n = @($preds).Count
+    $nContra = @($preds | Where-Object { $_.predicted -eq 'contradict' }).Count
+    $nContra90 = @($preds | Where-Object { $_.predicted -eq 'contradict' -and [double]$_.confidence -ge 0.90 }).Count
+    $nMissing = @($preds | Where-Object { $_.method -eq 'missing' }).Count
+    Write-Host "Wrote $n predictions -> $OutPath  (contradict: $nContra; contradict@>=0.90: $nContra90; missing: $nMissing)" -ForegroundColor Green
+    Write-Host "Next: hand $OutPath to CL (Computational Linguist) for the blind precision golden." -ForegroundColor Green
+    if ($nMissing -gt 0) {
+        Write-Warning "$nMissing pair(s) came back 'missing' (classifier didn't resolve them) — a re-run may recover them (t/3336 rate-limit pattern)."
+    }
+}

--- a/tests/RunXconflictClassifier.Tests.ps1
+++ b/tests/RunXconflictClassifier.Tests.ps1
@@ -1,0 +1,84 @@
+# Tag: qbaf (t/3339 — cross-conflict classifier runner pure transforms)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Tests for run-xconflict-classifier.ps1's pure transforms (t/3339).
+.DESCRIPTION
+    ConvertTo-XcInput (candidate rows -> chunked classifier input) and Join-XcPredictions (results ->
+    predictions) are exercised WITHOUT the AI backend or a subprocess: the script is dot-sourced with
+    $env:XC_RUNNER_NOEXEC set, so main() is skipped and only the functions load.
+#>
+
+BeforeAll {
+    $env:XC_RUNNER_NOEXEC = '1'
+    . "$PSScriptRoot/../scripts/run-xconflict-classifier.ps1"
+}
+
+AfterAll {
+    Remove-Item Env:\XC_RUNNER_NOEXEC -ErrorAction SilentlyContinue
+}
+
+Describe 'ConvertTo-XcInput — candidate rows -> chunked classifier input' -Tag 'qbaf' {
+
+    It 'chunks into synthetic conflicts of BatchSize and maps stance/cand -> a/b keyed by pair_id' {
+        $cands = @(
+            [pscustomobject]@{ pair_id = 'xc-0'; stance_text = 'A0'; cand_text = 'B0' }
+            [pscustomobject]@{ pair_id = 'xc-1'; stance_text = 'A1'; cand_text = 'B1' }
+            [pscustomobject]@{ pair_id = 'xc-2'; stance_text = 'A2'; cand_text = 'B2' }
+            [pscustomobject]@{ pair_id = 'xc-3'; stance_text = 'A3'; cand_text = 'B3' }
+            [pscustomobject]@{ pair_id = 'xc-4'; stance_text = 'A4'; cand_text = 'B4' }
+        )
+        $out = ConvertTo-XcInput -Candidates $cands -BatchSize 2
+        @($out.conflicts).Count | Should -Be 3          # 2 + 2 + 1
+        @($out.conflicts[0].pairs).Count | Should -Be 2
+        @($out.conflicts[2].pairs).Count | Should -Be 1  # remainder
+        $out.conflicts[0].pairs[0].id | Should -Be 'xc-0'
+        $out.conflicts[0].pairs[0].a  | Should -Be 'A0'
+        $out.conflicts[0].pairs[0].b  | Should -Be 'B0'
+        # every pair id preserved exactly once across batches
+        $ids = @($out.conflicts | ForEach-Object { $_.pairs } | ForEach-Object { $_.id })
+        ($ids | Sort-Object) -join ',' | Should -Be 'xc-0,xc-1,xc-2,xc-3,xc-4'
+    }
+}
+
+Describe 'Join-XcPredictions — results -> predictions' -Tag 'qbaf' {
+
+    It 'joins by pair_id and carries conflict ids + cosine' {
+        $cands = @(
+            [pscustomobject]@{ pair_id = 'xc-0'; stance_conflict_id = 'sc0'; cand_conflict_id = 'cc0'; cosine = 0.67 }
+        )
+        $results = @([pscustomobject]@{ id = 'xc-0'; label = 'contradict'; confidence = 0.93; method = 'llm-batch' })
+        $preds = @(Join-XcPredictions -Candidates $cands -Results $results)
+        @($preds).Count | Should -Be 1
+        $preds[0].predicted          | Should -Be 'contradict'
+        $preds[0].confidence         | Should -Be 0.93
+        $preds[0].method             | Should -Be 'llm-batch'
+        $preds[0].stance_conflict_id | Should -Be 'sc0'
+        $preds[0].cand_conflict_id   | Should -Be 'cc0'
+        $preds[0].cosine             | Should -Be 0.67
+    }
+
+    It 'never drops a pair with no result — emits missing' {
+        $cands = @(
+            [pscustomobject]@{ pair_id = 'xc-0'; stance_conflict_id = 'sc0'; cand_conflict_id = 'cc0'; cosine = 0.5 }
+            [pscustomobject]@{ pair_id = 'xc-1'; stance_conflict_id = 'sc1'; cand_conflict_id = 'cc1'; cosine = 0.6 }
+        )
+        $results = @([pscustomobject]@{ id = 'xc-0'; label = 'neutral'; confidence = 0.8; method = 'llm-batch' })
+        $preds = @(Join-XcPredictions -Candidates $cands -Results $results)
+        @($preds).Count | Should -Be 2
+        $missing = @($preds | Where-Object { $_.pair_id -eq 'xc-1' })
+        $missing[0].predicted | Should -Be 'missing'
+        $missing[0].method    | Should -Be 'missing'
+    }
+
+    It 'tolerates an empty results set (all missing, none dropped)' {
+        $cands = @([pscustomobject]@{ pair_id = 'xc-0'; stance_conflict_id = 'sc0'; cand_conflict_id = 'cc0'; cosine = 0.5 })
+        $preds = @(Join-XcPredictions -Candidates $cands -Results @())
+        @($preds).Count | Should -Be 1
+        $preds[0].method | Should -Be 'missing'
+    }
+}


### PR DESCRIPTION
Classifies CL's 1055 cross-conflict candidate pairs (candidates.json, #1997) through the same contradiction classifier → emits {pair_id, predicted, confidence, method} (+ conflict ids/cosine) for CL's blind precision golden (Wilson LB≥0.85, TL-GV'd). Only confirmed contradict@≥0.90 merges.

- Chunks candidates into synthetic conflicts of -BatchSize (default 15) to respect maxTokens.
- Never drops a pair (missing verdict → 'missing').
- Same file-channel + `& pwsh` full-env classifier path as the golden runner (key inherited, not enrich's stripped _safe_env). PAID; owner runs with GEMINI_API_KEY set.

Pure transforms unit-tested (4 Pester green). New standalone runner — additive/inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)