### PR TITLE
docs(t3339): RETIRE the >=2x/>=10% Fork-B bar; honest verified-real density

### DIFF
--- a/research/comp-linguist/analyses/xconflict-pairing/RESULTS.md
+++ b/research/comp-linguist/analyses/xconflict-pairing/RESULTS.md
@@ -1,6 +1,22 @@
 # Cross-conflict pairing — results (t/3339, Fork-B union lever)
 
-Status as of 2026-09-05: **union measured, clears the bar; awaiting PI dual-verify of the 16 before the write.**
+Status as of 2026-09-05: **HOLD — Fork-B benefit arm does NOT clear on the verified-real set. The ≥2×/≥10% bar is RETIRED (see below). No corpus write landed.**
+
+## ⚠️ CORRECTION + BAR RETIRED (t/3337 census, TL ruling t/3339#22)
+
+The §3 "union clears (×2.82 / 11.6%)" figure below **was invalidated** by the t/3337 precision census: the same-doc contribution to that union was built on the numeric detector's contradict-predictions, which are **0/54 precision** in production (it fires on DIFFERENT-subject numbers in same-doc pairs — "17% fewer postings" vs "24% fewer skills"; "63%" vs "65%" rounding). The same-doc lever's *deployed* precision is 4/62 = 6.5% (even LLM-only is 4/8 = 0.50).
+
+**Honest density — verified-real set only** (baseline + 4 LLM-verified same-doc + 12 PI-verified cross-conflict, ZERO numeric-detector edges):
+
+| metric | baseline | verified-real union |
+|---|---|---|
+| conflicts-with-attacks | 17 | **31 (×1.82)** |
+| adversarial nodes | 35 (3.5%) | **65 / 1034 = 6.3%** |
+| provenance | — | **100% observed, human-verified** |
+
+**The ≥2× / ≥10% bar is RETIRED** — not re-set to whatever the honest union scores (that would be a no-lose bucket the metric-provenance register forbids). It is retired because the corpus is **intrinsically low-adversarial**: even every real, human-verified contradiction reaches only ~6% of arg nodes / ×1.8 conflicts-with-attacks. This is a genuine descriptive finding (3rd low-adversarial signal), not a failure to hit a target. The 16 real edges remain valid + 100% observed; PI decides whether to write them for their own sake (they move no metric).
+
+Numeric detector fix (same-subject gate, masked-cosine ≥0.93) spec'd at t/3337#5 → PS implements → CL re-cert → TL GV.
 
 ## Pipeline recap
 Candidates (`candidates.json`, 1055 pairs) → PowerShell enrich classifier (`xconflict-predictions.json`)
@@ -19,7 +35,7 @@ Blind census (all 28 classifier-contradicts + 20 anchors, CL blind-labeled):
 ## 2. Census-verification (TL-permitted, t/3339#10)
 Because there were only 28 to check, all were hand-labeled → **16 CL-verified-true contradicts across 12 distinct stance-conflicts**. Merging only these = zero false attacks by construction (stronger than a passing sampled LB). TL conditions: (1) PI dual-verifies the 16, merge only those; (2) measure the union on the ACTUAL verified set; (3) a measured miss → recalibrate the bar, don't extrapolate.
 
-## 3. Union measure (`measure_union.py`) — PREVIEW on the full 16
+## 3. Union measure (`measure_union.py`) — PREVIEW on the full 16 (⚠️ INVALIDATED — see CORRECTION above; the same-doc row rests on 0/54-precision numeric edges)
 Topology: each verified stance-conflict is single-instance/no-qbaf; a merge creates a NEW 2-node conflict (+1 conflict-with-attack, +2 adversarial nodes, +2 denominator). Same-doc adds within-conflict edges (no new nodes). Adversarial = has an incoming attack (symmetric contradiction → both endpoints).
 
 | metric | baseline | +same-doc | +cross-conflict | bar |


### PR DESCRIPTION
Per TL ruling t/3339#22. The t/3337 precision census invalidated the 'union clears' preview (same-doc numeric edges = 0/54 precision). Honest verified-real density = x1.82 / 6.3%, 100% observed. Bar RETIRED descriptively (corpus is intrinsically low-adversarial). Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)