### PR TITLE
docs(embeddings): pin same-host/same-run bit-exact invariant in onnx-equivalence harness (t/3240 SO cond 1)

### DIFF
--- a/lib/embeddings/onnx-equivalence-check.mjs
+++ b/lib/embeddings/onnx-equivalence-check.mjs
@@ -19,6 +19,17 @@
 // the correct precision). No tolerance at that boundary — any divergence is a real finding (report,
 // don't relax). The local t/3181 run reported maxAbsDiff=0 (bit-exact intraOp=1 vs default).
 //
+// LOAD-BEARING INVARIANT — why zero-tolerance bit-exact is SAFE here and not flake-bait (Second
+// Opinion, t/3240 e/143#2; the gate is blocking as of t/3240): this is a PATHWISE, SAME-RUN,
+// SAME-HOST comparison — the two vectors are computed in ONE job on ONE machine (same onnxruntime
+// build, same CPU microarchitecture on both sides), so the classic float-nondeterminism vectors
+// (runner heterogeneity, SIMD kernel selection, ORT-version kernels) CANCEL instead of firing.
+// Therefore: NEVER convert this to a comparison against a STORED golden-vector baseline. Caching a
+// reference between runs re-couples the zero-tolerance contract to runner microarch + ORT kernel
+// versions and silently turns this blocking gate into a flaky-blocking-gate incident. The comparison
+// must always be worker-path-vs-in-thread-path, both computed live in this run. One comment prevents
+// the "optimization" that ticket history wouldn't.
+//
 // Requires: AI_TRIAD_ONNX_MODEL_DIR pointing at a dir with model.onnx + tokenizer.json +
 // tokenizer_config.json, and onnxruntime-node installed. Run AFTER `build:server`.
 //


### PR DESCRIPTION
Second Opinion condition 1 (e/143#2), TL-endorsed (p/342#285), for the embedding-onnx-equivalence advisory→blocking promotion (t/3240).

Co-locates WHY zero-tolerance bit-exact is safe here and must stay pathwise: this is a PATHWISE, SAME-RUN, SAME-HOST comparison (worker-path vs in-thread-path, one job/one machine), so runner-heterogeneity / SIMD-kernel / ORT-version nondeterminism cancels. Load-bearing rule pinned in the harness header: NEVER convert to a stored golden-vector baseline — caching a reference re-couples the zero-tolerance contract to runner microarch + ORT kernels and silently turns the blocking gate into a flaky-blocking-gate incident.

Comment-only, no behavior change. Pairs with SO condition 2 (path-filter extension to onnxruntime-node pin — DevOps ci.yml edit). On both landed, the gate is promoted per t/3240#5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)