### PR TITLE
fix(t3345): secretRef exclusion + deploy-metadata allowlist in orphan detection

### DIFF
--- a/operations/devops/Sync-StagingEnv.ps1
+++ b/operations/devops/Sync-StagingEnv.ps1
@@ -65,9 +65,17 @@ if ($MockCurrentEnvPath) {
 
 $CurrentMap = @{}
 foreach ($e in @($CurrentEnvJson)) {
+    # az returns secret-backed vars as {secretRef:'x', value:''} — skip them.
+    # Filtering only on value-property presence misses this case (empty string passes).
+    $secretRefProp = $e.PSObject.Properties['secretRef']
+    if ($null -ne $secretRefProp -and $secretRefProp.Value -ne '') { continue }
     $valProp = $e.PSObject.Properties['value']
     if ($null -ne $valProp) { $CurrentMap[$e.name] = $valProp.Value }
 }
+
+# Workflow-injected keys set per-revision at deploy time — not bicep-managed.
+# Exclude from orphan detection so they don't trigger false positives. (t/3345)
+$WorkflowManagedKeys = @('DEPLOY_TAG', 'DEPLOY_SHA')
 
 # Idempotency check — skip update if all literal keys already match
 $Drifted = [System.Collections.Generic.List[string]]::new()
@@ -79,7 +87,7 @@ foreach ($key in $BicepEnv.Keys) {
 
 # Orphan check: live app-template env keys absent from the full bicep managed set.
 # A key removed from bicep but still in the live ACA template is stale standing-state. (t/3345)
-$Orphans = @($CurrentMap.Keys | Where-Object { $_ -notin $ManagedNames })
+$Orphans = @($CurrentMap.Keys | Where-Object { $_ -notin $ManagedNames -and $_ -notin $WorkflowManagedKeys })
 
 if ($Drifted.Count -eq 0 -and $Orphans.Count -eq 0) {
     Write-Host "Staging baseEnv matches Bicep — no update needed"


### PR DESCRIPTION
## Summary

- **secretRef exclusion bug**: `az containerapp show` returns secret-backed env vars as `{secretRef:'x', value:''}`. The prior `$CurrentMap` filter checked only for value-property *presence*, so empty-string values slipped through. Fix: skip any entry where `secretRef` is non-empty.
- **Deploy-metadata allowlist**: `DEPLOY_TAG` / `DEPLOY_SHA` are injected per-revision by the workflow (not bicep-managed). Adding `$WorkflowManagedKeys` excludes them from orphan detection, preventing false positives.

Both bugs surfaced during the t/3345 Phase-1 probe observation run.

## Hold

Draft pending TL static GV (t/3345 Phase-2 4-condition bar, t/3345#6). Un-draft only after TL sign-off.

## Test plan

- [ ] TL static GV on secretRef exclusion logic and allowlist placement
- [ ] Main (DevOps) re-observation deploy: inject throwaway orphan → confirm Phase-1 warns on only it, not secrets or deploy-metadata (condition 4, t/3345#6)
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)