### PR TITLE
feat(validation): add aggregate conflicts.json schema safety net (t/3358)

### DIFF
--- a/taxonomy-editor/src/renderer/utils/validation.data.test.ts
+++ b/taxonomy-editor/src/renderer/utils/validation.data.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync, readdirSync, existsSync } from 'node:fs';
 import { resolve, join } from 'node:path';
-import { povTaxonomyFileSchema, situationsFileSchema, conflictFileSchema } from './validation';
+import { povTaxonomyFileSchema, situationsFileSchema, conflictFileSchema, aggregateConflictsFileSchema } from './validation';
 
 const REPO_ROOT = resolve(__dirname, '..', '..', '..', '..');
 const configPath = join(REPO_ROOT, '.aitriad.json');
@@ -85,6 +85,37 @@ describe.skipIf(!dataRoot)('Schema safety net — validation.ts vs real producti
           (result.error.issues.length > 10 ? `\n  ...and ${result.error.issues.length - 10} more` : ''),
         );
       }
+    });
+  });
+
+  // t/3358: the aggregate conflicts.json (the data-of-record fork-B census merge + demotion mutate)
+  // had NO schema safety net — only the 5 legacy conflict-*.json files (filtered above) were covered.
+  describe('Aggregate conflicts.json (t/3358)', () => {
+    const aggregatePath = join(conflictsDir, 'conflicts.json');
+
+    it('conflicts.json parses without errors against aggregateConflictsFileSchema', () => {
+      expect(existsSync(aggregatePath), `${aggregatePath} must exist`).toBe(true);
+      const data = JSON.parse(readFileSync(aggregatePath, 'utf8'));
+      const result = aggregateConflictsFileSchema.safeParse(data);
+      if (!result.success) {
+        const summary = result.error.issues
+          .slice(0, 10)
+          .map(i => `  ${i.path.join('.')}: ${i.message}`)
+          .join('\n');
+        expect.fail(
+          `conflicts.json fails aggregateConflictsFileSchema:\n${summary}` +
+          (result.error.issues.length > 10 ? `\n  ...and ${result.error.issues.length - 10} more` : ''),
+        );
+      }
+    });
+
+    it('rejects a seeded bad status (both-arms gate discipline)', () => {
+      expect(existsSync(aggregatePath), `${aggregatePath} must exist`).toBe(true);
+      const data = JSON.parse(readFileSync(aggregatePath, 'utf8'));
+      expect(data.conflicts?.length, 'live aggregate must have at least one conflict to seed').toBeGreaterThan(0);
+      const poisoned = { ...data, conflicts: [{ ...data.conflicts[0], status: 'bogus-status' }, ...data.conflicts.slice(1)] };
+      const result = aggregateConflictsFileSchema.safeParse(poisoned);
+      expect(result.success, 'a bogus status must fail the aggregate schema').toBe(false);
     });
   });
 });

--- a/taxonomy-editor/src/renderer/utils/validation.ts
+++ b/taxonomy-editor/src/renderer/utils/validation.ts
@@ -101,6 +101,8 @@ const conflictNoteSchema = z.object({
   note: z.string().min(1, 'Note is required'),
 });
 
