### PR TITLE
chore(t/3309): retire DATA_ROOT_VALIDATION_ENFORCE — /readyz warm-gate supersedes boot hard-fail (step-3, joint-gv)

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -588,7 +588,7 @@ jobs:
               EMBEDDING_WORKER_OFFLOAD           = '1'  # t/3165 durable close — gate verifies the offload flag is deployed
               GROUNDING_RECONCILE_INLINE         = '1'  # t/3163 G8a — gate verifies the staged inline-reconcile flag is deployed
               GROUNDING_SWEEP_ENABLED            = '1'  # t/3163 G8b — gate verifies the staged sweep-enable flag is deployed
-              DATA_ROOT_VALIDATION_ENFORCE       = '1'  # t/3305 — gate verifies data-root hard-fail is deployed (staging-validated real-env)
+              # DATA_ROOT_VALIDATION_ENFORCE retired in t/3309 step-3 — /readyz warm-gate replaces the boot hard-fail (co-landed with the server.ts exit(1) removal).
             } `
             -CheckFirewall `
             -StorageAccountName '${{ steps.deploy.outputs.storageAccountName }}' `

--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -553,13 +553,11 @@ var baseEnv = [
   // ops, so it must run on the undici-timeout/degrade-and-proceed code, not the untimed-fetch code.
   // baseEnv (never CLI --set-env-vars) + MUST stay in sync with deploy-azure.yml ExpectedEnvVars.
   { name: 'GROUNDING_SWEEP_ENABLED', value: '1' }
-  // t/3305: data-root boot validation is HARD-FAIL in prod (staging inherits this too). A
-  // misprovisioned data root crash-loops VISIBLY instead of serving empty panels (the t/3296
-  // fail-loud, with the t/3308 warn-alert as the warn-only backstop for any un-flagged env).
-  // Promoted to prod after the staging real-env gate (t/2683): staging rev staging-4826363 booted
-  // enforce-green against the live github-api ref:'main' corpus (0 validation-failures). baseEnv
-  // (never CLI --set-env-vars) + MUST stay in sync with deploy-azure.yml ExpectedEnvVars.
-  { name: 'DATA_ROOT_VALIDATION_ENFORCE', value: '1' }
+  // t/3309 step-3: DATA_ROOT_VALIDATION_ENFORCE (t/3305 boot hard-fail) RETIRED. The boot-time
+  // exit(1) in server.ts is superseded by the /readyz warm-gate: a misprovisioned data root now
+  // makes /readyz report failed → the deploy warm-gate blocks the traffic-shift and rolls back
+  // (Arm-A/Arm-B proven on staging, t/3309). Co-landed with the server.ts exit(1) removal (joint-gv).
+  // The t/3308 warn-alert remains as the warn-only observability backstop for any un-gated path.
 ]
 var envWithToken = githubTokenProvided
   ? concat(baseEnv, [ { name: 'GITHUB_TOKEN', secretRef: githubTokenSecretName } ])
@@ -593,9 +591,8 @@ var stagingEnvOverrides = [
   { name: 'AI_TRIAD_STATE_ROOT', value: '/mnt/staging-state' }
   // github-api writes go to the staging branch, not main (t/2650 class-B isolation)
   { name: 'GITHUB_BRANCH',       value: 'staging' }
-  // NOTE: DATA_ROOT_VALIDATION_ENFORCE=1 is NOT a staging-only override — it now lives in baseEnv
-  // so BOTH prod and staging enforce, promoted after the staging real-env validation (t/3305; rev
-  // staging-4826363 booted enforce-green). Kept out of the overrides to avoid a duplicate env key.
+  // NOTE: DATA_ROOT_VALIDATION_ENFORCE was retired in t/3309 step-3 (see baseEnv above) — the
+  // /readyz warm-gate replaces the boot hard-fail. Nothing to override here.
 ]
 // stagingBaseEnv = baseEnv with the isolation overrides applied.
 // filter() removes the baseEnv entries that stagingEnvOverrides supersedes.


### PR DESCRIPTION
**t/3309 step-3 — DevOps half of the joint-gv co-land** (pairs with ServerAPI #2007, server.ts exit(1) removal).

Retires the boot-time data-root hard-fail (`DATA_ROOT_VALIDATION_ENFORCE`, t/3305) now that the /readyz warm-gate supersedes it — a misprovisioned data root makes /readyz report `failed` → the deploy warm-gate blocks the traffic-shift + rolls back (Arm-A/Arm-B proven on staging, t/3309).

- `main.bicep`: drop `DATA_ROOT_VALIDATION_ENFORCE` from `baseEnv` (+ stagingEnvOverrides NOTE). t/3308 warn-alert stays as the warn-only backstop.
- `deploy-azure.yml`: drop it from `ExpectedEnvVars` (kept in sync per t/2631; **BicepEnvDrift 3/3 green** locally).

**DRAFT + `joint-gv` HOLD:** land ONLY after ServerAPI #2007 is TL-blessed, then align heads + manual `--match-head-commit` BOTH (no `--auto` — the auto-merge-jointgv-guard blocks it). One controlled deploy → returns to TL for the closing t/3309 GV (warm=true on a clean promote). Live standing-state cleanup of the now-inert var handled at deploy time (t/3345 footgun).