### PR TITLE
docs(cl): prose pass batch 3 — de-em-dash logical_form reference docs (t/3349)

### DIFF
--- a/research/comp-linguist/analyses/logical-form-golden/D3b-findings.md
+++ b/research/comp-linguist/analyses/logical-form-golden/D3b-findings.md
@@ -1,15 +1,14 @@
-# D3b — First `formalization_accuracy` measurement (t/3126)
+# D3b: First `formalization_accuracy` measurement (t/3126)
 
-**Inputs:** the PowerShell `Invoke-LogicalFormPass` batch (t/3215), `ai-triad-data` commit `853b2938`
-— 39 committed `logical_form`s across 17 summaries (factual 16 / intention 12 / belief 9 / desire 2,
+**Inputs:** the PowerShell `Invoke-LogicalFormPass` batch (t/3215), `ai-triad-data` commit `853b2938`, with 39 committed `logical_form`s across 17 summaries (factual 16 / intention 12 / belief 9 / desire 2,
 all `status:proposed`), produced after the prompt sort-fix (`90ce0d3e`) and the coercion/cap fix (PR #1814).
 
 **Method.** None of the three D3a observed golden nodes (`skp-beliefs-231`, `skp-beliefs-098`,
-`saf-beliefs-250`) were in the batch — `-MaxClaims 40` selected a different set, so the pre-authored
+`saf-beliefs-250`) were in the batch; `-MaxClaims 40` selected a different set, so the pre-authored
 D3a references have zero overlap with the pass output. I therefore grew an **observed golden set from the
 batch**: 10 claims stratified across all four categories (factual ×4, intention ×2, belief ×2, desire ×2),
 CL-authored **blind** (references written from `proposition` + `entity_refs` only, with the pass output
-withheld — see `worksheet.py`), then scored pass-vs-reference with `score_golden.py`.
+withheld; see `worksheet.py`), then scored pass-vs-reference with `score_golden.py`.
 Artifacts: `golden_set_d3b.json` (references), `candidates_d3b.json` (the frozen pass forms scored).
 
 ## Headline
@@ -27,7 +26,7 @@ Artifacts: `golden_set_d3b.json` (references), `candidates_d3b.json` (the frozen
 
 ## Confound decomposition (why the raw number understates the pass)
 
-t/2294 discipline — the disagreements were read, not just tallied. Three scoring variants isolate
+Per t/2294 discipline, the disagreements were read, not just tallied. Three scoring variants isolate
 metric/convention artifacts from real error:
 
 | variant | OVERALL | about | args |
@@ -39,43 +38,43 @@ metric/convention artifacts from real error:
 - **`about[]` convention artifact (+0.117).** My first references excluded a resolved entity from `about[]`
   when it already filled an `args` role (the con-1 precedent); the pass **includes** it. Schema rule (b)
   already *permits* a ref in both, and rule (e) frames `about[]` as "the logical-form projection of the
-  claim's already-resolved `entity_refs[]`" — i.e. a **complete topical index**. This measurement pins that
+  claim's already-resolved `entity_refs[]`", i.e. a **complete topical index**. This measurement pins that
   ambiguity: **`about[]` = every topical resolved entity, INCLUDING those also filling an arg role
   (superset).** The pass already complied; the 0.00s in V1 were an unpinned-convention artifact, not a pass
   error. Schema updated (`logical-form-schema.md` rule b/e).
 - **patient/theme role-label noise (+0.023).** On b-19/b-29/b-39 the pass and I pick the same participant
-  but label it `patient` vs `theme` — a thematic-role ambiguity scored as a double miss. Kept role-sensitive
+  but label it `patient` vs `theme`, a thematic-role ambiguity scored as a double miss. Kept role-sensitive
   in the canonical metric (agent/patient *does* matter for FOL export); V3 is diagnostic only.
 
 ## Real signal (genuine pass behavior, not artifact)
 
-- **`predicate` = 0.50 concentrates on multi-clause meta-descriptive BDI claims** — exactly the hard 71%
+- **`predicate` = 0.50 concentrates on multi-clause meta-descriptive BDI claims**, exactly the hard 71%
   from D3a. Two failure sub-modes:
   1. **Attitude leaks into the predicate** (b-04): the pass formalized "skeptics **support** rights"
-     (`predicate:support`, `agent:skeptics`) instead of the embedded "GDPR **protects** autonomy" — duplicating
+     (`predicate:support`, `agent:skeptics`) instead of the embedded "GDPR **protects** autonomy", duplicating
      `modality.desire` in the predicate. The meta-descriptive prompt rule strips "the document discusses…"
      but does **not** strip the attribution clause ("Skeptics support…"); that's the next prompt hardening.
   2. **Embedded-clause selection** (b-09 obstruct/hinder synonymy; b-13, b-23): on props with several
-     candidate assertions the pass picks a different — usually more surface — clause than the CL reference.
+     candidate assertions the pass picks a different (usually more surface) clause than the CL reference.
      Often a defensible reading, but it lowers reference agreement and is genuine variance.
 - **The pass is systematically *more complete* on args** (b-05/b-07/b-19/b-28 add `goal`/`instrument`/`manner`
-  the minimal reference omits). This *lowers* strict F1 (precision penalty) while being a quality *positive* —
+  the minimal reference omits). This *lowers* strict F1 (precision penalty) while being a quality *positive*,
   a note for both future reference authoring (be exhaustive) and metric design (participant-recall vs
   role-exact are different questions).
 
 ## Coverage gaps (this measurement is a seed, not the full set)
 
