### PR TITLE
feat(main): wire AI call log into generate-text IPC handler + fix scenario mislabel (t/3370)

### DIFF
--- a/taxonomy-editor/src/main/__tests__/aiHandlers.callLog.test.ts
+++ b/taxonomy-editor/src/main/__tests__/aiHandlers.callLog.test.ts
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Both-arms coverage for t/3370: the generate-text IPC handler must write an AI
+// call-log entry when AI_CALL_LOG_ENABLED is on, and must write nothing when it is
+// off. Uses the REAL writeAICallLogEntry (not mocked) against a temp data root so the
+// flag gate itself is exercised, not just "the handler calls the writer" — mirrors the
+// temp-dir pattern noted in AGENTS.md for modules that pull in electron.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { ipcMain } from 'electron';
+
+const mockGenerateText = vi.hoisted(() => vi.fn());
+
+vi.mock('../embeddings.js', () => ({
+  generateText: mockGenerateText,
+  generateChatStream: vi.fn(),
+  generateTextWithSearch: vi.fn(),
+  computeEmbeddings: vi.fn(),
+  computeQueryEmbedding: vi.fn(),
+  updateNodeEmbeddings: vi.fn(),
+  classifyNli: vi.fn(),
+  setDebateTemperature: vi.fn(),
+  getEmbeddingInfo: vi.fn(),
+}));
+
+vi.mock('../../../../lib/ai-client/index.js', () => ({
+  resolveBackend: vi.fn(() => 'gemini'),
+  DEFAULT_MODEL: 'gemini-2.0-flash',
+  DEFAULT_TEMPERATURE: 0.7,
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() },
+  app: { getPath: vi.fn(() => '/tmp'), getVersion: vi.fn(() => '1.0.0') },
+  safeStorage: { isEncryptionAvailable: vi.fn(() => false), encryptString: vi.fn(), decryptString: vi.fn() },
+}));
+
+let dataRoot: string;
+
+vi.mock('../fileIO.js', () => ({
+  PROJECT_ROOT: '/fake/root',
+  getDataRootPath: vi.fn(() => dataRoot),
+  resolveDataPath: vi.fn((p: string) => path.join(dataRoot, p)),
+}));
+
+vi.mock('../modelDiscovery.js', () => ({ refreshAIModels: vi.fn() }));
+vi.mock('../embeddingErrors.js', () => ({ buildEmbeddingFailureError: vi.fn() }));
+vi.mock('../../../../lib/debate/errors.js', () => ({ ActionableError: class extends Error {} }));
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({ getGlobalRecorder: vi.fn(() => null) }));
+vi.mock('../../../../lib/debate/constants.js', () => ({ DEFAULT_RELEVANCE_THRESHOLD: 0.5 }));
+vi.mock('../../../../lib/url-fetch/fetchUrlForPrompt.js', () => ({ fetchUrlForPrompt: vi.fn() }));
+
+import { registerAiHandlers } from '../ipc/aiHandlers.js';
+
+function getHandler(channel: string): (event: unknown, ...args: unknown[]) => Promise<unknown> {
+  const calls = (ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls;
+  const entry = calls.find((c: unknown[]) => c[0] === channel);
+  if (!entry) throw new Error(`${channel} handler not registered`);
+  return entry[1];
+}
+
+function makeSender() {
+  return { sender: { isDestroyed: () => false, send: vi.fn() } };
+}
+
+function readLogLines(): unknown[] {
+  const logPath = path.join(dataRoot, 'ai-call-log.jsonl');
+  if (!fs.existsSync(logPath)) return [];
+  return fs.readFileSync(logPath, 'utf-8').split('\n').filter(l => l.trim()).map(l => JSON.parse(l));
+}
+
+const ORIGINAL_FLAG = process.env.AI_CALL_LOG_ENABLED;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-call-log-t3370-'));
+  registerAiHandlers();
+});
+
+afterEach(() => {
+  fs.rmSync(dataRoot, { recursive: true, force: true });
+  if (ORIGINAL_FLAG === undefined) delete process.env.AI_CALL_LOG_ENABLED;
+  else process.env.AI_CALL_LOG_ENABLED = ORIGINAL_FLAG;
+});
+
+describe('generate-text — AI call log wiring (t/3370)', () => {
+  it('flag ON: logs 1 entry with scenario Debate on success', async () => {
+    process.env.AI_CALL_LOG_ENABLED = '1';
+    mockGenerateText.mockResolvedValue('ok');
+    const handler = getHandler('generate-text');
+    const { sender } = makeSender();
+    await handler({ sender }, 'prompt-text', undefined, undefined, undefined, 'req-log-1');
+
+    const lines = readLogLines() as Array<{ Scenario: string; PromptStart: string; Status: string }>;
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({ Scenario: 'Debate', PromptStart: 'prompt-text', Status: '200' });
+  });
+
+  it('flag ON: logs a non-200 status on failure', async () => {
+    process.env.AI_CALL_LOG_ENABLED = '1';
+    mockGenerateText.mockRejectedValue(new Error('boom'));
+    const handler = getHandler('generate-text');
+    const { sender } = makeSender();
+    await expect(handler({ sender }, 'prompt-text', undefined, undefined, undefined, 'req-log-2')).rejects.toThrow();
+
+    const lines = readLogLines() as Array<{ Scenario: string; Status: string }>;
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({ Scenario: 'Debate', Status: 'error' });
+  });
+
+  it('flag OFF (default): writes nothing', async () => {
+    delete process.env.AI_CALL_LOG_ENABLED;
+    mockGenerateText.mockResolvedValue('ok');
+    const handler = getHandler('generate-text');
+    const { sender } = makeSender();
+    await handler({ sender }, 'prompt-text', undefined, undefined, undefined, 'req-log-3');
+
+    expect(readLogLines()).toHaveLength(0);
+  });
+});

