### PR TITLE
fix(qbaf): maintain conflicts.json conflict_count invariant in both appliers (t/3368)

### DIFF
--- a/scripts/apply_semantic_merge.py
+++ b/scripts/apply_semantic_merge.py
@@ -162,6 +162,8 @@ def main():
     print(f"COLLATERAL (unexpected changes to untouched conflicts): {'ZERO' if not collateral else collateral}")
     print(f"VERIFIED-CLEAN: {'YES' if clean else 'NO — DO NOT PUSH'}")
 
+    doc["conflict_count"] = len(doc["conflicts"])   # t/3368: wrapper counter tracks true length on every write
+
     if args.write:
         if not clean:
             print("Refusing --write: not verified-clean.", file=sys.stderr); return 2

--- a/scripts/demote_nonconflicts.py
+++ b/scripts/demote_nonconflicts.py
@@ -104,6 +104,8 @@ def main():
     print(f"COLLATERAL (untouched changed): {'ZERO' if not collateral else collateral[:5]}")
     print(f"VERIFIED-CLEAN: {'YES' if clean else 'NO — DO NOT PUSH'}")
 
+    doc["conflict_count"] = len(doc["conflicts"])   # t/3368: wrapper counter tracks true length on every write
+
     if args.write:
         if not clean:
             print("Refusing --write: not verified-clean (missing/refused/collateral).", file=sys.stderr)

--- a/scripts/test_apply_semantic_merge.py
+++ b/scripts/test_apply_semantic_merge.py
@@ -87,7 +87,7 @@ def test_write_refused_when_manifest_id_missing(tmp_path, monkeypatch):
     assert m.main() == 2  # refuses --write when not verified-clean (missing manifest id)
 
 
