### PR TITLE
feat(embeddings): poolStats() getter + WORKER_POOL_SHED_CODE marker (t/3374)

### DIFF
--- a/lib/embeddings/offThreadEmbedding.test.ts
+++ b/lib/embeddings/offThreadEmbedding.test.ts
@@ -38,6 +38,9 @@ import {
   __resetEmbeddingWorkerForTests,
   __queueDepthForTests,
   __poolSizeForTests,
+  poolStats,
+  isWorkerPoolShedError,
+  WORKER_POOL_SHED_CODE,
   type EmbeddingWorkerLike,
 } from './offThreadEmbedding.js';
 import * as onnx from './onnxEmbedding.js';
@@ -324,6 +327,63 @@ describe('offThreadEmbedding — pool: aggregate shed at MAX_QUEUE_DEPTH × K', 
     expect(shedWarn!.data?.queueDepth).toBe(32);
     expect(shedWarn!.data?.max).toBe(32); // scaled ×K, not the base 16
     void pending;
+  });
+});
+
+describe('offThreadEmbedding — t/3374: poolStats() getter + WORKER_POOL_SHED_CODE marker (for t/3373)', () => {
+  it('poolStats() reports queueDepth + the dynamic cap (MAX_QUEUE_DEPTH × liveSlots)', () => {
+    // Fresh pool, no requests: depth 0, live = nominal pool size, cap = 16 × liveSlots.
+    const fresh = poolStats();
+    expect(fresh.queueDepth).toBe(0);
+    expect(fresh.liveSlots).toBe(__poolSizeForTests());
+    expect(fresh.cap).toBe(16 * fresh.liveSlots);
+  });
+
+  it('poolStats().queueDepth tracks residents as the queue fills (matches __queueDepthForTests)', () => {
+    const w = new FakeWorker(); // never replies → tasks stay resident
+    __setEmbeddingWorkerFactory(() => w);
+    const pending: Promise<unknown>[] = [];
+    for (let i = 0; i < 5; i++) pending.push(computeEmbeddingsOffThread(['x'], { requester: `fill-${i}` }).catch(() => {}));
+
+    const stats = poolStats();
+    expect(stats.queueDepth).toBe(5);
+    expect(stats.queueDepth).toBe(__queueDepthForTests());
+    expect(stats.cap).toBe(16 * stats.liveSlots); // cap stays the dynamic product
+    void pending;
+  });
+
+  it('a queue-full shed error carries the WORKER_POOL_SHED_CODE + passes isWorkerPoolShedError', async () => {
+    const w = new FakeWorker();
+    __setEmbeddingWorkerFactory(() => w);
+    const pending: Promise<unknown>[] = [];
+    for (let i = 0; i < 16; i++) pending.push(computeEmbeddingsOffThread(['x'], { requester: `filler-${i}` }).catch(() => {}));
+
+    const err = await computeEmbeddingsOffThread(['x'], { requester: 'overflow' }).catch((e: unknown) => e);
+    expect(isWorkerPoolShedError(err)).toBe(true);
+    expect((err as { code?: string }).code).toBe(WORKER_POOL_SHED_CODE);
+    expect(WORKER_POOL_SHED_CODE).toBe('WORKER_POOL_SHED'); // the wire value ServerAPI branches on
+    void pending;
+  });
+
+  it('an all-slots-respawning shed error also carries the code', async () => {
+    vi.useFakeTimers();
+    const w = new FakeWorker();
+    __setEmbeddingWorkerFactory(() => w);
+    // Dispatch one task then crash the sole worker → during the backoff gap every slot is down.
+    const p = computeEmbeddingsOffThread(['x'], { requester: 'victim' });
+    const pRejected = expect(p).rejects.toThrow(/worker crash/i); // handler before the crash
+    w.emit('error', new Error('boom'));
+    await pRejected;
+
+    const err = await computeEmbeddingsOffThread(['y'], { requester: 'gap' }).catch((e: unknown) => e);
+    expect(isWorkerPoolShedError(err)).toBe(true);
+    expect((err as { code?: string }).code).toBe(WORKER_POOL_SHED_CODE);
+  });
+
+  it('isWorkerPoolShedError is false for a non-shed error', () => {
+    expect(isWorkerPoolShedError(new Error('unrelated'))).toBe(false);
+    expect(isWorkerPoolShedError(null)).toBe(false);
+    expect(isWorkerPoolShedError({ code: 'WORKER_POOL_SHED' })).toBe(false); // not an ActionableError
   });
 });
 

--- a/lib/embeddings/offThreadEmbedding.ts
+++ b/lib/embeddings/offThreadEmbedding.ts
@@ -168,6 +168,18 @@ function queueLen(): number {
   return _queue.length + _slots.reduce((n, s) => n + (s.inFlight ? 1 : 0), 0);
 }
 
