### PR TITLE
fix(qbaf): same-subject hard-gate on the numeric detector (t/3337)

### DIFF
--- a/scripts/enrich_conflicts_qbaf.py
+++ b/scripts/enrich_conflicts_qbaf.py
@@ -245,27 +245,58 @@ def _cc_bare_numbers(text):
     return out
 
 
-def _detect_numeric_temporal_conflict(text_a, text_b):
-    """True iff A and B share a subject AND cite directly incompatible quantities of the same kind.
+_CC_MAG_RE = re.compile(r"\b(billion|million|trillion|thousand|fold)\b", re.IGNORECASE)
+_CC_CUR_RE = re.compile(r"[$€£]")
 
-    Conservative (high precision): requires >=3 shared content words, and a same-kind numeric set that
-    is non-empty on BOTH sides and disjoint (percentages, years, or bare numbers). Bare numbers demand
-    a stronger subject overlap (>=4) since they are the most ambiguous. Returns False on any doubt.
+
+def _mask_numbers(text):
+    """Replace numeric values (%, years, currency, magnitudes, bare numbers) with a NUM placeholder so an
+    embedding of the result captures the METRIC/subject, not the values (t/3337#5 same-subject gate)."""
+    t = text or ""
+    t = _CC_PCT_RE.sub(" NUM ", t)                       # percentages / 'percent' / pp
+    t = _CC_YEAR_RE.sub(" NUM ", t)                      # years
+    t = re.sub(r"(?<![\w.])\d+(?:\.\d+)?", " NUM ", t)   # bare numbers
+    t = _CC_CUR_RE.sub(" NUM ", t)                       # currency symbols
+    t = _CC_MAG_RE.sub(" NUM ", t)                       # magnitude words
+    return re.sub(r"\s+", " ", t).strip()
+
+
+def _detect_numeric_temporal_conflict(text_a, text_b, embedder=None, subject_threshold=0.93):
+    """True iff A and B describe the SAME quantity AND cite directly incompatible values of the same kind.
+
+    Two-stage (t/3337#5, calibrated on the same-doc census — the old ≥3-shared-word subject proxy was
+    0/54 precision, firing on different-subject pairs like "17% postings" vs "24% skills"):
+      1. candidate: >=3 shared content words + a same-kind numeric set (percentages / years / bare;
+         bare needs >=4 shared) non-empty on BOTH sides and disjoint. Same unit-type is enforced by the
+         per-kind branches (a percent can't pair with a bare number).
+      2. same-subject HARD-GATE: mask the numbers, embed both (MiniLM), and fire ONLY if masked-cosine
+         >= subject_threshold (0.93) — i.e. the disjoint numbers describe the same metric, not merely
+         co-occur. embedder is injectable for tests (default = local MiniLM).
+
+    Known v1 residual (accepted, CL t/3337#5): same-metric-DIFFERENT-SCOPE ("top 10%" vs "top 20%") and
+    rounding (63% vs 65%) pass the subject gate — masked-cosine can't separate them; the LLM arbitrates.
     """
     shared = _cc_content_words(text_a) & _cc_content_words(text_b)
     if len(shared) < 3:
         return False
+    candidate = False
     pa, pb = _cc_percents(text_a), _cc_percents(text_b)
     if pa and pb and pa.isdisjoint(pb):
-        return True
-    ya, yb = _cc_years(text_a), _cc_years(text_b)
-    if ya and yb and ya.isdisjoint(yb):
-        return True
-    if len(shared) >= 4:
+        candidate = True
+    if not candidate:
+        ya, yb = _cc_years(text_a), _cc_years(text_b)
+        if ya and yb and ya.isdisjoint(yb):
+            candidate = True
+    if not candidate and len(shared) >= 4:
         na, nb = _cc_bare_numbers(text_a), _cc_bare_numbers(text_b)
         if na and nb and na.isdisjoint(nb):
-            return True
-    return False
+            candidate = True
+    if not candidate:
+        return False
+    # same-subject hard-gate: the numbers must be about the SAME quantity (not just word-overlapping).
+    embedder = embedder or _default_embedder
+    va, vb = embedder([_mask_numbers(text_a), _mask_numbers(text_b)])
+    return _cosine(va, vb) >= subject_threshold
 
 
 def _qbaf_testedness(qbaf, instances):
@@ -695,7 +726,7 @@ def detect_semantic_edges(to_process, min_confidence=0.0, mode="per-conflict", c
         ci_to_cid[ci] = cid
         conflict_pairs = []
         for c in cands:
-            if _detect_numeric_temporal_conflict(c["a"], c["b"]):
+            if _detect_numeric_temporal_conflict(c["a"], c["b"], embedder=embedder):
                 edges_by_ci.setdefault(ci, []).extend(
                     _mk_attack_edges(c["i"], c["j"], "numeric", 1.0, tau=min_confidence))
                 if predictions_sink is not None:

--- a/scripts/test_enrich_conflicts_qbaf.py
+++ b/scripts/test_enrich_conflicts_qbaf.py
@@ -160,10 +160,19 @@ def test_testedness_adversarial_when_attack_present():
 # _detect_numeric_temporal_conflict — deterministic complement (t/3302 fork-B, TL's mandatory
 # high-precision detector). Conservative: subject overlap + same-kind disjoint quantities.
 
+def _bow_embedder(texts):
+    # Deterministic bag-of-words vectors (test-only proxy for MiniLM): masked-identical text -> cosine
+    # 1.0; different-subject masked text -> < 0.93. Exercises the same-subject gate without a model.
+    # The detector masks BEFORE calling the embedder, so these receive already-masked strings.
+    toks = [set(str(t).lower().split()) for t in texts]
+    vocab = sorted(set().union(*toks)) if toks else []
+    return [[1.0 if v in tk else 0.0 for v in vocab] for tk in toks]
+
+
 def test_numeric_conflicting_percentages_same_subject():
     assert eq._detect_numeric_temporal_conflict(
         "Compute among safety labs grew 30 percent last year",
-        "Compute among safety labs grew 10 percent last year") is True
+        "Compute among safety labs grew 10 percent last year", embedder=_bow_embedder) is True
 
 
 def test_numeric_same_percentage_no_conflict():
@@ -181,20 +190,52 @@ def test_numeric_different_subject_no_conflict():
 def test_temporal_conflicting_years_same_subject():
     assert eq._detect_numeric_temporal_conflict(
         "The superintelligence ban takes effect by 2027 under this act",
-        "The superintelligence ban takes effect by 2030 under this act") is True
+        "The superintelligence ban takes effect by 2030 under this act", embedder=_bow_embedder) is True
 
 
 def test_bare_numbers_conflict_requires_strong_overlap():
     # 4+ shared content words + disjoint bare numbers -> conflict.
     assert eq._detect_numeric_temporal_conflict(
         "The frontier training run used 3 data centers in the cluster",
-        "The frontier training run used 7 data centers in the cluster") is True
+        "The frontier training run used 7 data centers in the cluster", embedder=_bow_embedder) is True
 
 
 def test_bare_numbers_weak_overlap_no_conflict():
     # Disjoint numbers but too few shared words -> no fire (subject gate not met).
     assert eq._detect_numeric_temporal_conflict(
         "labs used 3 chips", "labs used 7 servers") is False