-def test_conflict_count_invariant_maintained(tmp_path, monkeypatch):
+def test_conflict_count_invariant_maintained(tmp_path, monkeypatch, capsys):
     # t/3368: the wrapper counter must equal len(conflicts) after write — corrects a stale value
     # (the fork-B applier appended xmerge conflicts without bumping it: 1240 vs 1252).
     corpus = {"conflict_count": 99, "conflicts": [
@@ -103,6 +103,7 @@ def test_conflict_count_invariant_maintained(tmp_path, monkeypatch):
                         lambda graphs: [{"strengths": {}, "iterations": 1} for g in graphs])
     monkeypatch.setattr(sys, "argv", ["apply", "--conflicts", str(cpath), "--manifest", str(mpath), "--out", str(opath)])
     assert m.main() == 0
+    assert "VERIFIED-CLEAN: YES" in capsys.readouterr().out  # counter update coexists with the 0-collateral verifier (t/3368#2)
     out = json.load(open(opath, encoding="utf-8"))
     assert out["conflict_count"] == len(out["conflicts"]) == 2  # 1 original + 1 xmerge; corrected from 99
 

--- a/scripts/test_apply_semantic_merge.py
+++ b/scripts/test_apply_semantic_merge.py
@@ -87,6 +87,26 @@ def test_write_refused_when_manifest_id_missing(tmp_path, monkeypatch):
     assert m.main() == 2  # refuses --write when not verified-clean (missing manifest id)
 
 
+def test_conflict_count_invariant_maintained(tmp_path, monkeypatch):
+    # t/3368: the wrapper counter must equal len(conflicts) after write — corrects a stale value
+    # (the fork-B applier appended xmerge conflicts without bumping it: 1240 vs 1252).
+    corpus = {"conflict_count": 99, "conflicts": [
+        {"claim_id": "c1", "instances": [{"a": 1}, {"a": 2}],
+         "qbaf": {"graph": {"nodes": [{"id": "inst-0"}, {"id": "inst-1"}], "edges": []}}}]}
+    manifest = {"_meta": {"tau": 0.90}, "same_doc": [],
+                "cross_conflict": [{"pair_id": "xc-1", "stance_conflict_id": "sc", "stance_text": "A",
+                                    "cand_conflict_id": "cc", "cand_inst_idx": 0, "cand_text": "B",
+                                    "confidence": 0.92}]}
+    cpath = tmp_path / "c.json"; mpath = tmp_path / "m.json"; opath = tmp_path / "o.json"
+    _write(cpath, corpus); _write(mpath, manifest)
+    monkeypatch.setattr(m, "_run_bridge_batch",
+                        lambda graphs: [{"strengths": {}, "iterations": 1} for g in graphs])
+    monkeypatch.setattr(sys, "argv", ["apply", "--conflicts", str(cpath), "--manifest", str(mpath), "--out", str(opath)])
+    assert m.main() == 0
+    out = json.load(open(opath, encoding="utf-8"))
+    assert out["conflict_count"] == len(out["conflicts"]) == 2  # 1 original + 1 xmerge; corrected from 99
+
+
 if __name__ == "__main__":
     import pytest
     sys.exit(pytest.main([__file__, "-v"]))

--- a/scripts/test_demote_nonconflicts.py
+++ b/scripts/test_demote_nonconflicts.py
@@ -73,7 +73,7 @@ def test_write_refused_when_not_clean(tmp_path, monkeypatch):
     assert dm.main() == 2  # refuses --write when not verified-clean
 
 
-def test_conflict_count_invariant_maintained(tmp_path, monkeypatch):
+def test_conflict_count_invariant_maintained(tmp_path, monkeypatch, capsys):
     # t/3368: reclassify-in-place doesn't change len, but the write still corrects a stale counter.
     corpus = {"conflict_count": 99, "conflicts": [
         {"claim_id": "c-fact", "status": "open", "instances": [{"a": 1}],
@@ -84,6 +84,7 @@ def test_conflict_count_invariant_maintained(tmp_path, monkeypatch):
     _write(cpath, corpus); _write(lpath, {"standalone_facts": [{"conflict_id": "c-fact"}]})
     monkeypatch.setattr(sys, "argv", ["dm", "--list", str(lpath), "--conflicts", str(cpath), "--out", str(opath)])
     assert dm.main() == 0
+    assert "VERIFIED-CLEAN: YES" in capsys.readouterr().out  # counter update coexists with the 0-collateral verifier (t/3368#2)
     out = json.load(open(opath, encoding="utf-8"))
     assert out["conflict_count"] == len(out["conflicts"]) == 2  # reclassify keeps len; corrected from 99
 

--- a/scripts/test_demote_nonconflicts.py
+++ b/scripts/test_demote_nonconflicts.py
@@ -73,6 +73,21 @@ def test_write_refused_when_not_clean(tmp_path, monkeypatch):
     assert dm.main() == 2  # refuses --write when not verified-clean
 
 
+def test_conflict_count_invariant_maintained(tmp_path, monkeypatch):
+    # t/3368: reclassify-in-place doesn't change len, but the write still corrects a stale counter.
+    corpus = {"conflict_count": 99, "conflicts": [
+        {"claim_id": "c-fact", "status": "open", "instances": [{"a": 1}],
+         "qbaf": {"graph": {"nodes": [{"id": "inst-0"}], "edges": []}}},
+        {"claim_id": "c-keep", "status": "open", "instances": [{"a": 9}],
+         "qbaf": {"graph": {"nodes": [{"id": "inst-0"}], "edges": []}}}]}
+    cpath = tmp_path / "c.json"; lpath = tmp_path / "l.json"; opath = tmp_path / "o.json"
+    _write(cpath, corpus); _write(lpath, {"standalone_facts": [{"conflict_id": "c-fact"}]})
+    monkeypatch.setattr(sys, "argv", ["dm", "--list", str(lpath), "--conflicts", str(cpath), "--out", str(opath)])
+    assert dm.main() == 0
+    out = json.load(open(opath, encoding="utf-8"))
+    assert out["conflict_count"] == len(out["conflicts"]) == 2  # reclassify keeps len; corrected from 99
+
+
 if __name__ == "__main__":
     import pytest
     sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Bug (Rosetta Stone t/3358#1): the fork-B applier appended 12 xmerge conflicts without bumping the aggregate wrapper's `conflict_count` (1240 vs 1252 actual).

**Fix (Part 2, invariant):** both appliers set `doc["conflict_count"] = len(doc["conflicts"])` right before the write/dry-run dump — the counter tracks true length on every aggregate mutation. Test arm in each suite (10 pytest green). Self-cert /trivial-change (single-scope, existing-field maintenance, no data-model change).

**Sequencing (folds Part 1):** with the invariant in `demote_nonconflicts.py`, the just-released #2024 demotion `--write` will itself set `conflict_count=1252` — fixing the live 1240 drift in that single write, so no standalone data touch-up is needed. Part 3 (Rosetta refine on the aggregate schema, t/3358) unblocks once the live counter is correct. Flagged the fold-vs-separate choice on t/3368#1; fold is fewer data writes for the same end state.

Code only — no data written. Routing to Quality (TL) for GV since it changes data-write-tool behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)