### PR TITLE
feat(debate-workspace): show greatest-hits exclusion in Debate Setup panel (t/3356)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateSetupDialog.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateSetupDialog.tsx
@@ -291,6 +291,12 @@ export function DebateSetupDialog({
                 </dd>
               </Fragment>
             )}
+            {activeDebate.exclude_greatest_hits && (
+              <Fragment>
+                <dt className="dsd-setup-dt">Greatest hits</dt>
+                <dd className="dsd-setup-dd">excluded</dd>
+              </Fragment>
+            )}
           </dl>
           {hasDistinctStageModels && (
             <details style={{ marginTop: 10 }}>


### PR DESCRIPTION
## Summary
- Adds a "Greatest hits" row to the SETUP section of `DebateSetupDialog`
- Row is only visible when `exclude_greatest_hits === true`; hidden on false/absent (old debates unaffected)
- UI-only change — no store, no API, no new CSS classes

## Test plan
- [ ] Open a debate created with greatest-hits exclusion enabled → SETUP section shows "Greatest hits: excluded"
- [ ] Open a debate without the flag → row is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
