### PR TITLE
feat(devops): done-evidence gate predicate + tests (warn-phase, t/3360)

### DIFF
--- a/operations/devops/done-evidence-predicate.mjs
+++ b/operations/devops/done-evidence-predicate.mjs
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { execFileSync } from 'node:child_process'; // used only by the CLI shim's git query
+
+/**
+ * Pure verdict for the done-requires-EVIDENCE gate (t/3360, G1 cross-check audit).
+ *
+ * FAILURE CLASS it closes: a ticket transitions to Done with a bare "done" and no evidence, so a
+ * closed ticket isn't traceable to a landed commit. The pre-existing `done-requires-commit` rule was
+ * context-ONLY (a static reminder, condition:"true") — it nudged but verified nothing.
+ *
+ * DESIGN (Orca Support t/3360#2): the `transition_ticket` PreToolUse payload carries only
+ * { ticket_id, status } — NOT the closing comment — and there is no comments API nor an extensible
+ * transition param. So evidence is checked against GIT, not comments: a Done transition requires a
+ * commit on `origin/main` whose message references the ticket key (the fleet's `t/KEY` commit
+ * convention). `ticket_type` is NOT in the payload, so carve-outs (chore/docs/no-code) CANNOT be
+ * mechanical — that gap is sized during the warn phase before any blocking flip.
+ *
+ * Split (merge-guard pattern, t/3270/t/3318, Guard Testability t/2971): the impure `git log` query
+ * lives in the CLI shim; `doneEvidenceVerdict` is a PURE function of { statusTarget, hitCount, gitOk }
+ * so both arms stay unit-testable (test == runtime). Returns { block, reason }.
+ *
+ * git-error mode = FAIL-OPEN (warn-phase proposal; TL confirms at the flip, t/3360#3): a git hiccup
+ * must not brick EVERY Done transition — this gate is an evidence backstop, not the record of truth,
+ * and its blast radius (all Done transitions, all roles) is far wider than the merge-guard's. That is
+ * the risk-matched opposite of the merge-guard's fail-CLOSED.
+ */
+export function doneEvidenceVerdict({ statusTarget, hitCount, gitOk } = {}) {
+  // Self-scope: only a transition whose TARGET status is Done is in scope (case-insensitive).
+  if (String(statusTarget).toLowerCase() !== 'done') return { block: false, reason: 'not-done-transition' };
+  // FAIL-OPEN on any git failure / unparseable key (gitOk=false) — see header.
+  if (!gitOk) return { block: false, reason: 'git-unavailable-fail-open' };
+  // A landed commit references the ticket key → committed evidence exists.
+  if (hitCount > 0) return { block: false, reason: 'evidence-present' };
+  // Done + git OK + zero commits referencing the ticket → no committed evidence.
+  return { block: true, reason: 'no-committed-evidence' };
+}
+
+/**
+ * Normalize a payload `ticket_id` to the `t/KEY` form used in commit messages.
+ * Accepts "t/3360", "3360", "T/3360" → "t/3360"; returns null if unrecognizable (→ fail-open).
+ * Kept pure + exported so the key-parsing arm is unit-tested independently of git.
+ */
+export function normalizeTicketKey(raw) {
+  const m = String(raw ?? '').trim().match(/^(?:t\/)?(\d{1,7})$/i);
+  return m ? `t/${m[1]}` : null;
+}
+
+// CLI shim (the ONLY impure part). Convention (worktree-path-guard / merge-guard): BLOCK == write
+// 'fire' to stdout; ALLOW == exit 0 with no stdout. The feedback rule invokes THIS module by abs
+// path so the rule runs the exact logic the both-arms test proves (test == runtime, TL GV t/3270#4).
+// The endsWith guard makes the shim run ONLY on direct invocation, never when imported by the test.
+//   node done-evidence-predicate.mjs "<status>" "<ticket_id>"
+if (process.argv[1] && process.argv[1].replace(/\\/g, '/').endsWith('done-evidence-predicate.mjs')) {
+  const statusTarget = process.argv[2] || '';
+  if (String(statusTarget).toLowerCase() === 'done') {
+    const key = normalizeTicketKey(process.argv[3] || '');
+    let hitCount = 0;
+    let gitOk = true;
+    if (!key) {
+      gitOk = false; // unparseable id → fail-open (don't block on an id we can't turn into a key)
+    } else {
+      try {
+        const out = execFileSync('git', ['log', 'origin/main', `--grep=${key}`, '--oneline'], {
+          encoding: 'utf8',
+          timeout: 8000,
+        });
+        hitCount = out.split(/\r?\n/).filter((l) => l.trim()).length;
+      } catch {
+        gitOk = false; // git error → fail-open (see header)
+      }
+    }
+    if (doneEvidenceVerdict({ statusTarget, hitCount, gitOk }).block) process.stdout.write('fire');
+  }
+}