-- **match_level is `exact` for all 45 entity_refs in the batch** — no superclass/subclass/related. The
+- **match_level is `exact` for all 45 entity_refs in the batch**. No superclass/subclass/related. The
   match_level axis (where the schema warns formalization error concentrates, §6/R4) is **untested** here;
   only the constructed `con-2` row exercises it.
 - **n=10**, meta-descriptive-heavy, no `status:rejected` case (the batch's grounded set carried none).
-- The three **bias-free D3a references** (authored before any pass output existed) remain unscored — a
+- The three **bias-free D3a references** (authored before any pass output existed) remain unscored, a
   targeted top-up (PS offered; cap now bounds spend) would add the least-anchored rows.
 
 ## Provenance
 
 `formalization_accuracy` moves **stipulated → measured (seed)**: `0.803` (n=10, convention-pinned; `0.686`
-as-first-authored pre-pin). Not yet `derived` — that needs n≥30 with match_level diversity and the bias-free
+as-first-authored pre-pin). Not yet `derived`; that needs n≥30 with match_level diversity and the bias-free
 rows. Register updated. Follow-ups filed: prompt hardening (strip attribution clause), metric refinement
 (predicate synonymy, participant-recall arg score), golden-set expansion + match_level diversity, bias-free
 top-up.
@@ -95,7 +94,7 @@ metric-strictness rather than error: `predicate` 0.50 → `predicate_syn` **0.65
 
 ## t/3227 validation (attitude-attribution prompt fix)
 