--- a/taxonomy-editor/src/main/__tests__/electronAIAdapter.test.ts
+++ b/taxonomy-editor/src/main/__tests__/electronAIAdapter.test.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3370 regression: makeElectronAIAdapter used to hardcode scenario: 'Debate' for all
+// three callers (debate, op-ed generation, brief export), mislabeling the non-debate
+// call-log entries. This asserts the scenario now comes from the caller-supplied param.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGenerateText = vi.hoisted(() => vi.fn());
+const mockWriteAICallLogEntry = vi.hoisted(() => vi.fn());
+
+vi.mock('../embeddings.js', () => ({ generateText: mockGenerateText }));
+vi.mock('../aiCallLog.js', () => ({ writeAICallLogEntry: mockWriteAICallLogEntry }));
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({ getGlobalRecorder: vi.fn(() => null) }));
+
+import { makeElectronAIAdapter } from '../electronAIAdapter.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('makeElectronAIAdapter — scenario parameterization (t/3370)', () => {
+  it('logs with the caller-supplied scenario, not a hardcoded "Debate"', async () => {
+    mockGenerateText.mockResolvedValue('generated text');
+    const adapter = makeElectronAIAdapter('OpEd Generation');
+    await adapter.generateText('a prompt', 'gemini-2.0-flash');
+
+    expect(mockWriteAICallLogEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ scenario: 'OpEd Generation', status: '200' }),
+    );
+  });
+
+  it('logs the same caller-supplied scenario on failure', async () => {
+    mockGenerateText.mockRejectedValue(new Error('boom'));
+    const adapter = makeElectronAIAdapter('Brief Export');
+    await expect(adapter.generateText('a prompt', 'gemini-2.0-flash')).rejects.toThrow();
+
+    expect(mockWriteAICallLogEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ scenario: 'Brief Export', status: 'error' }),
+    );
+  });
+
+  it('still supports the original Debate scenario for the debate engine caller', async () => {
+    mockGenerateText.mockResolvedValue('generated text');
+    const adapter = makeElectronAIAdapter('Debate');
+    await adapter.generateText('a prompt', 'gemini-2.0-flash');
+
+    expect(mockWriteAICallLogEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ scenario: 'Debate', status: '200' }),
+    );
+  });
+});

