### PR TITLE
fix(debate-workspace): always show greatest-hits state in Debate Setup (t/3356)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateSetupDialog.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateSetupDialog.tsx
@@ -291,12 +291,10 @@ export function DebateSetupDialog({
                 </dd>
               </Fragment>
             )}
-            {activeDebate.exclude_greatest_hits && (
-              <Fragment>
-                <dt className="dsd-setup-dt">Greatest hits</dt>
-                <dd className="dsd-setup-dd">excluded</dd>
-              </Fragment>
-            )}
+            <Fragment>
+              <dt className="dsd-setup-dt">Greatest hits</dt>
+              <dd className="dsd-setup-dd">{activeDebate.exclude_greatest_hits ? 'excluded' : 'included'}</dd>
+            </Fragment>
           </dl>
           {hasDistinctStageModels && (
             <details style={{ marginTop: 10 }}>


### PR DESCRIPTION
## Summary
- Follow-up to #2027: the SETUP row only rendered when `exclude_greatest_hits` was `true`, so "included" debates (and legacy debates with the field absent) still showed no row — the exact invisibility t/3356 was filed to fix.
- Now always renders "Greatest hits: excluded" or "included" (absent coalesces to `false` -> included, per t/3356#1).

## Test plan
- [x] `npx vitest run src/renderer/components/debate-workspace/` - 268/268 passed
- [x] Manual diff review - single ternary change, no other behavior touched

t/3356

Co-Authored-By: DebateWorkspace (Orca) <main.taxonomy-editor-src-renderer-components-debate-workspace@ai-triad-research.orca.local>