### PR TITLE
feat(devops): Phase-1 orphan detection in staging env sync (t/3345)

### DIFF
--- a/operations/devops/Get-BicepBaseEnv.ps1
+++ b/operations/devops/Get-BicepBaseEnv.ps1
@@ -39,7 +39,8 @@
 [CmdletBinding()]
 param(
     [string]$BicepPath,
-    [switch]$ForStaging
+    [switch]$ForStaging,
+    [switch]$NamesOnly
 )
 
 Set-StrictMode -Version Latest
@@ -69,6 +70,32 @@ $block = $Matches[1]
 $literalPattern = @"
 \{\s*name:\s*'([^']+)',\s*value:\s*'([^'\$\{\}]*)'\s*\}
 "@.Trim()
+
+if ($NamesOnly) {
+    # Return all key names from baseEnv (and stagingEnvOverrides if ForStaging),
+    # regardless of value type (literal, interpolated, param-ref). Used by
+    # Sync-StagingEnv.ps1 to scope its orphan-removal reconcile safely (t/3345).
+    $namePattern = "\{\s*name:\s*'([^']+)'"
+    $allNames    = [System.Collections.Generic.List[string]]::new()
+    foreach ($src in @($block)) {
+        $src | Select-String -Pattern $namePattern -AllMatches | ForEach-Object {
+            foreach ($m in $_.Matches) {
+                $n = $m.Groups[1].Value
+                if ($n -notin $allNames) { $allNames.Add($n) }
+            }
+        }
+    }
+    if ($ForStaging -and $content -match '(?s)var stagingEnvOverrides\s*=\s*\[(.*?)\]') {
+        $stagingBlock = $Matches[1]
+        $stagingBlock | Select-String -Pattern $namePattern -AllMatches | ForEach-Object {
+            foreach ($m in $_.Matches) {
+                $n = $m.Groups[1].Value
+                if ($n -notin $allNames) { $allNames.Add($n) }
+            }
+        }
+    }
+    return [string[]]$allNames
+}
 
 $result = @{}
 $block | Select-String -Pattern $literalPattern -AllMatches | ForEach-Object {

--- a/operations/devops/Sync-StagingEnv.ps1
+++ b/operations/devops/Sync-StagingEnv.ps1
@@ -36,6 +36,21 @@ if ($BicepEnv.Count -eq 0) {
     exit 1
 }
 
+# Get full managed-name set (all key names bicep declares, including non-literal values)
+# Used to safely scope orphan detection — a key absent from this set was removed from bicep. (t/3345)
+$getEnvArgsNamesOnly = @{ BicepPath = $BicepPath; NamesOnly = $true }
+if ($isStaging) { $getEnvArgsNamesOnly['ForStaging'] = $true }
+$ManagedNames = & (Join-Path $PSScriptRoot 'Get-BicepBaseEnv.ps1') @getEnvArgsNamesOnly
+
+# Fail-closed: NamesOnly must be a strict superset of the literal-value set.
+# If it isn't, the bicep parse is broken — abort rather than risk mass-wiping env vars. (t/3345)
+if ($null -eq $ManagedNames -or $ManagedNames.Count -eq 0 -or $ManagedNames.Count -lt $BicepEnv.Count) {
+    Write-Error ("Get-BicepBaseEnv.ps1 -NamesOnly returned $($ManagedNames.Count) names but the " +
+        "literal-value pass returned $($BicepEnv.Count) — NamesOnly must be a superset. " +
+        "Aborting reconcile to prevent mass-wipe of env vars. (t/3345)")
+    exit 1
+}
+
 # Get current staging env vars from the active template
 if ($MockCurrentEnvPath) {
     $CurrentEnvJson = Get-Content $MockCurrentEnvPath | ConvertFrom-Json
@@ -62,13 +77,28 @@ foreach ($key in $BicepEnv.Keys) {
     }
 }
 
-if ($Drifted.Count -eq 0) {
+# Orphan check: live app-template env keys absent from the full bicep managed set.
+# A key removed from bicep but still in the live ACA template is stale standing-state. (t/3345)
+$Orphans = @($CurrentMap.Keys | Where-Object { $_ -notin $ManagedNames })
+
+if ($Drifted.Count -eq 0 -and $Orphans.Count -eq 0) {
     Write-Host "Staging baseEnv matches Bicep — no update needed"
     exit 0
 }
 
-Write-Host "Drift detected in $($Drifted.Count) key(s):"
-$Drifted | ForEach-Object { Write-Host "  $_" }
+if ($Drifted.Count -gt 0) {
+    Write-Host "Drift detected in $($Drifted.Count) key(s):"
+    $Drifted | ForEach-Object { Write-Host "  $_" }
+}
+
+# Phase-1 (t/3345): warn about orphaned keys; Phase-2 will auto-remove after TL GV.
+if ($Orphans.Count -gt 0) {
+    Write-Host ("::warning::Staging env has $($Orphans.Count) orphaned key(s) not in bicep managed set: " +
+        "$($Orphans -join ', '). These were removed from bicep but persist in the live app template. " +
+        "Unset manually until Phase-2 lands: " +
+        "az containerapp update --name $AppName -g $ResourceGroup " +
+        "--remove-env-vars $($Orphans -join ' ') (t/3345)")
+}
 
 if ($DryRun) {
     Write-Host "[DryRun] Would call: az containerapp update --set-env-vars ..."
@@ -77,11 +107,17 @@ if ($DryRun) {
 
 # Synchronous (no --no-wait) so failures surface immediately and the following
 # New-ContainerAppRevision inherits the updated template (t/2630 TL condition)
-$EnvArgs = @($BicepEnv.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value)" })
-Write-Host "Syncing to Azure..."
-az containerapp update --name $AppName -g $ResourceGroup --set-env-vars @EnvArgs
-if ($LASTEXITCODE -ne 0) {
-    Write-Error "az containerapp update failed (exit $LASTEXITCODE)"
-    exit 1
+if ($Drifted.Count -gt 0) {
+    $EnvArgs = @($BicepEnv.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value)" })
+    Write-Host "Syncing to Azure..."
+    az containerapp update --name $AppName -g $ResourceGroup --set-env-vars @EnvArgs
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "az containerapp update failed (exit $LASTEXITCODE)"
+        exit 1
+    }
+    Write-Host "Staging baseEnv synced successfully"
 }
-Write-Host "Staging baseEnv synced successfully"
+if ($Orphans.Count -gt 0) {
+    Write-Host ("Orphaned key(s) not removed (Phase-1 warn-only, pending Phase-2 TL GV): " +
+        "$($Orphans -join ', ') (t/3345)")
+}

--- a/tests/GetBicepBaseEnv.Tests.ps1
+++ b/tests/GetBicepBaseEnv.Tests.ps1
@@ -1,0 +1,53 @@
+#Requires -Modules Pester
+<#
+.SYNOPSIS
+    Tests for Get-BicepBaseEnv.ps1 -NamesOnly switch (t/3345).
+
+    Verifies TL condition (3): -NamesOnly must be a superset of the hashtable keys
+    AND must cover every name: entry in the fixture bicep (including non-literal keys).
+#>
+
+Describe 'Get-BicepBaseEnv -NamesOnly' {
+    BeforeAll {
+        $scriptRoot  = Split-Path $PSScriptRoot -Parent
+        $getEnvScript = Join-Path $scriptRoot 'operations/devops/Get-BicepBaseEnv.ps1'
+        $bicepFixture = Join-Path $PSScriptRoot 'fixtures/bicep-env-drift/good-main.bicep'
+    }
+
+    It 'Returns all names including non-literal keys (interpolated, resource-ref, param-ref)' {
+        $names = & $getEnvScript -BicepPath $bicepFixture -NamesOnly
+        # Literal keys
+        $names | Should -Contain 'NODE_ENV'
+        $names | Should -Contain 'HOME'
+        $names | Should -Contain 'WEBSITE_AUTH_ENABLED'
+        # Non-literal keys that the standard (hashtable) pass skips
+        $names | Should -Contain 'ALLOWED_ORIGINS'       # interpolated value
+        $names | Should -Contain 'AZURE_KEYVAULT_URL'    # resource property reference
+        $names | Should -Contain 'ADMIN_USERS'           # parameter reference
+    }
+
+    It 'Is a superset of the hashtable keys returned by the standard pass' {
+        $hashtable = & $getEnvScript -BicepPath $bicepFixture
+        $names     = & $getEnvScript -BicepPath $bicepFixture -NamesOnly
+        foreach ($key in $hashtable.Keys) {
+            $names | Should -Contain $key -Because "-NamesOnly must include every literal key"
+        }
+    }
+
+    It 'Returns more names than the hashtable (has at least one non-literal key)' {
+        $hashtable = & $getEnvScript -BicepPath $bicepFixture
+        $names     = & $getEnvScript -BicepPath $bicepFixture -NamesOnly
+        $names.Count | Should -BeGreaterThan $hashtable.Count
+    }
+
+    It 'Returns a string array (not a hashtable)' {
+        $names = & $getEnvScript -BicepPath $bicepFixture -NamesOnly
+        $names | Should -BeOfType [string]
+    }
+
+    It 'Contains no duplicates' {
+        $names  = & $getEnvScript -BicepPath $bicepFixture -NamesOnly
+        $unique = $names | Sort-Object -Unique
+        $unique.Count | Should -Be $names.Count
+    }
+}

--- a/tests/GetBicepBaseEnv.Tests.ps1
+++ b/tests/GetBicepBaseEnv.Tests.ps1
@@ -51,3 +51,28 @@ Describe 'Get-BicepBaseEnv -NamesOnly' {
         $unique.Count | Should -Be $names.Count
     }
 }
+
+Describe 'Get-BicepBaseEnv -NamesOnly against real main.bicep' {
+    BeforeAll {
+        $scriptRoot   = Split-Path $PSScriptRoot -Parent
+        $getEnvScript = Join-Path $scriptRoot 'operations/devops/Get-BicepBaseEnv.ps1'
+        $realBicep    = Join-Path $scriptRoot 'deploy/azure/main.bicep'
+    }
+
+    It 'Real main.bicep: -NamesOnly is a superset of literal-hashtable keys' {
+        $hashtable = & $getEnvScript -BicepPath $realBicep
+        $names     = & $getEnvScript -BicepPath $realBicep -NamesOnly
+        foreach ($key in $hashtable.Keys) {
+            $names | Should -Contain $key -Because "-NamesOnly must cover every literal key in real main.bicep"
+        }
+    }
+
+    It 'Real main.bicep: -NamesOnly includes known non-literal keys' {
+        $names = & $getEnvScript -BicepPath $realBicep -NamesOnly
+        $names | Should -Contain 'ALLOWED_ORIGINS'    -Because 'interpolated value in baseEnv'
+        $names | Should -Contain 'AZURE_KEYVAULT_URL' -Because 'resource property reference in baseEnv'
+        # APPLICATIONINSIGHTS_* — at least one key from the AppInsights block
+        $appInsightsKeys = @($names | Where-Object { $_ -like 'APPLICATIONINSIGHTS_*' })
+        $appInsightsKeys.Count | Should -BeGreaterThan 0 -Because 'AppInsights resource-ref keys must appear in managed set'
+    }
+}

--- a/tests/StagingEnvSync.Tests.ps1
+++ b/tests/StagingEnvSync.Tests.ps1
@@ -43,4 +43,45 @@ Describe 'Sync-StagingEnv' {
             -PassThru -Wait -NoNewWindow
         $proc.ExitCode | Should -Be 2
     }
+
+    It 'Orphan detection: exits 2 (-DryRun) when env has key not in bicep managed set' {
+        # orphaned-env.json matches bicep literals but also has READYZ_FORCE_DATA_ROOT_FAILED=1,
+        # which is absent from good-main.bicep entirely. Script must detect the orphan
+        # and exit 2 (same sentinel as drift — "would update"). (t/3345)
+        $orphanedEnv = Join-Path $fixtureDir 'orphaned-env.json'
+        $proc = Start-Process pwsh `
+            -ArgumentList '-NonInteractive', '-File', $syncScript,
+                          '-BicepPath',           $bicepFixture,
+                          '-MockCurrentEnvPath',  $orphanedEnv,
+                          '-DryRun' `
+            -PassThru -Wait -NoNewWindow
+        $proc.ExitCode | Should -Be 2
+    }
+
+    It 'Safety boundary: non-literal bicep key (ALLOWED_ORIGINS) is not flagged as orphan' {
+        # matching-env-with-nonliteral.json has ALLOWED_ORIGINS with a value.
+        # ALLOWED_ORIGINS IS in good-main.bicep (as an interpolated/non-literal value),
+        # so -NamesOnly must include it and the orphan check must NOT flag it. (t/3345)
+        $envWithNonLiteral = Join-Path $fixtureDir 'matching-env-with-nonliteral.json'
+        $proc = Start-Process pwsh `
+            -ArgumentList '-NonInteractive', '-File', $syncScript,
+                          '-BicepPath',           $bicepFixture,
+                          '-MockCurrentEnvPath',  $envWithNonLiteral,
+                          '-DryRun' `
+            -PassThru -Wait -NoNewWindow
+        $proc.ExitCode | Should -Be 0
+    }
+
+    It 'Secret ref keys are never flagged as orphans' {
+        # matching-env.json has AZURE_KEYVAULT_URL as a secretRef (no value field).
+        # The CurrentMap builder excludes secretRef entries, so they can never appear
+        # in Orphans. Confirm the script exits 0 (matching env, no orphans). (t/3345)
+        $proc = Start-Process pwsh `
+            -ArgumentList '-NonInteractive', '-File', $syncScript,
+                          '-BicepPath',           $bicepFixture,
+                          '-MockCurrentEnvPath',  $matchingEnv,
+                          '-DryRun' `
+            -PassThru -Wait -NoNewWindow
+        $proc.ExitCode | Should -Be 0
+    }
 }

--- a/tests/fixtures/staging-env-sync/matching-env-with-nonliteral.json
+++ b/tests/fixtures/staging-env-sync/matching-env-with-nonliteral.json
@@ -1,0 +1,9 @@
+[
+  { "name": "AI_TRIAD_DATA_ROOT",   "value": "/mnt/shared" },
+  { "name": "TAXONOMY_CACHE_DIR",   "value": "/mnt/shared" },
+  { "name": "HOME",                 "value": "/home/aitriad" },
+  { "name": "NODE_ENV",             "value": "production" },
+  { "name": "WEBSITE_AUTH_ENABLED", "value": "true" },
+  { "name": "ALLOWED_ORIGINS",      "value": "https://taxonomy-editor.example.com" },
+  { "name": "AZURE_KEYVAULT_URL",   "secretRef": "kv-url" }
+]

--- a/tests/fixtures/staging-env-sync/orphaned-env.json
+++ b/tests/fixtures/staging-env-sync/orphaned-env.json
@@ -1,0 +1,9 @@
+[
+  { "name": "AI_TRIAD_DATA_ROOT",              "value": "/mnt/shared" },
+  { "name": "TAXONOMY_CACHE_DIR",              "value": "/mnt/shared" },
+  { "name": "HOME",                            "value": "/home/aitriad" },
+  { "name": "NODE_ENV",                        "value": "production" },
+  { "name": "WEBSITE_AUTH_ENABLED",            "value": "true" },
+  { "name": "READYZ_FORCE_DATA_ROOT_FAILED",   "value": "1" },
+  { "name": "AZURE_KEYVAULT_URL",              "secretRef": "kv-url" }
+]


### PR DESCRIPTION
## Summary
- Adds `-NamesOnly` switch to `Get-BicepBaseEnv.ps1` — captures all key names bicep declares, including non-literal values (interpolated, resource-ref, param-ref) that the standard literal-value pass skips
- `Sync-StagingEnv.ps1` now detects orphaned env keys (present in live ACA template but absent from bicep managed set) and emits `::warning::` with manual-removal command
- Fail-closed guard aborts if NamesOnly count < literal count to prevent mass-wipe on parse failure
- `az containerapp update` only fires when drift exists; orphans are warn-only (Phase-2 pending TL GV)

## Test plan
- [x] `GetBicepBaseEnv.Tests.ps1` — 5 new tests: NamesOnly superset, non-literal coverage, string array type, no duplicates
- [x] `StagingEnvSync.Tests.ps1` — +4 tests: orphan DryRun exits 2, ALLOWED_ORIGINS (non-literal) not flagged as orphan, secretRef not flagged, existing pass/fire arms unchanged
- [x] All 10/10 pass locally

## Hold
Draft until TL sign-off per gate-promotion discipline. Phase-2 (`--remove-env-vars`) in a separate PR after >=1 staging cycle observation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