--- a/taxonomy-editor/src/main/electronAIAdapter.ts
+++ b/taxonomy-editor/src/main/electronAIAdapter.ts
@@ -9,10 +9,11 @@ import type { AIAdapter, GenerateOptions } from '../../../lib/debate/aiAdapter.j
 import { writeAICallLogEntry } from './aiCallLog.js';
 import { getGlobalRecorder } from '../../../lib/flight-recorder/index.js';
 
-// voiceTimeoutMs: caller-supplied fallback when opts.timeoutMs is absent
-// (wired from runtime-config opedVoiceTimeoutMs so the tunable timeout
-// governs Stage B LLM calls, not just Stage A source prep).
-export function makeElectronAIAdapter(voiceTimeoutMs?: number): AIAdapter {
+// scenario: the AI call log label for this adapter instance's caller (t/3370) — e.g.
+// 'Debate', 'OpEd Generation', 'Brief Export'. voiceTimeoutMs: caller-supplied fallback
+// when opts.timeoutMs is absent (wired from runtime-config opedVoiceTimeoutMs so the
+// tunable timeout governs Stage B LLM calls, not just Stage A source prep).
+export function makeElectronAIAdapter(scenario: string, voiceTimeoutMs?: number): AIAdapter {
   return {
     generateText: async (prompt: string, model: string, opts?: GenerateOptions): Promise<string> => {
       let retryCount = 0;
@@ -27,7 +28,7 @@ export function makeElectronAIAdapter(voiceTimeoutMs?: number): AIAdapter {
           opts?.signal,
           opts?.responseSchema,
         );
-        writeAICallLogEntry({ scenario: 'Debate', promptId: '', promptStart: prompt, retryCount, status: '200' });
+        writeAICallLogEntry({ scenario, promptId: '', promptStart: prompt, retryCount, status: '200' });
         return text;
       } catch (err) {
         getGlobalRecorder()?.record({
@@ -35,7 +36,7 @@ export function makeElectronAIAdapter(voiceTimeoutMs?: number): AIAdapter {
           message: 'electronAIAdapter: generateText failed — rethrowing to debate engine',
           error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
         });
-        writeAICallLogEntry({ scenario: 'Debate', promptId: '', promptStart: prompt, retryCount, status: 'error' });
+        writeAICallLogEntry({ scenario, promptId: '', promptStart: prompt, retryCount, status: 'error' });
         throw err;
       }
     },

--- a/taxonomy-editor/src/main/ipc/aiHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/aiHandlers.ts
@@ -21,6 +21,20 @@ import { DEFAULT_RELEVANCE_THRESHOLD } from '../../../../lib/debate/constants.js
 import { buildEmbeddingFailureError } from '../embeddingErrors.js';
 import { fetchUrlForPrompt } from '../../../../lib/url-fetch/fetchUrlForPrompt.js';
 import { extractHttpUrls } from '../../../../lib/url-fetch/extractHttpUrls.js';
+import { writeAICallLogEntry } from '../aiCallLog.js';
+
+// AI call-log status classifier (t/3370). Duplicated from src/server/ai/aiBackends.ts'
+// deriveCallLogStatus — that copy is unexported, and main-process code depending on
+// server code is the wrong dependency direction (separate deployment targets).
+function deriveCallLogStatus(err: unknown): string {
+  const e = err as { statusCode?: number; status?: number; name?: string; message?: string };
+  const code = e?.statusCode ?? e?.status;
+  if (typeof code === 'number' && Number.isFinite(code)) return String(code);
+  const msg = (e?.message ?? '').toLowerCase();
+  if (e?.name === 'AbortError' || msg.includes('abort')) return 'aborted';
+  if (msg.includes('timeout') || msg.includes('timed out')) return 'timeout';
+  return 'error';
+}
 
 // ── Per-request AbortController map (t/2509) ──────────────────────────────
 
@@ -161,12 +175,14 @@ export function registerAiHandlers(): void {
     const t0 = Date.now();
     const controller = requestId ? new AbortController() : undefined;
     if (requestId && controller) activeGenerations.set(requestId, controller);
+    let retryCount = 0;
     try {
-      return {
-        text: await generateText(prompt, model, (progress) => {
-          event.sender.send('generate-text-progress', progress);
-        }, timeoutMs, temperature, controller?.signal),
-      };
+      const text = await generateText(prompt, model, (progress) => {
+        retryCount = progress.attempt;
+        event.sender.send('generate-text-progress', progress);
+      }, timeoutMs, temperature, controller?.signal);
+      writeAICallLogEntry({ scenario: 'Debate', promptId: '', promptStart: prompt, retryCount, status: '200' });
+      return { text };
     } catch (err) {
       if ((err as Error).name === 'AbortError' || controller?.signal.aborted) {
         getGlobalRecorder()?.record({
@@ -176,6 +192,7 @@ export function registerAiHandlers(): void {
           message: 'ai.cancelled',
           data: { requestId, elapsed_ms: Date.now() - t0 },
         });
+        writeAICallLogEntry({ scenario: 'Debate', promptId: '', promptStart: prompt, retryCount, status: deriveCallLogStatus(err) });
         throw err;
       }
       const problem = err instanceof ActionableError ? err.problem : (err instanceof Error ? err.message : String(err));
@@ -187,6 +204,7 @@ export function registerAiHandlers(): void {
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
       console.error('[IPC] generate-text failed:', problem);
+      writeAICallLogEntry({ scenario: 'Debate', promptId: '', promptStart: prompt, retryCount, status: deriveCallLogStatus(err) });
       throw new ActionableError({
         goal: 'Generate text via AI backend',
         problem: `AI generation failed: ${problem}`,

--- a/taxonomy-editor/src/main/ipc/briefExportHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/briefExportHandlers.ts
@@ -214,7 +214,7 @@ async function runJob(job: BriefJob, body: BriefExportRequestBody): Promise<void
         toolVersions: TOOL_VERSIONS,
         timestamp: new Date().toISOString(),
       },
-      makeElectronAIAdapter(),
+      makeElectronAIAdapter('Brief Export'),
       (s) => { setState(job, s); stage = s; },
       (a: BriefArtifact) => { artifacts.push(a); },
     );

--- a/taxonomy-editor/src/main/ipc/opedHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/opedHandlers.ts
@@ -345,7 +345,7 @@ export function registerOpEdHandlers(): void {
     };
 
     const deps: OpEdGeneratorDeps = {
-      adapter: makeElectronAIAdapter(getVoiceTimeoutMs()),
+      adapter: makeElectronAIAdapter('OpEd Generation', getVoiceTimeoutMs()),
       promptsDir: PROMPTS_DIR,
       repoRoot: PROJECT_ROOT,
     };


### PR DESCRIPTION
## Summary

TL-approved design (t/3369#1, p/356#18). Parent: t/3369 (Rosetta Stone).

- `aiHandlers.ts` `generate-text` handler now calls `writeAICallLogEntry` on both success and failure — this is the path every renderer debate/analysis call goes through via the bridge, and it previously produced zero AI-call-log records even with `AI_CALL_LOG_ENABLED` on.
- Added a local `deriveCallLogStatus` classifier in `src/main/` (duplicated from the unexported server-side `aiBackends.ts` version — main can't depend on server code, separate deployment targets).
- `electronAIAdapter.ts` no longer hardcodes `scenario: 'Debate'` — `makeElectronAIAdapter(scenario, voiceTimeoutMs?)` takes the caller's scenario. `opedHandlers.ts` → `'OpEd Generation'`, `briefExportHandlers.ts` → `'Brief Export'`.

## Test plan

- [x] `aiHandlers.callLog.test.ts` — flag ON logs 1 entry (success + failure arms), flag OFF writes nothing. Uses the real `writeAICallLogEntry` against a temp data root (not mocked) so the flag gate itself is exercised.
- [x] `electronAIAdapter.test.ts` — regression: adapter logs under the caller-supplied scenario, not a hardcoded `'Debate'`.
- [x] Existing `opedHandlers.*.test.ts` / `briefExportHandlers.test.ts` (mocked adapter) still pass.
- [x] `tsc -p tsconfig.main.json` — no new errors introduced.

Closes t/3370.

🤖 Generated with [Claude Code](https://claude.com/claude-code)