-The prompt hardening (t/3227, PR #1823 — strip the attitude-attribution clause so a stance verb never
+The prompt hardening (t/3227, PR #1823, which strips the attitude-attribution clause so a stance verb never
 becomes the predicate) was validated on a **DRY synthetic-fixture probe** (PowerShell, prompt `98597d10`,
 no data write): the pass re-run over the 8 rows b-04/05/07/09/13/19/23/28, reconstructed from this golden
 set's real `proposition` + `entity_refs` + node. Scored vs the same references (`candidates_d3b_t3227probe.json`):
@@ -106,10 +105,10 @@ set's real `proposition` + `entity_refs` + node. Scored vs the same references (
 | overall   | ~0.80 | **0.857** |
 | controls b-05/b-07/b-19/b-28 | 1.00 | 1.00 (no regression) |
 
-The lift comes from **b-04 `support`→`protect`** and **b-13 `promote`→`prevent`** — the two attitude-leak
+The lift comes from **b-04 `support`→`protect`** and **b-13 `promote`→`prevent`**, the two attitude-leak
 cases now formalize the content proposition; no stance verb leaked into any predicate; modality unchanged
 (BDI holder/attitude, factual null). b-09 (`preempt`) and b-23 (`democratize`) stay predicate-misses but
-are **content verbs, not attitude leaks** — clause-selection/synonymy divergence, tracked in t/3228, not a
+are **content verbs, not attitude leaks**, a clause-selection/synonymy divergence, tracked in t/3228, not a
 regression of this fix.
 
 Caveat: this is an 8-row synthetic-fixture probe (faithful proposition/entity_refs, so args/about are real
@@ -120,13 +119,13 @@ under the hardened prompt lands with the t/3229 real top-up run.
 python score_golden.py --golden golden_set_d3b.json --candidates candidates_d3b_t3227probe.json   # -> 0.857 (8 rows)
 ```
 
-## t/3229 expansion — n=28 observed golden
+## t/3229 expansion: n=28 observed golden
 
 The seed golden set was expanded from 10 to **28 observed rows** (`golden_set_expanded.json` +
 `candidates_expanded.json`): the original 10, plus **15 new** D3b claims CL-authored **blind** (diverse
 across factual/belief/intention; the batch's ~14 near-duplicate Trump/AI-Action-Plan intentions were
-deliberately not all labelled — see the diversity-ceiling note), plus the **3 bias-free D3a nodes**
-(`skp-beliefs-231`, `skp-beliefs-098`, `saf-beliefs-250` — references authored in D3a *before* any pass
+deliberately not all labelled; see the diversity-ceiling note), plus the **3 bias-free D3a nodes**
+(`skp-beliefs-231`, `skp-beliefs-098`, `saf-beliefs-250`, references authored in D3a *before* any pass
 output; candidates from the hardened prompt, `ai-triad-data` `78b3ed2f` / t/3238). Plus **4 constructed
 axis cases** (reference-only, no candidate) covering match_level `subclass`/`instance_of`/`related` and a
 `status:rejected` case.
@@ -144,12 +143,12 @@ axis cases** (reference-only, no candidate) covering match_level `subclass`/`ins
 | *diag* predicate_syn | 0.65 | 0.696 |
 | *diag* args_participant | 0.46 | 0.429 |
 
-- **The 3 bias-free rows all matched predicate** (consolidate / exploit / collect) — the least-anchored
+- **The 3 bias-free rows all matched predicate** (consolidate / exploit / collect), the least-anchored
   rows (reference written before the pass existed) agree with the hardened pass on the core predicate.
 - **predicate 0.643 is a floor, not the hardened-prompt figure.** 25 of the 28 candidates are the
   **old-prompt** D3b batch (pre-t/3227), so b-03/b-04 still show the attitude-leak (`support`) the
   t/3227 fix removes. A clean single-prompt re-baseline needs all-hardened candidates (see below).
-- **args (0.28) is the genuine low axis** — richer arg structures in the diverse new claims diverge on
+- **args (0.28) is the genuine low axis.** Richer arg structures in the diverse new claims diverge on
   role labels and completeness; `args_participant` 0.43 shows part is role-labeling, not missed participants.
 - temporal 0.929 = two defensible judgment misses (b-08 dates the intention; b-33 before-vs-unspecified).
 
@@ -159,17 +158,17 @@ axis cases** (reference-only, no candidate) covering match_level `subclass`/`ins
 against real pass output until a hierarchical resolver exists. See `logical-form-schema.md`.
 
 **Still `measured (seed)`, not `derived`.** Blocking: (1) n=28 < 30; (2) **mixed prompt versions** in the
-candidate set (25 old-prompt + 3 hardened) — a clean baseline needs one prompt; (3) the batch's diversity
+candidate set (25 old-prompt + 3 hardened), so a clean baseline needs one prompt; (3) the batch's diversity
 ceiling (~25 distinct claim shapes; the rest are near-duplicates). Path to `derived`: a single all-hardened
 re-run over the ~28 golden claims reaching n≥30 (one more PowerShell run). The match_level-diversity part
-of the original criterion is **unachievable from real data** (t/3238) and is dropped — non-exact coverage
+of the original criterion is **unachievable from real data** (t/3238) and is dropped; non-exact coverage
 stays constructed-only.
 
 ```
 python score_golden.py --golden golden_set_expanded.json --candidates candidates_expanded.json   # -> STRICT 0.791 (n=28, mixed-prompt, superseded)
 ```
 
-## DERIVED — n=31 single-prompt hardened baseline (t/3229 / t/3255)
+## DERIVED: n=31 single-prompt hardened baseline (t/3229 / t/3255)
 
 The mixed-prompt confound was removed by re-running the pass with `-Force` over the 15 D3b golden-source
 files under the hardened prompt (`ai-triad-data` `1f1ef8be` / t/3255), giving an **all-hardened** candidate
@@ -194,7 +193,7 @@ set (25 re-run D3b + 3 bias-free D3a already hardened + 3 newly-added rows). Gol
   (leak gone, though still a different clause than the reference's `manage`). Single-prompt predicate rose
   0.643→0.714 on the same 28 rows.
 - The 3 added rows net predicate down slightly (b-31 `improve` matched; b-21 `protect`/`preempt` and b-36
-  `elevate`/`surpass` are clause-selection misses) — expected, more diverse, truer estimate.
+  `elevate`/`surpass` are clause-selection misses), expected, more diverse, truer estimate.
 - **predicate (0.68) stays the weak axis**, now purely clause-selection/synonymy on multi-clause
   meta-descriptive BDI (no attitude-leaks left); `predicate_syn` 0.69 shows part is synonymy.
 

--- a/research/comp-linguist/analyses/logical-form-golden/README.md
+++ b/research/comp-linguist/analyses/logical-form-golden/README.md
@@ -1,12 +1,12 @@
-# logical_form Golden Set (t/3126 D3a) — with input-substrate findings
+# logical_form Golden Set (t/3126 D3a): input-substrate findings
 
 **D3b measured (2026-09-02):** first `formalization_accuracy` = **0.803** (n=10, convention-pinned; 0.686 pre-pin) on the t/3215 pass batch. Observed golden grown from the real pass output (`golden_set_d3b.json` + frozen `candidates_d3b.json`); full analysis in **`D3b-findings.md`**. Reproduce: `python score_golden.py --golden golden_set_d3b.json --candidates candidates_d3b.json`.
 
-**Status (post-#1778 review):** `about[]` ADOPTED as a first-class schema field (TL p/571; conditions (a)–(e) in `logical-form-schema.md`); `args[].sort` pinned to the register `DolceCategory` set (5 values, `lib/entities/types.ts`); prompt updated (emit `about[]` + meta-descriptive guard + factual→`point`/`verbatim`). The "reshape recommendations" below are now IMPLEMENTED in the schema/prompt — retained as the rationale of record.
+**Status (post-#1778 review):** `about[]` ADOPTED as a first-class schema field (TL p/571; conditions (a)–(e) in `logical-form-schema.md`); `args[].sort` pinned to the register `DolceCategory` set (5 values, `lib/entities/types.ts`); prompt updated (emit `about[]` + meta-descriptive guard + factual→`point`/`verbatim`). The "reshape recommendations" below are now IMPLEMENTED in the schema/prompt, and retained as the rationale of record.
 
 Reference set + scorer for the `logical_form` formalization pass (schema: `docs/logical-form-schema.md`;
 prompt: `scripts/AITriad/Prompts/logical-form-formalization.prompt`). Empirically grounded in the live
-summaries corpus per t/2294 — every observed row is a real claim with its real `entity_refs`; the
+summaries corpus per t/2294. Every observed row is a real claim with its real `entity_refs`; the
 reference `logical_form` is CL-authored.
 
 ## Finding: the pass's input substrate largely does not match the schema's assumption
@@ -24,32 +24,32 @@ Inventory of all `entity_refs`-bearing claims (n=472 across 229 summaries; regen
 
 Net: only **~64/472 (13.5%)** are cleanly formalizable as-is (non-empty, non-meta). The full golden
 set + the D3b `formalization_accuracy` measurement should be built against the **resolved** input
-(factual→point/verbatim; meta-descriptive handled), not the current field as-is — otherwise the
+(factual→point/verbatim; meta-descriptive handled), not the current field as-is, since otherwise the
 reference formalizes the wrong text.
 
 ## Reshape recommendations (feed back into D1/D2 + the FOL track)
 
 1. **Schema amendment (D1):** add `about: [{ref, match_level}]` for topical entity_refs distinct from
-   participant `args[]` — mirrors §7.3's `about(p, ent)`. Without it, 88%-single-ref topical mentions
+   participant `args[]`, mirroring §7.3's `about(p, ent)`. Without it, 88%-single-ref topical mentions
    are forced into a participant role they don't fill. (Encoded in the seed rows below as `about`.)
-2. **Prompt amendment (D2):** a meta-descriptive guard — if the proposition is "The document …",
+2. **Prompt amendment (D2):** a meta-descriptive guard, applied when the proposition is "The document …",
    formalize the *embedded* assertion, and if none is recoverable, emit `status:"rejected"` with low
    `formalization_confidence` rather than `discuss(document,…)`.
 3. **Factual arm:** the pass reads `point`/`verbatim` for `factual_claims` (canonical_proposition is
    empty for 100% of them).
 4. **Upstream (Collaborator/PS extraction):** emit atomic `canonical_proposition`s, not "The
-   document…" summaries — the single highest-leverage fix; it moves the 71% meta share toward
+   document…" summaries, the single highest-leverage fix; it moves the 71% meta share toward
    formalizable.
 
 ## What this seed contains
 
-A small hand-formalized **seed** (not the full N≥30 golden set — that waits on the input resolution
+A small hand-formalized **seed** (not the full N≥30 golden set, which waits on the input resolution
 above so the reference isn't built against the wrong field):
-- **observed** rows — real clean claims (with camp), formalized per the schema + the `about[]`
+- **observed** rows, real clean claims (with camp), formalized per the schema + the `about[]`
   amendment, showing the participant-vs-topical distinction on real data.
-- **constructed** rows — the strata the live corpus lacks: a non-exact `match_level`, a negated
+- **constructed** rows, the strata the live corpus lacks: a non-exact `match_level`, a negated
   polarity, an explicit temporal, a multi-participant frame, and a factual (modality:null) case.
-  Labelled `constructed` (t/2294 — never let a constructed case masquerade as observed evidence).
+  Labelled `constructed` (t/2294; never let a constructed case masquerade as observed evidence).
 
 `score_golden.py` scores a candidate `logical_form` set against these references **per component**
 (predicate / args+roles / polarity / modality / temporal / about) → `formalization_accuracy`, so the

--- a/research/comp-linguist/docs/claims-entity-fol-recommendations.md
+++ b/research/comp-linguist/docs/claims-entity-fol-recommendations.md
@@ -2,15 +2,15 @@
 
 **Author:** Computational Linguist
 **Date:** 2026-08-31
-**Status:** Implemented — Phase 1 landed on `main`; the formalization calibration gate is met (see Implementation status below).
+**Status:** Implemented. Phase 1 landed on `main`; the formalization calibration gate is met (see Implementation status below).
 **Scope:** Analysis of five pipeline concerns raised 2026-08-31, with recommendations grounded in a full survey of both repos as of this date.
 
 ## Implementation status (updated 2026-09-03)
 
 The five concerns and the R1–R7 recommendations below were adopted; Phase 1 is on `main`:
 
-- **R2 / R3 / R4 — entity grounding on claims (t/3124, landed).** Claims now carry `entity_refs[]` (`ref`, `surface`, `method`, `link_confidence`, `match_level`, `status`). The resolution ladder and registered thresholds are recorded in the metric-provenance register.
-- **R1 / R5 Phase 1 — the `logical_form` layer (t/3126, landed).** A neo-Davidsonian event-frame schema on claims (`docs/logical-form-schema.md`), an LLM formalization prompt (`scripts/AITriad/Prompts/logical-form-formalization.prompt`), and a golden set plus per-component scorer (`analyses/logical-form-golden/`). BDI attitudes reify first-order via `holds/3` (no belief-closure); `about[]` carries topical grounding, and `args[].sort` is pinned to the register's 5-value `DolceCategory` set (each participant inherits its entity's `dolce_category` — R1's "DOLCE typing for free").
+- **R2 / R3 / R4, entity grounding on claims (t/3124, landed).** Claims now carry `entity_refs[]` (`ref`, `surface`, `method`, `link_confidence`, `match_level`, `status`). The resolution ladder and registered thresholds are recorded in the metric-provenance register.
+- **R1 / R5 Phase 1, the `logical_form` layer (t/3126, landed).** A neo-Davidsonian event-frame schema on claims (`docs/logical-form-schema.md`), an LLM formalization prompt (`scripts/AITriad/Prompts/logical-form-formalization.prompt`), and a golden set plus per-component scorer (`analyses/logical-form-golden/`). BDI attitudes reify first-order via `holds/3` (no belief-closure); `about[]` carries topical grounding, and `args[].sort` is pinned to the register's 5-value `DolceCategory` set (each participant inherits its entity's `dolce_category`, R1's "DOLCE typing for free").
 - **The formalization pass (t/3215, landed).** PowerShell `Invoke-LogicalFormPass` runs the schema + prompt over claims after entity resolution.
 - **Prompt hardening (t/3227) and scorer diagnostics (t/3228).** The meta-descriptive rule now also strips the attitude-attribution clause (the predicate is the content proposition, not the stance verb); the scorer adds diagnostic `predicate_syn` and `args_participant` components.
 - **Calibration gate met (t/3229), then re-baselined on the current prompt (t/3239).** `formalization_accuracy` is a **derived** metric. The paper-canonical figure is the **v2 census on the current production prompt** `a9c93103` (stance-strip strengthened): **strict 0.778 / lenient 0.978 (n=45)**, a stratified holistic claim-level verdict (`research/comp-linguist/analyses/lf-golden-v2/`). The earlier n=31 = 0.802 (per-component mean, superseded prompt `1103ed06`) is retained in the provenance register as the prior-prompt/prior-definition measurement. Recorded honest caveats: single-annotator reference, and `match_level` is `exact`-only in practice because the resolver hardcodes it (t/3238), so non-exact coverage is constructed-only until a hierarchical resolver exists.
@@ -232,7 +232,7 @@ Question raised 2026-08-31. Diagnosis from the live data files and the cmdlet so
 
 Also structural, beyond the pilot-never-scaled story: the extraction corpus is per-node evidence facts, which exist for only 556 of 4,144 nodes, and the 805 document summaries with their thousands of claims are not an entity source at all today. Even a fully-scaled Phase 1 reads a narrow slice of the project's text. The long-run size driver for the register is claim-side extraction, which is R2/T2–T3 of this document.
 
-**R7: unfreeze in order — curate, vectorize, then scale.**
+**R7: unfreeze in order, then curate, vectorize, and scale.**
 
 1. **Curation pass on the existing 78** (human or human-approved batch): author or LLM-draft-then-approve descriptions, approve the sound records, merge obvious variants. This is the blocking step for everything else and is a bounded effort.
 2. **Populate `entity_embeddings.json` from the approved set** (T1 as already proposed, now with an explicit trigger). Consider extending vectors to `proposed` records under a status tag so within-run and cross-run near-variant surfacing both work; the R6 rule (symbol is identity, vector is grounding) makes this safe.
@@ -240,7 +240,7 @@ Also structural, beyond the pilot-never-scaled story: the extraction corpus is p
 4. **Then widen the corpus to claims** per R2/T2–T3, which turns the register's growth from a per-node evidence trickle into the document pipeline's natural byproduct.
 5. **Add a register-liveness check to the calibration cycle**: register size, extraction coverage (nodes processed / nodes with facts), approval ratio, and days-since-last-mint. A register that sits untouched for a month while 805 documents flow past is exactly the silent-stall class this project keeps rediscovering; make it a scanned number instead of a surprise.
 
-Ticket impact: adds two tickets to §9 — T10/t/3118 (curation + approval pass on existing 78, precedes T1) and T11/t/3123 (scaled Phase 1 run over remaining corpus, follows T1); T1's description gains the approved-set trigger; the liveness check folds into T5/t/3125.
+Ticket impact: adds two tickets to §9. T10/t/3118 (curation + approval pass on existing 78, precedes T1) and T11/t/3123 (scaled Phase 1 run over remaining corpus, follows T1); T1's description gains the approved-set trigger; the liveness check folds into T5/t/3125.
 
 ## 12. Addendum: entities vs concepts, and the reuse-gate discipline (decision 2026-08-31)
 

--- a/research/comp-linguist/docs/logical-form-schema.md
+++ b/research/comp-linguist/docs/logical-form-schema.md
@@ -1,16 +1,16 @@
-# `logical_form` Schema — Neo-Davidsonian Event Frames on Claims
+# `logical_form` Schema: Neo-Davidsonian Event Frames on Claims
 
 **Ticket:** t/3126 (T6). **Depends on:** t/3124 (entity_refs resolution, Done).
 **Design of record:** `claims-entity-fol-recommendations.md` §7.2 (Phase 1), §7.3 (reification), §7.4 (ownership).
 **Owner:** CL (schema + prompt); PowerShell implements the formalization pass. Mandatory-review surface.
-**Status:** Landed — schema + prompt + golden seed (PR #1778); prompt sort-fix (`90ce0d3e`); pass built (t/3215, PR #1792/#1814). `about[]` adopted (TL p/571 / t/3126#6) and its superset convention **pinned by the D3b measurement** (`formalization_accuracy` = 0.803, n=10).
+**Status:** Landed. Schema + prompt + golden seed (PR #1778); prompt sort-fix (`90ce0d3e`); pass built (t/3215, PR #1792/#1814). `about[]` adopted (TL p/571 / t/3126#6) and its superset convention **pinned by the D3b measurement** (`formalization_accuracy` = 0.803, n=10).
 
 ## Purpose
 
 A derived, structured proposition layer on claims (`key_points` / `factual_claims` in the summaries
 schema; lazily on node `canonical_proposition` equivalents). It is the prerequisite for the FOL track
 (§7.2 Phase 1): TPTP export (t/3127) and edge verification (t/3128) consume it. It is produced by an
-LLM formalization pass with its own golden set + calibration gate — nothing downstream trusts a
+LLM formalization pass with its own golden set + calibration gate. Nothing downstream trusts a
 `logical_form` until `formalization_accuracy` is measured.
 
 Design rule it inherits: **the prover is only as sound as the logical form** (§8.1). A wrong
@@ -31,7 +31,7 @@ live claim shape (summaries, post-t/3124):
 
 The formalization pass reads the proposition from `canonical_proposition` (register-normalized) for
 BDI claims, and from `point`/`verbatim` for `factual_claims` (whose `canonical_proposition` is empty
-for 100% of them — D3a); `category` for the attitude, the camp for the holder, and `entity_refs[]`
+for 100% of them, D3a); `category` for the attitude, the camp for the holder, and `entity_refs[]`
 for both the argument bindings and the `about[]` projection. It never re-extracts entities.
 
 ## Schema
@@ -87,7 +87,7 @@ holds(camp_acc, belief, p1) ∧ about(p1, ent_055) ∧ acquire(e1) ∧ agent(e1,
 
 - The proposition `p1` is a first-class object (DOLCE non-physical endurant / D&S description).
 - `factual_claims` (`modality: null`) assert the frame directly, without the `holds(...)` wrapper.
-- **No belief-closure axiom** — camps are deliberately not logically omniscient (that non-omniscience
+- **No belief-closure axiom.** Camps are deliberately not logically omniscient (that non-omniscience
   is half the research interest). The t/3127 axiom module must exclude closure and document the
   exclusion; this schema encodes nothing that presumes it.
 - Cross-camp queries this enables: "which propositions does acc believe and saf reject?" =
@@ -100,9 +100,9 @@ holds(camp_acc, belief, p1) ∧ about(p1, ent_055) ∧ acquire(e1) ∧ agent(e1,
    `lit:"…"` and are flagged, not invented (t/2294 / R6 symbol-is-identity).
 2. **`match_level` and `sort` are copied, not judged.** They come from the entity_ref / the entity
    register's `dolce_category`; the pass does not re-derive DOLCE typing per claim (keeps one identity
-   model across resolution, formalization, and the future re-merge — the §7.4/t/2946 one-identity rule).
-3. **`attitude` follows `category`; `holder` follows POV** — mechanical, not re-judged from prose.
-4. **`unspecified`/`null`/`proposed` are first-class**, never silent omissions — an absent field is a
+   model across resolution, formalization, and the future re-merge, the §7.4/t/2946 one-identity rule).
+3. **`attitude` follows `category`; `holder` follows POV**, mechanical, not re-judged from prose.
+4. **`unspecified`/`null`/`proposed` are first-class**, never silent omissions. An absent field is a
    formalization bug; an explicit `unspecified` is a valid reading (the same "timeout is a result"
    discipline §7.2 Phase 2 applies to the prover).
 
@@ -118,36 +118,36 @@ holds(camp_acc, belief, p1) ∧ about(p1, ent_055) ∧ acquire(e1) ∧ agent(e1,
   alone. A ref may also appear in `about[]` only (topical non-participant). It is **never a
   "couldn't-formalize" dumping bucket.** *(Pinned by the D3b measurement: leaving participants out of
   `about[]` was an unpinned-convention ambiguity that deflated scored agreement by ~0.12 with no semantic
-  content — see `analyses/logical-form-golden/D3b-findings.md`.)*
+  content; see `analyses/logical-form-golden/D3b-findings.md`.)*
 - **(c) Non-substitute.** A cleanly-formalizable claim still populates `args[]`; `about[]` is never an
   excuse to skip formalization.
 - **(d) Earns its place on the non-formalizable majority.** With 54% of claims carrying an empty
   `canonical_proposition` (100% of factual) and 71% of BDI props meta-descriptive (D3a), `about[]`
-  MUST be populated there — that is its whole value. Empty-there = not earning the field.
+  MUST be populated there. That is its whole value. Empty-there = not earning the field.
 - **(e) Reconciles with the `summary:*` entity_mention layer (t/3160).** `about[]` is the *logical-form
-  projection of the claim's already-resolved `entity_refs[]`* — same `ent-` ids, no new resolution —
+  projection of the claim's already-resolved `entity_refs[]`* (same `ent-` ids, no new resolution),
   so it does NOT double-ground what the mention-index layer captures. Different layer (LF topical
   grounding vs mention occurrences), same identities.
 
 ## Calibration + provenance (deliverable 3 preview)
 
-- **Metric:** `formalization_accuracy` — golden-set agreement between the pass's `logical_form` and the
+- **Metric:** `formalization_accuracy`, the golden-set agreement between the pass's `logical_form` and the
   CL-labelled reference, scored per component (predicate / args+roles / polarity / modality / temporal)
   so a partial-credit profile shows *which* component the pass gets wrong (predicate vs role vs
   temporal have different downstream costs).
 - **Golden set:** labelled claim→logical_form pairs, **empirically reproduced** by running the actual
-  pass on real claims (t/2294) — not authored from the doc example. Stratified across `category`
+  pass on real claims (t/2294), not authored from the doc example. Stratified across `category`
   (B/D/I + factual) and `match_level` so accuracy is readable where it matters (superclass/related
   args are where formalization error concentrates).
 - **Provenance:** register entry class **stipulated → measured (seed, D3b)**: `formalization_accuracy` =
   **0.803** (n=10, convention-pinned; 0.686 as-first-authored pre-`about[]`-pin) on the t/3215 batch
   (`ai-triad-data` `853b2938`). Mechanical fields (polarity/modality/temporal/about) = 1.00; residual weak
-  axis is `predicate` = 0.50, concentrated on multi-clause meta-descriptive BDI. Not yet `derived` — needs
+  axis is `predicate` = 0.50, concentrated on multi-clause meta-descriptive BDI. Not yet `derived`; it needs
   n≥30 with match_level diversity and the bias-free D3a rows. `formalization_confidence` is a pass self-rating
   (stipulated) until correlated with golden-set correctness. Full analysis:
   `analyses/logical-form-golden/D3b-findings.md`.
 
-## Prompt-port coupling — one shape across two runtimes (t/3250)
+## Prompt-port coupling: one shape across two runtimes (t/3250)
 
 `logical_form` is produced by **two ports of a single prompt** and validated by **one canonical Zod
 schema**. All four artifacts must agree; a change to the frame shape updates all four in lockstep or
@@ -166,7 +166,7 @@ two prompt ports (#3a/#3b) are *implementations* that must conform to them, neve
 
 **Change protocol.** Any change to the frame shape (new field, vocabulary change, added role) touches
 **#1 (spec) + #4 (Zod) first**, then BOTH ports (#3a PS + #3b Py) which share prompt #2. Never change one
-port's output without the other — node and claim frames must stay the same shape (that is the whole point
+port's output without the other. Node and claim frames must stay the same shape (that is the whole point
 of one schema). Port-specific behavior that does NOT change the shape:
 
 - The **node port (#3b)** forces `modality.holder` = camp (from the node-id prefix) and `attitude` =
@@ -181,8 +181,8 @@ Both emit the identical field set in §Schema; the Zod (#4) is the mechanical gu
 
 ## Open items (post-review)
 
-- [x] `args[].sort` enum pinned to the live register `DolceCategory` set (`lib/entities/types.ts`) — the 5 values above.
+- [x] `args[].sort` enum pinned to the live register `DolceCategory` set (`lib/entities/types.ts`), the 5 values above.
 - [x] `about[]` adopted as a first-class field with conditions (a)–(e) (TL p/571 / t/3126#6; CL review #1778 issue 2).
 - [ ] **PowerShell contract** (handed off): persistence slot (derived field on the claim objects, same pass-slot family as `Invoke-RetrievalConfidencePass`); `{{ENTITY_REFS}}` must join `dolce_category`→`sort`; the factual arm reads `point`/`verbatim`.
-- [ ] `event_ref` scope (per-claim vs per-summary) — reconcile with the t/3127 TPTP generator.
+- [ ] `event_ref` scope (per-claim vs per-summary), to be reconciled with the t/3127 TPTP generator.
 - [ ] `holds/3` cross-role interface question deferred to t/3127 (TPTP export), per CL review.


### PR DESCRIPTION
Final batch of the corpus /review-prose pass (owner chose the thorough option). Flowing-prose em-dashes -> 0 across claims-entity-fol-recommendations, logical-form-schema, golden README, and D3b-findings (~50 reshapes by sentence-shape, not colon-swap). Remaining em-dashes are all exempt (schema-field tables, no-value cells, definition bullets). No content/metric changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)