+/**
+ * Read-only snapshot of the worker-pool queue state (t/3374, for ServerAPI's t/3373 non-silent shed
+ * alert + pre-shed queue-depth gauge). Pure getters over module state — NO behavior change.
+ * - `queueDepth`: current resident tasks (queued + in-flight) — the value compared against the cap.
+ * - `cap`: the DYNAMIC admission cap = `MAX_QUEUE_DEPTH × liveSlots` (t/3211 condition B).
+ * - `liveSlots`: slots currently able to serve (0 when every slot is respawning → hard shed).
+ */
+export function poolStats(): { queueDepth: number; cap: number; liveSlots: number } {
+  const liveSlots = liveSlotCount();
+  return { queueDepth: queueLen(), cap: MAX_QUEUE_DEPTH * liveSlots, liveSlots };
+}
+
 function warn(message: string, data: Record<string, unknown>): void {
   // Fallback-Path Logging: every shed / crash / wedge / clamp records WHAT degraded + WHY + WHO.
   getGlobalRecorder()?.record({ type: 'system.error', component: 'offThreadEmbedding', level: 'warn', message, data });
@@ -413,8 +425,31 @@ function unpack(buffer: ArrayBuffer, count: number, dim: number): Float32Array[]
 
 // ── ActionableErrors (all fail-loud → server load-shed; NONE fall back to in-thread) ──
 
-function shedError(requester: string, reason: string): ActionableError {
-  return new ActionableError({
+/**
+ * Discriminable code stamped on the LOAD-SHED ActionableErrors (queue-full / all-respawning / age-out)
+ * so consumers can branch on the shed class WITHOUT string-matching the formatted message — e.g.
+ * ServerAPI emits a clean stdout shed token for the t/3373 non-silent alert. NOT stamped on
+ * {@link workerDownError} (a fault, not a shed). The code lives on the error INSTANCE — `ActionableError`
+ * itself is DebateTool scope (lib/debate/errors.ts), so this never touches the shared class (t/3374).
+ */
+export const WORKER_POOL_SHED_CODE = 'WORKER_POOL_SHED';
+
+/** An {@link ActionableError} stamped with {@link WORKER_POOL_SHED_CODE}. */
+export type WorkerPoolShedError = ActionableError & { code: typeof WORKER_POOL_SHED_CODE };
+
+/** Stamp the shed code on a freshly-built shed error (instance property; class untouched). */
+function markShed(err: ActionableError): WorkerPoolShedError {
+  (err as WorkerPoolShedError).code = WORKER_POOL_SHED_CODE;
+  return err as WorkerPoolShedError;
+}
+
+/** True when `err` is a worker-pool load-shed error (queue-full / all-respawning / age-out). */
+export function isWorkerPoolShedError(err: unknown): err is WorkerPoolShedError {
+  return err instanceof ActionableError && (err as { code?: unknown }).code === WORKER_POOL_SHED_CODE;
+}
+
+function shedError(requester: string, reason: string): WorkerPoolShedError {
+  return markShed(new ActionableError({
     goal: 'Compute embeddings off the main thread without starving the event loop',
     problem: `Embedding request from "${requester}" was shed: ${reason}`,
     location: 'lib/embeddings/offThreadEmbedding.ts:computeEmbeddingsOffThread',
@@ -422,11 +457,11 @@ function shedError(requester: string, reason: string): ActionableError {
       'Retry after backpressure clears — this maps to the existing t/3078 block-mode 503 load-shed',
       'Intentional load-shedding, not a fault: the worker queue is bounded to protect request handling',
     ],
-  });
+  }));
 }
 
-function ageOutError(requester: string, waitedMs: number): ActionableError {
-  return new ActionableError({
+function ageOutError(requester: string, waitedMs: number): WorkerPoolShedError {
+  return markShed(new ActionableError({
     goal: 'Compute embeddings off the main thread within the request budget',
     problem: `Embedding request from "${requester}" was shed: waited ${waitedMs}ms in the queue, past `
       + `the ${QUEUE_AGE_OUT_MS}ms age-out budget, before a worker was free to serve it`,
@@ -436,7 +471,7 @@ function ageOutError(requester: string, waitedMs: number): ActionableError {
       'Intentional load-shedding, not a fault: a task queued past the budget would exceed the route '
         + 'timeout anyway, so it is rejected rather than dispatched to compute a now-abandoned result',
     ],
-  });
+  }));
 }
 
 function workerDownError(requester: string, cause: DownCause, detail: string): ActionableError {


### PR DESCRIPTION
Small read-only addition to lib/embeddings/offThreadEmbedding.ts requested by ServerAPI (p/575#18) to make t/3211's arm-2 shed alert non-silent (t/3373) — the pool's shed WARN is flight-recorder-only today.

## What (no behavior change)
- `poolStats(): { queueDepth, cap, liveSlots }` — snapshot for ServerAPI's pre-shed queue-depth gauge. queueDepth = queued+in-flight; cap = MAX_QUEUE_DEPTH x liveSlots (dynamic t/3211 cap); liveSlots = live count.
- `WORKER_POOL_SHED_CODE = 'WORKER_POOL_SHED'` stamped on BOTH shed ActionableErrors (queue-full/all-respawning + age-out) so ServerAPI branches on the code, not the message. Exported with `isWorkerPoolShedError()` guard. NOT on workerDownError (a fault, not a shed).

## Scope
Code attached to the error INSTANCE — `ActionableError` itself is DebateTool scope (lib/debate) and is untouched. Self-cert (single-scope, read-only, existing patterns).

## Verify
24 passed + 1 skipped (skip-guarded real-ONNX case) — full offThreadEmbedding suite unchanged + 5 new t/3374 tests. embeddings tsc 0, eslint 0.

Closes t/3374; unblocks ServerAPI's t/3373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)