### PR TITLE
fix(devops): env-reconcile cond-1 tests + cond-3 membership-superset guard (t/3345 Phase-2 prereqs)

### DIFF
--- a/operations/devops/Sync-StagingEnv.ps1
+++ b/operations/devops/Sync-StagingEnv.ps1
@@ -42,11 +42,16 @@ $getEnvArgsNamesOnly = @{ BicepPath = $BicepPath; NamesOnly = $true }
 if ($isStaging) { $getEnvArgsNamesOnly['ForStaging'] = $true }
 $ManagedNames = & (Join-Path $PSScriptRoot 'Get-BicepBaseEnv.ps1') @getEnvArgsNamesOnly
 
-# Fail-closed: NamesOnly must be a strict superset of the literal-value set.
-# If it isn't, the bicep parse is broken — abort rather than risk mass-wiping env vars. (t/3345)
-if ($null -eq $ManagedNames -or $ManagedNames.Count -eq 0 -or $ManagedNames.Count -lt $BicepEnv.Count) {
-    Write-Error ("Get-BicepBaseEnv.ps1 -NamesOnly returned $($ManagedNames.Count) names but the " +
-        "literal-value pass returned $($BicepEnv.Count) — NamesOnly must be a superset. " +
+# Fail-closed: NamesOnly MUST contain EVERY literal-value key (a membership superset), not merely a
+# larger COUNT. A count check passes when a dropped literal key is offset by a spurious non-literal
+# match — and then that dropped key would be treated as an orphan and deleted live. So require every
+# $BicepEnv key ∈ $ManagedNames; if any is missing (or the set is empty), the bicep parse is broken
+# → ABORT rather than risk a mass-wipe of env vars. (t/3345, TL cond-3 t/3345#8)
+$missingFromManaged = @($BicepEnv.Keys | Where-Object { $_ -notin $ManagedNames })
+if ($null -eq $ManagedNames -or $ManagedNames.Count -eq 0 -or $missingFromManaged.Count -gt 0) {
+    Write-Error ("Get-BicepBaseEnv.ps1 -NamesOnly failed the membership-superset guard: " +
+        "$($ManagedNames.Count) name(s) returned; literal key(s) missing from the managed-name set: " +
+        "[$($missingFromManaged -join ', ')]. NamesOnly must contain every literal key. " +
         "Aborting reconcile to prevent mass-wipe of env vars. (t/3345)")
     exit 1
 }

--- a/tests/StagingEnvSync.Tests.ps1
+++ b/tests/StagingEnvSync.Tests.ps1
@@ -84,4 +84,35 @@ Describe 'Sync-StagingEnv' {
             -PassThru -Wait -NoNewWindow
         $proc.ExitCode | Should -Be 0
     }
+
+    It 'cond-1 REAL az shape: secret-backed key {secretRef, value:""} is excluded from orphans (t/3345)' {
+        # secret-realshape-env.json matches bicep literals + ROGUE_SECRET as
+        # {secretRef:'rogue-secret', value:''} — the REAL az output shape (empty-STRING value, not a
+        # missing value field). The original bug: the value-presence filter let this into CurrentMap →
+        # flagged it a (non-bicep) orphan. The secretRef-non-empty exclusion must skip it → no orphan,
+        # no drift → exit 0. Regression guard for the t/3345#5 over-match (this shape, not the mock's).
+        $envRealSecret = Join-Path $fixtureDir 'secret-realshape-env.json'
+        $proc = Start-Process pwsh `
+            -ArgumentList '-NonInteractive', '-File', $syncScript,
+                          '-BicepPath',           $bicepFixture,
+                          '-MockCurrentEnvPath',  $envRealSecret,
+                          '-DryRun' `
+            -PassThru -Wait -NoNewWindow
+        $proc.ExitCode | Should -Be 0
+    }
+
+    It 'cond-2 allowlist: workflow-managed DEPLOY_TAG/DEPLOY_SHA are not flagged as orphans (t/3345)' {
+        # deploy-metadata-env.json matches bicep literals + DEPLOY_TAG/DEPLOY_SHA (plain values set at
+        # deploy time, never in bicep). The $WorkflowManagedKeys allowlist must exclude them from the
+        # orphan set → no orphan, no drift → exit 0. Guards against a regression that drops the allowlist
+        # and would delete live deploy metadata under Phase-2. (t/3345#5 / #6)
+        $envDeployMeta = Join-Path $fixtureDir 'deploy-metadata-env.json'
+        $proc = Start-Process pwsh `
+            -ArgumentList '-NonInteractive', '-File', $syncScript,
+                          '-BicepPath',           $bicepFixture,
+                          '-MockCurrentEnvPath',  $envDeployMeta,
+                          '-DryRun' `
+            -PassThru -Wait -NoNewWindow
+        $proc.ExitCode | Should -Be 0
+    }
 }

--- a/tests/fixtures/staging-env-sync/deploy-metadata-env.json
+++ b/tests/fixtures/staging-env-sync/deploy-metadata-env.json
@@ -1,0 +1,10 @@
+[
+  { "name": "AI_TRIAD_DATA_ROOT",   "value": "/mnt/shared" },
+  { "name": "TAXONOMY_CACHE_DIR",   "value": "/mnt/shared" },
+  { "name": "HOME",                 "value": "/home/aitriad" },
+  { "name": "NODE_ENV",             "value": "production" },
+  { "name": "WEBSITE_AUTH_ENABLED", "value": "true" },
+  { "name": "AZURE_KEYVAULT_URL",   "secretRef": "kv-url" },
+  { "name": "DEPLOY_TAG",           "value": "latest" },
+  { "name": "DEPLOY_SHA",           "value": "abc1234def5678" }
+]

--- a/tests/fixtures/staging-env-sync/secret-realshape-env.json
+++ b/tests/fixtures/staging-env-sync/secret-realshape-env.json
@@ -1,0 +1,9 @@
+[
+  { "name": "AI_TRIAD_DATA_ROOT",   "value": "/mnt/shared" },
+  { "name": "TAXONOMY_CACHE_DIR",   "value": "/mnt/shared" },
+  { "name": "HOME",                 "value": "/home/aitriad" },
+  { "name": "NODE_ENV",             "value": "production" },
+  { "name": "WEBSITE_AUTH_ENABLED", "value": "true" },
+  { "name": "AZURE_KEYVAULT_URL",   "secretRef": "kv-url" },
+  { "name": "ROGUE_SECRET",         "secretRef": "rogue-secret", "value": "" }
+]


### PR DESCRIPTION
**Closes the two remaining Phase-2 GV-bar items (TL t/3345#8).** Keeps the script **warn-only** — no live `--remove-env-vars`; the flip stays a separate gated step (TL GV of this PR → mandatory Second-Opinion consult t/3345#10 → flip).

**cond-3 — membership-superset guard:** replaced the fail-closed COUNT check (`ManagedNames.Count -lt BicepEnv.Count`) with a MEMBERSHIP check — abort iff any literal `BicepEnv` key ∉ `ManagedNames` (a dropped literal key offset by a spurious non-literal match passes a count check, then gets deleted live).

**cond-1 — both-arms tests on the REAL az output shape** (the mock-shape gap behind t/3345#5):
- `secret-realshape-env.json`: secret-backed `{secretRef:'x', value:''}` (empty-STRING value) → excluded → exit 0.
- `deploy-metadata-env.json`: `DEPLOY_TAG`/`DEPLOY_SHA` (allowlist) → not orphaned → exit 0.
- **StagingEnvSync 7/7 green** (existing plain-value orphan test = the "flagged" arm).

**Deviation flagged:** the superset-ABORT arm isn't unit-forced — the `-NamesOnly` regex (`{ name:'X'`) is a strict prefix of the literal regex, so NamesOnly ⊇ literal by construction; a divergence needs parse breakage, not constructible with a well-formed bicep. Guard passes on real `good-main.bicep` (regression sentinel); abort arm logic-reviewed.

**@TL** — routing for the Phase-2 GV (cond-1 + cond-3 closure). Non-destructive; the live-removal flip + SO consult remain the separate final step.