+
+
+# same-subject masked-cosine hard-gate (t/3337#5) — the fix for the 0/54 same-doc precision failure
+
+def test_mask_numbers_replaces_values_keeps_metric():
+    m = eq._mask_numbers("17% of firms cut 5,000 jobs by 2024 worth $3 billion")
+    assert "17" not in m and "5,000" not in m and "2024" not in m and "$" not in m and "billion" not in m
+    assert "firms" in m and "jobs" in m and "worth" in m   # metric/subject words survive
+
+def test_same_subject_gate_blocks_different_subject_that_old_detector_fired():
+    # The regression the census exposed: disjoint % + >=3 shared words but DIFFERENT metric (postings vs
+    # skills). Old detector fired (0/54 precision); the masked-cosine gate must SKIP it.
+    a = "job postings dropped 17 percent this year across the market"
+    b = "required skills dropped 24 percent this year across the market"
+    assert eq._detect_numeric_temporal_conflict(a, b, embedder=_bow_embedder) is False
+
+def test_same_subject_gate_still_fires_same_metric():
+    # Same metric, different value -> masked-identical -> cosine 1.0 -> fires (recall preserved).
+    a = "unemployment rose 17 percent this year across the market"
+    b = "unemployment rose 24 percent this year across the market"
+    assert eq._detect_numeric_temporal_conflict(a, b, embedder=_bow_embedder) is True
+
+def test_same_subject_gate_no_candidate_skips_embed():
+    # Same numbers (not disjoint) -> no candidate -> returns False WITHOUT calling the embedder.
+    called = {"n": 0}
+    def spy(texts):
+        called["n"] += 1
+        return _bow_embedder(texts)
+    assert eq._detect_numeric_temporal_conflict(
+        "labs grew compute 30 percent last year", "labs grew compute 30 percent last year",
+        embedder=spy) is False
+    assert called["n"] == 0   # no embed when there's no disjoint-number candidate (cheap fast-path)
 
 
 # detect_semantic_edges + enrich_conflict extra_edges — fork-B wiring (t/3302, AI mocked)
