### PR TITLE
feat(devops): warm-gate fails fast on definitive /readyz status:failed (t/3343)

### DIFF
--- a/operations/devops/Invoke-ReadyzWarmGateCheck.ps1
+++ b/operations/devops/Invoke-ReadyzWarmGateCheck.ps1
@@ -79,6 +79,16 @@ try {
             break
         }
 
+        if ($action -eq 'fail') {
+            # DEFINITIVE failure — /readyz reports {status:'failed'} (a hard, non-transient failure the
+            # server has already decided, e.g. data-root-failed). Stop NOW rather than polling the whole
+            # timeout treating it as warm-up: fail-safe is identical (warm=false → no traffic shift →
+            # rollback), but we fail fast and label it a hard failure, not "warming". (t/3343)
+            Write-Host "::error::/readyz reports a DEFINITIVE failure after $poll poll(s) (status=$status, body=$body) — warm=false: NOT shifting traffic (root constraint #1). Failing fast (not warming); the deploy rolls back to the previous revision. (t/3343)"
+            $warm = $false
+            break
+        }
+
         # 'wait' — 503 warming, 404 absent, a non-'ready'/SPA-HTML 200, or a transient/connection error.
         if ([DateTime]::UtcNow -ge $deadline) {
             Write-Host "::error::embeddings pre-warm not ready (/readyz last status=$status, body=$body) within ${TimeoutSec}s — warm=false: NOT shifting traffic (root constraint #1). The deploy rolls back to the previous revision. (t/3148)"

--- a/operations/devops/ReadyzWarmGatePredicate.ps1
+++ b/operations/devops/ReadyzWarmGatePredicate.ps1
@@ -14,9 +14,16 @@
     Contract (taxonomy-editor/src/server/routes/meta.ts, t/3112):
       200  {status:'ready',   nodeCount>0}  -> embeddings.json cache warm.
       503  {status:'warming', ...}          -> cache still loading.
+      503  {status:'failed',  reason:...}   -> DEFINITIVE failure (e.g. data-root-failed, t/3309).
       404  (route ABSENT)                   -> image predates /readyz (old revision).
 
     Gate semantics (blocking flip, TL-decided mechanism B, p/542#108):
+      - 'fail'     iff  the body parses as JSON with .status == 'failed' (ANY status code). A
+                        DEFINITIVE, non-transient failure the server has already decided (t/3343):
+                        the caller stops immediately with warm=false instead of polling the whole
+                        TimeoutSec treating it as warm-up. Checked FIRST so it wins over the non-200
+                        'wait' short-circuit. Fail-SAFE is identical to a timeout (no traffic shift);
+                        this only fails FASTER and labels the outcome a hard failure, not "warming".
       - 'proceed'  iff  StatusCode == 200  AND  the body parses as JSON with
                         .status == 'ready' AND nodeCount > 0 (a real warm signal).
       - 'wait'     for EVERYTHING else, and the loop blocks on sustained 'wait':
@@ -41,6 +48,17 @@ function Get-ReadyzGateAction {
         [Parameter(Mandatory)] [int] $StatusCode,
         [Parameter()] [AllowNull()] [AllowEmptyString()] [string] $Body
     )
+    # DEFINITIVE failure first: the server signals a hard, non-transient failure (e.g.
+    # data-root-failed) via {status:'failed'} on ANY status code (503 today). Detect it before the
+    # non-200 'wait' short-circuit so the caller can fail FAST instead of polling the whole
+    # TimeoutSec as warm-up (t/3343). StrictMode-safe: the parse + .status access stay inside try,
+    # so a malformed/SPA/scalar body or a body with no .status yields $null → never a false 'fail'.
+    $bodyStatus = $null
+    if (-not [string]::IsNullOrWhiteSpace($Body)) {
+        try { $bodyStatus = ($Body | ConvertFrom-Json -ErrorAction Stop).status } catch { $bodyStatus = $null }
+    }
+    if ($bodyStatus -eq 'failed') { return 'fail' }
+
     if ($StatusCode -ne 200) { return 'wait' }
     try {
         $parsed = $Body | ConvertFrom-Json -ErrorAction Stop

--- a/tests/ReadyzWarmGate.Tests.ps1
+++ b/tests/ReadyzWarmGate.Tests.ps1
@@ -69,6 +69,20 @@ Describe 'Get-ReadyzGateAction (pure predicate: status + body)' -Tag 'unit' {
         Get-ReadyzGateAction -StatusCode 200 -Body $script:SpaBody   | Should -Not -Be 'proceed'
         Get-ReadyzGateAction -StatusCode 404 -Body $script:ReadyBody | Should -Not -Be 'proceed'
     }
+    It 'FAIL: 503 + {status:failed} (definitive data-root-failed) → fail (not wait; server has decided)' {
+        Get-ReadyzGateAction -StatusCode 503 -Body '{"status":"failed","reason":"data-root-failed: forced"}' | Should -Be 'fail'
+    }
+    It 'FAIL: {status:failed} wins for ANY status code (200 too) — definitive check precedes the 200/non-200 split' {
+        Get-ReadyzGateAction -StatusCode 200 -Body '{"status":"failed","reason":"x"}' | Should -Be 'fail'
+        Get-ReadyzGateAction -StatusCode 500 -Body '{"status":"failed"}'               | Should -Be 'fail'
+    }
+    It 'NOT fail: warming/ready/absent/SPA never map to fail (only an explicit status:failed does)' {
+        Get-ReadyzGateAction -StatusCode 503 -Body '{"status":"warming"}' | Should -Be 'wait'
+        Get-ReadyzGateAction -StatusCode 200 -Body $script:ReadyBody      | Should -Be 'proceed'
+        Get-ReadyzGateAction -StatusCode 404 -Body 'Not Found'            | Should -Be 'wait'
+        Get-ReadyzGateAction -StatusCode 200 -Body $script:SpaBody        | Should -Be 'wait'
+        Get-ReadyzGateAction -StatusCode 503 -Body ''                     | Should -Be 'wait'
+    }
 }
 
 Describe 'Invoke-ReadyzWarmGateCheck.ps1 (warm=true/false output, mechanism B)' -Tag 'unit' {
@@ -140,5 +154,25 @@ Describe 'Invoke-ReadyzWarmGateCheck.ps1 (warm=true/false output, mechanism B)' 
         $out = & $script:ScriptPath -BaseUrl 'http://rev.local' -TimeoutSec 0 -PollIntervalSec 0 *>&1 | Out-String
         $LASTEXITCODE | Should -Be 0
         Get-EmittedWarm | Should -Be 'false'
+    }
+
+    It 'FAIL-FAST: 503 {status:failed} on poll #1 → warm=false after ONE poll (not the full timeout), distinct hard-failure error, exit 0 (t/3343)' {
+        $global:readyzCalls = 0
+        Mock Invoke-WebRequest {
+            $global:readyzCalls++
+            [pscustomobject]@{ StatusCode = 503; Content = '{"status":"failed","reason":"data-root-failed: forced"}' }
+        }.GetNewClosure()
+        try {
+            # Generous TimeoutSec: a correct fail-fast breaks on poll #1 regardless; a regression that
+            # treated status:failed as 'warming' would instead spin to the (real-time) deadline.
+            $out = & $script:ScriptPath -BaseUrl 'http://rev.local' -TimeoutSec 5 -PollIntervalSec 0 *>&1 | Out-String
+            $LASTEXITCODE       | Should -Be 0
+            Get-EmittedWarm     | Should -Be 'false'
+            $global:readyzCalls | Should -Be 1     # broke immediately — did NOT burn the timeout
+            $out | Should -Match 'DEFINITIVE failure'
+            $out | Should -Not -Match 'pre-warm not ready'   # not the generic timeout message
+        } finally {
+            Remove-Variable -Name readyzCalls -Scope Global -ErrorAction SilentlyContinue
+        }
     }
 }


### PR DESCRIPTION
Closes t/3343. The deploy warm-gate labeled every non-ready /readyz 503 as "(warming)" and polled the full `TimeoutSec` before failing — even a definitive `{status:'failed'}` (data-root-failed). Seen live in the t/3309 Arm-B run 33992048601 (48× 503 all logged as warming, then timeout-fail).

**Change (DevOps-scope only; server already emits the distinction):**
- `ReadyzWarmGatePredicate.ps1`: new `'fail'` action — body `.status=='failed'` (any code) → `'fail'`, checked before the non-200 'wait' short-circuit. StrictMode-safe.
- `Invoke-ReadyzWarmGateCheck.ps1`: break immediately on `'fail'` → `warm=false` + distinct DEFINITIVE-failure `::error::` (not "warming", not the timeout message).
- `tests/ReadyzWarmGate.Tests.ps1`: +3 predicate + 1 loop case. **20/20 Pester green.**

**Fail-SAFE unchanged** (warm=false → no traffic shift → rollback); only faster + accurate labeling. Self-cert /trivial-change; design pre-endorsed by TL (p/331#1105) + ServerAPI (p/526#166).

**DRAFT hold:** un-drafting only after t/3309 part-4b's GREEN run is posted, so TL's GV evidence uses the reverted baseline warm-gate unconfounded.