### PR TITLE
test(devops): extract superset guard to pure function + both-arms test (t/3345 flip-gate)

### DIFF
--- a/operations/devops/Sync-StagingEnv.ps1
+++ b/operations/devops/Sync-StagingEnv.ps1
@@ -42,16 +42,16 @@ $getEnvArgsNamesOnly = @{ BicepPath = $BicepPath; NamesOnly = $true }
 if ($isStaging) { $getEnvArgsNamesOnly['ForStaging'] = $true }
 $ManagedNames = & (Join-Path $PSScriptRoot 'Get-BicepBaseEnv.ps1') @getEnvArgsNamesOnly
 
-# Fail-closed: NamesOnly MUST contain EVERY literal-value key (a membership superset), not merely a
-# larger COUNT. A count check passes when a dropped literal key is offset by a spurious non-literal
-# match — and then that dropped key would be treated as an orphan and deleted live. So require every
-# $BicepEnv key ∈ $ManagedNames; if any is missing (or the set is empty), the bicep parse is broken
-# → ABORT rather than risk a mass-wipe of env vars. (t/3345, TL cond-3 t/3345#8)
-$missingFromManaged = @($BicepEnv.Keys | Where-Object { $_ -notin $ManagedNames })
-if ($null -eq $ManagedNames -or $ManagedNames.Count -eq 0 -or $missingFromManaged.Count -gt 0) {
+# Fail-closed membership-superset guard (t/3345, TL cond-3 t/3345#8): NamesOnly MUST contain EVERY
+# literal-value key — not merely a larger COUNT (a dropped literal key offset by a spurious
+# non-literal match passes a count check, then gets deleted live). The set-logic is the pure,
+# directly-tested Test-ManagedNamesSuperset (t/2971 Guard Testability, TL t/3345#14).
+. (Join-Path $PSScriptRoot 'Test-ManagedNamesSuperset.ps1')
+$supersetVerdict = Test-ManagedNamesSuperset -LiteralKeys @($BicepEnv.Keys) -ManagedNames $ManagedNames
+if (-not $supersetVerdict.Ok) {
     Write-Error ("Get-BicepBaseEnv.ps1 -NamesOnly failed the membership-superset guard: " +
-        "$($ManagedNames.Count) name(s) returned; literal key(s) missing from the managed-name set: " +
-        "[$($missingFromManaged -join ', ')]. NamesOnly must contain every literal key. " +
+        "$(@($ManagedNames).Count) name(s) returned; literal key(s) missing from the managed-name set: " +
+        "[$($supersetVerdict.Missing -join ', ')]. NamesOnly must contain every literal key. " +
         "Aborting reconcile to prevent mass-wipe of env vars. (t/3345)")
     exit 1
 }

--- a/operations/devops/Test-ManagedNamesSuperset.ps1
+++ b/operations/devops/Test-ManagedNamesSuperset.ps1
@@ -1,0 +1,40 @@
+<#
+.SYNOPSIS
+    Pure predicate for the env-reconcile fail-closed guard (t/3345, TL t/3345#14).
+
+.DESCRIPTION
+    Decides whether the bicep-managed NAME set (`-NamesOnly` pass) is a safe superset of the
+    literal-value key set. The reconcile in Sync-StagingEnv.ps1 deletes any live env key NOT in
+    the managed-name set, so if a literal key were missing from that set it would be wrongly
+    orphaned and DELETED live. This predicate is the fail-closed gate: it must hold before any
+    removal runs.
+
+    Extracted as a PURE function (t/2971 Guard Testability): the abort arm is not forceable in the
+    script itself — the `-NamesOnly` regex (`{ name: 'X'`) is a strict prefix of the literal regex
+    (`{ name: 'X', value: '…'`), so a real well-formed bicep can never make NamesOnly miss a literal
+    key. Extracting the set-logic lets both arms be proven directly with CONSTRUCTED sets.
+
+.OUTPUTS
+    [pscustomobject] @{ Ok = [bool]; Missing = [string[]] }
+      Ok=$true  → every literal key is present in ManagedNames (and ManagedNames is non-empty) → safe.
+      Ok=$false → ManagedNames is empty, or one or more literal keys are absent (Missing lists them)
+                  → the caller MUST abort the reconcile (fail-closed).
+#>
+function Test-ManagedNamesSuperset {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [string[]] $LiteralKeys,
+        [Parameter(Mandatory)] [AllowNull()] [AllowEmptyCollection()] [string[]] $ManagedNames
+    )
+    $names = @($ManagedNames)
+    # Empty managed-name set = broken parse → never safe (would orphan everything).
+    if ($names.Count -eq 0) {
+        return [pscustomobject]@{ Ok = $false; Missing = @($LiteralKeys) }
+    }
+    # Membership (NOT count): every literal key must appear in the managed-name set. A count check
+    # passes when a dropped literal key is offset by a spurious non-literal match — then the dropped
+    # key gets deleted live. Collect the specific offenders for a diagnosable abort message.
+    $missing = @($LiteralKeys | Where-Object { $_ -notin $names })
+    return [pscustomobject]@{ Ok = ($missing.Count -eq 0); Missing = $missing }
+}

--- a/tests/ManagedNamesSuperset.Tests.ps1
+++ b/tests/ManagedNamesSuperset.Tests.ps1
@@ -1,0 +1,62 @@
+#Requires -Modules Pester
+<#
+.SYNOPSIS
+    Direct both-arms proof for the env-reconcile fail-closed superset guard (t/3345, TL t/3345#14).
+
+    The abort arm is not forceable through Sync-StagingEnv.ps1 with a real bicep — the -NamesOnly
+    regex is a strict prefix of the literal regex, so NamesOnly is always a superset of the literal
+    set (t/2971 Guard Testability gap flagged at t/3345#13). Extracting Test-ManagedNamesSuperset as
+    a pure function lets both arms be proven directly with CONSTRUCTED sets, no bicep/Azure needed.
+#>
+
+Describe 'Test-ManagedNamesSuperset' {
+    BeforeAll {
+        $scriptRoot = Split-Path $PSScriptRoot -Parent
+        . (Join-Path $scriptRoot 'operations/devops/Test-ManagedNamesSuperset.ps1')
+    }
+
+    It 'OK arm: proper superset (ManagedNames ⊋ LiteralKeys) → Ok, no Missing' {
+        $v = Test-ManagedNamesSuperset -LiteralKeys @('A', 'B') -ManagedNames @('A', 'B', 'C', 'D')
+        $v.Ok | Should -BeTrue
+        @($v.Missing).Count | Should -Be 0
+    }
+
+    It 'OK arm: equal sets → Ok' {
+        (Test-ManagedNamesSuperset -LiteralKeys @('A', 'B') -ManagedNames @('B', 'A')).Ok | Should -BeTrue
+    }
+
+    It 'OK arm: empty LiteralKeys with non-empty ManagedNames → Ok (nothing to protect)' {
+        (Test-ManagedNamesSuperset -LiteralKeys @() -ManagedNames @('A')).Ok | Should -BeTrue
+    }
+
+    It 'ABORT arm: one literal key missing → not Ok, Missing names it' {
+        $v = Test-ManagedNamesSuperset -LiteralKeys @('A', 'B', 'C') -ManagedNames @('A', 'C')
+        $v.Ok | Should -BeFalse
+        $v.Missing | Should -Be @('B')
+    }
+
+    It 'ABORT arm: multiple missing → Missing lists all offenders' {
+        $v = Test-ManagedNamesSuperset -LiteralKeys @('A', 'B', 'C', 'D') -ManagedNames @('A')
+        $v.Ok | Should -BeFalse
+        ($v.Missing | Sort-Object) | Should -Be @('B', 'C', 'D')
+    }
+
+    It 'ABORT arm: empty ManagedNames (broken parse) → not Ok, Missing = all literal keys' {
+        $v = Test-ManagedNamesSuperset -LiteralKeys @('A', 'B') -ManagedNames @()
+        $v.Ok | Should -BeFalse
+        ($v.Missing | Sort-Object) | Should -Be @('A', 'B')
+    }
+
+    It 'ABORT arm: null ManagedNames → not Ok (never treat a broken parse as safe)' {
+        (Test-ManagedNamesSuperset -LiteralKeys @('A') -ManagedNames $null).Ok | Should -BeFalse
+    }
+
+    It 'The count-check trap: a dropped literal key OFFSET by a spurious extra name — count-equal but NOT a superset' {
+        # LiteralKeys and ManagedNames are the SAME size (3), so the old count check
+        # ($ManagedNames.Count -lt $BicepEnv.Count) would PASS — but 'B' is missing and 'X' is spurious.
+        # Membership correctly aborts. This is the exact failure the count check let through.
+        $v = Test-ManagedNamesSuperset -LiteralKeys @('A', 'B', 'C') -ManagedNames @('A', 'C', 'X')
+        $v.Ok | Should -BeFalse
+        $v.Missing | Should -Be @('B')
+    }
+}


### PR DESCRIPTION
**Closes the t/2971 deviation** flagged at t/3345#13 — the TL flip-gate item (t/3345#14). The fail-closed membership-superset guard's ABORT arm wasn't forceable through Sync-StagingEnv.ps1 with a real bicep (the `-NamesOnly` regex is a strict prefix of the literal regex → NamesOnly ⊇ literal by construction). Extracting the set-logic makes both arms directly testable.

- `Test-ManagedNamesSuperset.ps1` — pure fn `({LiteralKeys, ManagedNames} → {Ok, Missing})`; membership not count.
- `Sync-StagingEnv.ps1` — dot-source + call it (behavior identical; **still warn-only**, no live removal).
- `ManagedNamesSuperset.Tests.ps1` — 8 direct both-arms tests (constructed sets), incl. the **count-check trap** (dropped literal key offset by a spurious name → count-equal but not a superset → aborts) — the exact failure the old count check let through.

**15/15 green** (8 predicate + 7 StagingEnvSync unchanged). Self-cert /add-ps-cmdlet. **@TL: flip-gate GV** — with this, the flip sequence is: GV → SO consult (t/3345#10) → live-removal flip.