--- a/operations/devops/done-evidence-predicate.test.mjs
+++ b/operations/devops/done-evidence-predicate.test.mjs
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Both-arms proof for the done-requires-evidence gate (t/3360). The predicate keys on a git state
+// the ticket workflow can't exercise in unit tests, so both arms are proven here directly. Run:
+//   node --test operations/devops/done-evidence-predicate.test.mjs
+// Proves the SAME logic the feedback rule invokes (test == runtime, per t/3270#4).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { doneEvidenceVerdict, normalizeTicketKey } from './done-evidence-predicate.mjs';
+
+// ── doneEvidenceVerdict: BLOCK arm ──
+test('BLOCK arm: Done + git OK + zero commits referencing the ticket', () => {
+  const v = doneEvidenceVerdict({ statusTarget: 'Done', hitCount: 0, gitOk: true });
+  assert.equal(v.block, true);
+  assert.equal(v.reason, 'no-committed-evidence');
+});
+
+// ── doneEvidenceVerdict: ALLOW arms ──
+test('ALLOW arm: Done + a commit references the ticket (evidence present)', () => {
+  const v = doneEvidenceVerdict({ statusTarget: 'Done', hitCount: 3, gitOk: true });
+  assert.equal(v.block, false);
+  assert.equal(v.reason, 'evidence-present');
+});
+
+test('ALLOW arm: exactly one commit still counts as evidence', () => {
+  assert.equal(doneEvidenceVerdict({ statusTarget: 'Done', hitCount: 1, gitOk: true }).block, false);
+});
+
+test('ALLOW arm: git unavailable → FAIL-OPEN (a git hiccup must not brick Done)', () => {
+  const v = doneEvidenceVerdict({ statusTarget: 'Done', hitCount: 0, gitOk: false });
+  assert.equal(v.block, false);
+  assert.equal(v.reason, 'git-unavailable-fail-open');
+});
+
+test('ALLOW arm: non-Done transitions are out of scope (never block)', () => {
+  for (const s of ['In Progress', 'Todo', 'Backlog', 'Cancelled', 'Verified', 'Blocked', '']) {
+    const v = doneEvidenceVerdict({ statusTarget: s, hitCount: 0, gitOk: true });
+    assert.equal(v.block, false, `status "${s}" must not block`);
+    assert.equal(v.reason, 'not-done-transition');
+  }
+});
+
+test('Done is matched case-insensitively (block still fires for "done")', () => {
+  assert.equal(doneEvidenceVerdict({ statusTarget: 'done', hitCount: 0, gitOk: true }).block, true);
+  assert.equal(doneEvidenceVerdict({ statusTarget: 'DONE', hitCount: 0, gitOk: true }).block, true);
+});
+
+test('empty/undefined args never throw and default to allow', () => {
+  assert.equal(doneEvidenceVerdict().block, false);
+  assert.equal(doneEvidenceVerdict({}).block, false);
+});
+
+// ── normalizeTicketKey ──
+test('normalizeTicketKey: accepts t/KEY, bare number, and uppercase; rejects junk', () => {
+  assert.equal(normalizeTicketKey('t/3360'), 't/3360');
+  assert.equal(normalizeTicketKey('3360'), 't/3360');
+  assert.equal(normalizeTicketKey('T/3360'), 't/3360');
+  assert.equal(normalizeTicketKey('  t/42  '), 't/42');
+  assert.equal(normalizeTicketKey('e/105'), null); // email ref, not a ticket key
+  assert.equal(normalizeTicketKey('p/526'), null); // ping ref
+  assert.equal(normalizeTicketKey('not-a-key'), null);
+  assert.equal(normalizeTicketKey(''), null);
+  assert.equal(normalizeTicketKey(null), null);
+  assert.equal(normalizeTicketKey(undefined), null);
+});


### PR DESCRIPTION
**t/3360 (G1 cross-check audit)** — promote `done-requires-commit` from a context-only reminder to a real evidence gate. This PR lands the **tested predicate** (warn-phase artifact); the feedback-rule wiring lands warn-only next, and the BLOCKING flip routes to TL for GV.

**Mechanism (per Orca Support t/3360#2 — git, not comments):** the `transition_ticket` PreToolUse payload has only `{ticket_id,status}` (no comments API / transition param), so evidence = a commit on `origin/main` whose message references the ticket key (`t/KEY`).
- `done-evidence-predicate.mjs`: pure `doneEvidenceVerdict({statusTarget,hitCount,gitOk})` (fire iff Done + gitOk + hitCount==0) + `normalizeTicketKey`; CLI shim runs `git log origin/main --grep=<key>` and emits `fire` on block (merge-guard shim pattern, **test==runtime**). **FAIL-OPEN** on git error (risk-matched — Done-blocking blast radius is wide).
- `done-evidence-predicate.test.mjs`: 8 tests, both arms + FP corpus. Live shim verified: Done+t/3345→allow, Done+t/9999999→fire, In Progress→allow.

Self-certified against the t/3270/t/3318 gate-predicate pattern (deviations: fail-OPEN vs merge-guard's fail-closed, risk-matched + flagged for TL). No mechanical ticket_type carve-out (not in payload) — sized in the warn phase.