+/** t/3358: LEGACY per-file schema — validates the 5 hand-authored `conflict-*.json` files only.
+ *  Do NOT point this at the aggregate `conflicts.json`; use `aggregateConflictsFileSchema` below. */
 export const conflictFileSchema = z.object({
   claim_id: z.string().min(1, 'Claim ID is required'),
   claim_label: z.string().min(1, 'Claim label is required'),
@@ -109,6 +111,74 @@ export const conflictFileSchema = z.object({
   linked_taxonomy_nodes: z.array(z.string()),
   instances: z.array(conflictInstanceSchema),
   human_notes: z.array(conflictNoteSchema),
+});
+
+// t/3358: looser instance shape for the aggregate — `date_flagged` is a legacy-file-only convention;
+// fork-B-merged instances lack it and sometimes carry temporal_scope/temporal_bound/attack_type instead.
+const aggregateConflictInstanceSchema = z.object({
+  doc_id: z.string().min(1, 'Document ID is required'),
+  stance: z.enum(['supports', 'disputes', 'neutral', 'qualifies'], { message: 'Stance is required' }),
+  assertion: z.string().min(1, 'Assertion is required'),
+  date_flagged: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Valid date is required').optional(),
+  temporal_scope: z.string().optional(),
+  temporal_bound: z.string().optional(),
+  attack_type: z.string().optional(),
+}).passthrough();
+
+// t/3358: the #2024 demotion write shape (scripts/demote_nonconflicts.py:79-82) — status flips to
+// 'demoted', claim_type is tagged, and this provenance block is attached (kept, never deleted).
+const aggregateDemotionSchema = z.object({
+  reason: z.string(),
+  source: z.string(),
+  ticket: z.string(),
+  reversible: z.boolean(),
+}).passthrough();
+
+// t/3358: QBAF subgraph — owned by the debate/QBAF engine (CL/PS), not this role, and its edge vocab
+// (edge_origin, symmetric, register, detector, confidence, tau, classifier, ...) is actively evolving.
+// Validated at STRUCTURE level only (nodes/edges are arrays of objects with the minimal linking fields)
+// rather than locking every field — see the net-not-gate note on aggregateConflictItemSchema below.
+const aggregateQbafSchema = z.object({
+  graph: z.object({
+    nodes: z.array(z.object({ id: z.string() }).passthrough()),
+    edges: z.array(z.object({ source: z.string(), target: z.string() }).passthrough()),
+  }).passthrough(),
+}).passthrough();
+
+/**
+ * t/3358: the AGGREGATE per-conflict shape (`conflicts.json`'s `conflicts[]`) — a superset of the
+ * legacy per-file shape covering fork-B census-merge fields (#2013) and the demotion write (#2024).
+ *
+ * NET, NOT GATE: `.passthrough()` here and on the nested QBAF/demotion/merge_provenance schemas means
+ * this arm catches enum drift, shape drift, and type drift (the failure class t/3352 surfaced), but it
+ * deliberately does NOT lock the full vocab of any nested object — an unmodeled field is accepted, not
+ * rejected. Don't mistake a green parse here for full-vocab validation of qbaf/merge_provenance/demotion.
+ */
+const aggregateConflictItemSchema = z.object({
+  claim_id: z.string().min(1, 'Claim ID is required'),
+  claim_label: z.string().min(1, 'Claim label is required'),
+  description: z.string().min(1, 'Description is required'),
+  // superset of the legacy statuses + fork-B ('active') + the demotion write ('demoted')
+  status: z.enum(['open', 'resolved', 'wont-fix', 'active', 'demoted']),
+  linked_taxonomy_nodes: z.array(z.string()),
+  instances: z.array(aggregateConflictInstanceSchema),
+  // legacy annotated array form, or the fork-B placeholder empty string
+  human_notes: z.union([z.string(), z.array(conflictNoteSchema)]),
+  claim_type: z.string().optional(),
+  claim_origin: z.string().optional(),
+  source: z.string().optional(),
+  source_debate_id: z.string().optional(),
+  merge_provenance: z.object({}).passthrough().optional(),
+  demotion: aggregateDemotionSchema.optional(),
+  qbaf: aggregateQbafSchema.optional(),
+}).passthrough();
+
+export const aggregateConflictsFileSchema = z.object({
+  _schema_version: z.string(),
+  _doc: z.string(),
+  last_modified: z.string(),
+  conflict_count: z.number().int(),
+  conflicts: z.array(aggregateConflictItemSchema),
 });
 
 export type ValidationErrors = Record<string, string>;


### PR DESCRIPTION
## t/3358 — aggregate conflicts.json had NO schema safety net

`validation.data.test.ts`'s conflict arm only covers the 5 legacy `conflict-*.json` files (`startsWith('conflict-')` excludes `conflicts.json`). The aggregate — the actual data-of-record the fork-B census merge (#2013) and the #2024 demotion write mutate — had zero CI schema check: the same single-context-validation/silent-degradation class t/3352 surfaced on the POV files.

### Design (TL-approved, t/3358#2)
**Sibling `aggregateConflictsFileSchema`, not extending `conflictFileSchema`.** The live aggregate shape diverges too far to share one schema without loosening `date_flagged`-required / `human_notes`-array-only — a real regression in the protection the 5 hand-authored legacy files have today. `conflictFileSchema` is now doc-commented legacy-per-file-only.

- **status**: superset `open|resolved|wont-fix|active|demoted`
- **human_notes**: `string | ConflictNote[]` (both genuinely live — empty-string placeholder vs. legacy annotated array)
- **instances**: looser shape, `date_flagged` optional (fork-B instances lack it)
- **optional** `claim_type`/`claim_origin`/`source`/`source_debate_id`/`merge_provenance`/`demotion` — `demotion` typed per `scripts/demote_nonconflicts.py:79-82`'s actual write shape
- **qbaf**: structure-level only (`graph.nodes[]`/`edges[]` arrays) — the vocab is CL/PS's, not locked here
- **net-not-gate documented** at `aggregateConflictItemSchema`: `.passthrough()` everywhere means this catches enum/shape/type drift but does not lock the full vocab of any nested object

### Tests (`validation.data.test.ts`, both-arms per gate discipline)
1. live `conflicts.json` parses clean against `aggregateConflictsFileSchema`
2. a seeded bad `status` fails the schema

### TL conditions status
1. **Second Opinion consult (t/3361)** — requesting now, before merge.
2. **Post-demotion re-verify of the positive arm before Done** — the #2024 demotion write hasn't run against the live data yet (0 `demoted` entries currently); I'll re-run the positive arm once it lands and confirm in the ticket before transitioning Done. Schema already accepts the `demoted` shape (built from the tool's write code, not guessed).
3. **Net-not-gate doc comment** — done, on `aggregateConflictItemSchema`.

### Verification
renderer tsc clean · eslint clean · utils vitest 215/215 (incl. both new arms).

Draft pending Second Opinion consult + TL review.

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>

🤖 Generated with [Claude Code](https://claude.com/claude-code)