### PR TITLE
revert(t/3309): remove Arm-B fire-arm scaffolding (READYZ_FORCE_DATA_ROOT_FAILED + warm-gate 480→300)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -168,11 +168,10 @@ jobs:
           # t/3309 data-root readiness); the warm-gate mechanism is unchanged. Brings staging to prod
           # parity on the traffic-shift gate AND lets t/3309 Arm B (misprovisioned data-root → /readyz
           # 503) run end-to-end on staging without touching prod.
-          # TimeoutSec 480 = TEMPORARY t/3309 test window (ServerAPI p/526#122): 480 > ~360s worst-case
-          # with-retry so a transient GH blip can't masquerade as an Arm-A fail. REVERT to 300 (prod
-          # parity) after the both-arms GV — tracked.
+          # TimeoutSec 300 = prod parity (deploy-azure.yml). (Restored after the t/3309 both-arms GV;
+          # the Arm-B fire-arm used a temporary 480 window — t/3309.)
           $BaseUrl = "${{ steps.smoke.outputs.base_url }}"
-          & ./operations/devops/Invoke-ReadyzWarmGateCheck.ps1 -BaseUrl $BaseUrl -TimeoutSec 480 -PollIntervalSec 10
+          & ./operations/devops/Invoke-ReadyzWarmGateCheck.ps1 -BaseUrl $BaseUrl -TimeoutSec 300 -PollIntervalSec 10
 
       - name: Fail + roll back if not warm (t/3309)
         # Staging's rollback is failure()-gated (vs prod's warm-output-gated), so translate the

--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -596,13 +596,6 @@ var stagingEnvOverrides = [
   // NOTE: DATA_ROOT_VALIDATION_ENFORCE=1 is NOT a staging-only override — it now lives in baseEnv
   // so BOTH prod and staging enforce, promoted after the staging real-env validation (t/3305; rev
   // staging-4826363 booted enforce-green). Kept out of the overrides to avoid a duplicate env key.
-  // ⚠️ TEMPORARY — t/3309 Arm-B fire-arm ONLY. Forces the /readyz data-root-readiness handler to
-  // return a DEFINITIVE 503 {status:failed, reason:data-root-failed} (ServerAPI #1998, runtime-only:
-  // boot validateDataRoot still reads real data → passes, no exit(1)). Fail-closed by isStagingIdentity
-  // (prod app name can't match /staging/ → inert in prod). Exercises the /readyz warm-gate end-to-end:
-  // smoke green on real data, warm-gate polls forced-503 → warm=false → fail+rollback+RED. REVERT
-  // immediately after the Arm-B run captures the evidence (t/3309 GV). Do NOT leave this on staging.
-  { name: 'READYZ_FORCE_DATA_ROOT_FAILED', value: '1' }
 ]
 // stagingBaseEnv = baseEnv with the isolation overrides applied.
 // filter() removes the baseEnv entries that stagingEnvOverrides supersedes.


### PR DESCRIPTION
Arm-B evidence captured in deploy-staging run 33992048601 (warm-gate 48× /readyz 503 → warm=false → Fail → rollback → RED). This reverts the two temporary test knobs to prod-parity baseline:
- `main.bicep`: drop `READYZ_FORCE_DATA_ROOT_FAILED=1` from stagingEnvOverrides
- `deploy-staging.yml`: warm-gate `TimeoutSec 480 → 300` (prod parity)

Merge + redeploy = **Arm-B part 4**: restored staging rev serves /readyz 200 → warm=true → promote → GREEN. Hands the 4-part package to ServerAPI/TL for the joint GV.