@@ -217,7 +258,8 @@ def test_detect_semantic_edges_numeric_and_llm():
         ids = {p["id"] for c in batch for p in c["pairs"]}
         assert ids == {"1:0:1"}, f"numeric pair must not reach the LLM; got {ids}"
         return {"1:0:1": {"label": "contradict", "confidence": 0.9}}
-    by_ci = eq.detect_semantic_edges(to_process, min_confidence=0.5, mode="per-conflict", cc_runner=runner)
+    by_ci = eq.detect_semantic_edges(to_process, min_confidence=0.5, mode="per-conflict", cc_runner=runner,
+                                     embedder=_bow_embedder)
     # Symmetric contradictions: TWO attack edges each (i->j and j->i), t/3336#4.
     assert len(by_ci[0]) == 2 and all(e["detector"] == "numeric" and e["type"] == "attacks" for e in by_ci[0])
     assert {(e["source"], e["target"]) for e in by_ci[0]} == {("inst-0", "inst-1"), ("inst-1", "inst-0")}
@@ -269,7 +311,8 @@ def test_semantic_edge_provenance_classifier_and_tau():
             _si("neutral", "d2", "dogs are loud household pets")]}),
     ]
     runner = lambda batch, mode, temp: {"1:0:1": {"label": "contradict", "confidence": 0.9}}
-    by_ci = eq.detect_semantic_edges(to_process, min_confidence=0.9, mode="per-conflict", cc_runner=runner)
+    by_ci = eq.detect_semantic_edges(to_process, min_confidence=0.9, mode="per-conflict", cc_runner=runner,
+                                     embedder=_bow_embedder)
     # LLM edge carries classifier id + τ (TL GV cond 1)
     llm_edge = by_ci[1][0]
     assert llm_edge["classifier"] == eq._CC_USAGE_ID
@@ -293,7 +336,7 @@ def test_predictions_sink_captures_numeric_and_llm():
     runner = lambda batch, mode, temp: {"1:0:1": {"label": "contradict", "confidence": 0.9, "method": "llm-batch"}}
     sink = []
     eq.detect_semantic_edges(to_process, min_confidence=0.9, mode="per-conflict",
-                             cc_runner=runner, predictions_sink=sink)
+                             cc_runner=runner, predictions_sink=sink, embedder=_bow_embedder)
     assert len(sink) == 2  # one numeric candidate + one llm candidate, none dropped
     by_conf = {p["conflict_id"]: p for p in sink}
     num = by_conf["c0"]


### PR DESCRIPTION
Standalone correctness fix (CL spec t/3337#5): the numeric detector was **0/54 precision** on the same-doc census — the ≥3-shared-word subject proxy fired on different-subject pairs ('17% postings' vs '24% skills'). A 0%-precision detector would corrupt any corpus write, so this is worth landing on its own; the same-doc *lever* revival stays separately gated on TL's recalibrate.

**Fix (before firing):** number-mask both assertions → **masked-cosine (MiniLM) ≥ 0.93** + same unit-type. Candidate check runs first, so embed is skipped when there's no disjoint-number candidate.

**Calibration:** fires 6/6 constructed same-subject, blocks 52/54 production FPs (CL). Real-MiniLM check: same-subject cos 1.00 (fire); automation postings-vs-skills 0.71 (skip); latency-vs-cost 0.76 (skip).

**Accepted v1 residual (CL):** same-metric-different-scope + 63/65 rounding pass the subject gate (masked-cosine can't separate; LLM arbitrates) — value-floor add-on deferred (not v1).

Tests +6 → **35 pytest green**. Embedder injectable for determinism.

Flow: CL re-certifies on the same-doc census → TL GV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)