### PR TITLE
feat(debate): add debate_grounding field to GraphAttributes type (t/3367)

### DIFF
--- a/lib/debate/taxonomyTypes.ts
+++ b/lib/debate/taxonomyTypes.ts
@@ -42,6 +42,10 @@ export interface GraphAttributes {
   node_scope?: 'claim' | 'scheme' | 'bridging';
   attribution_text?: string;
   aphorism?: string;
+  /** First-person present-tense own-voice declarative restatement of the node claim (1-2 sentences).
+   *  Debate-grounding register (t/3367). Absent on most nodes until backfill (t/3366); loader treats
+   *  absence as normal and falls back to description, as today. */
+  debate_grounding?: string;
   _phrase_regen_pending?: boolean;
   debate_tested?: DebateTestedRecord;
   /** Data-integrity provenance signal (t/3264). Absent = 'curated'. Used by formatTaxonomyContext


### PR DESCRIPTION
## Summary

- Adds `debate_grounding?: string` to `interface GraphAttributes` in `lib/debate/taxonomyTypes.ts`
- Field is the first-person present-tense own-voice declarative restatement of a node claim (1-2 sentences), contracted by CL in t/3367#1
- No loader code change needed — `graph_attributes` is already passed through verbatim from JSON
- No behavioral change to debate output; field is loaded but not yet rendered (render change is CL's, gated on t/3357)
- Field will be absent on nearly all nodes until corpus backfill runs (t/3366); absence is normal

## Test plan

- [x] `npx vitest run` — 128 test files passed, 3073 tests passed (0 failures) at commit db867d45
- [x] No new exports, no new bridge methods, no auth surface changes
- [x] Additive optional field; no existing consumers broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015k3EvDwMShv7847rNchawk