### PR TITLE
feat(embeddings): worker-pool shed token + pre-shed queue-depth gauge (t/3373)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/embedQueueDepthMonitor.test.ts
+++ b/taxonomy-editor/src/server/__tests__/embedQueueDepthMonitor.test.ts
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3373 — the pre-shed queue-depth gauge's decision core. The timer glue is thin; the risk is in
+// the state machine: fire ONCE on sustained-high onset, clear ONCE on recovery (hysteresis), and
+// stay silent when idle / all-slots-down. Those are exercised here as pure transitions — no fake
+// timers, no live worker pool.
+
+import { describe, it, expect } from 'vitest';
+import {
+  classifyQueueDepth,
+  toSample,
+  INITIAL_GAUGE_STATE,
+  QUEUE_HIGH_RATIO,
+  QUEUE_CLEAR_RATIO,
+  SUSTAINED_HIGH_SAMPLES,
+  type GaugeState,
+} from '../embedQueueDepthMonitor.js';
+
+/** Drive a sequence of poolStats snapshots through the state machine, collecting every emission. */
+function run(
+  snapshots: Array<{ queueDepth: number; cap: number; liveSlots: number }>,
+  opts?: { highRatio?: number; clearRatio?: number; sustained?: number },
+): { emits: Array<{ level: 'warn' | 'info'; message: string }>; final: GaugeState } {
+  let state: GaugeState = { ...INITIAL_GAUGE_STATE };
+  const emits: Array<{ level: 'warn' | 'info'; message: string }> = [];
+  for (const snap of snapshots) {
+    const { next, emit } = classifyQueueDepth(state, toSample(snap), opts);
+    state = next;
+    if (emit) emits.push(emit);
+  }
+  return { emits, final: state };
+}
+
+describe('toSample', () => {
+  it('computes ratio = depth/cap', () => {
+    expect(toSample({ queueDepth: 12, cap: 16, liveSlots: 1 }).ratio).toBe(12 / 16);
+  });
+  it('ratio is 0 when cap is 0 (all slots down) — never dividing by zero', () => {
+    expect(toSample({ queueDepth: 5, cap: 0, liveSlots: 0 }).ratio).toBe(0);
+  });
+  it('ratio is 0 at idle (depth 0)', () => {
+    expect(toSample({ queueDepth: 0, cap: 16, liveSlots: 1 }).ratio).toBe(0);
+  });
+});
+
+describe('classifyQueueDepth — sustained-high onset', () => {
+  const high = { queueDepth: 14, cap: 16, liveSlots: 1 }; // 87.5% ≥ 75%
+
+  it('does NOT fire before SUSTAINED_HIGH_SAMPLES consecutive high samples', () => {
+    const snaps = Array.from({ length: SUSTAINED_HIGH_SAMPLES - 1 }, () => high);
+    const { emits } = run(snaps);
+    expect(emits).toHaveLength(0);
+  });
+
+  it('fires exactly one WARN on the Nth consecutive high sample', () => {
+    const snaps = Array.from({ length: SUSTAINED_HIGH_SAMPLES }, () => high);
+    const { emits, final } = run(snaps);
+    expect(emits).toHaveLength(1);
+    expect(emits[0].level).toBe('warn');
+    expect(emits[0].message).toContain('worker-pool queue depth high');
+    expect(final.firing).toBe(true);
+  });
+
+  it('does NOT re-fire while it stays high (throttled — one emit per transition)', () => {
+    const snaps = Array.from({ length: SUSTAINED_HIGH_SAMPLES + 5 }, () => high);
+    const { emits } = run(snaps);
+    expect(emits.filter(e => e.level === 'warn')).toHaveLength(1);
+  });
+
+  it('a single high spike interrupted by a low sample resets the counter — no fire', () => {
+    const low = { queueDepth: 2, cap: 16, liveSlots: 1 };
+    const snaps = [high, high, low, high]; // never 3 in a row
+    const { emits, final } = run(snaps);
+    expect(emits).toHaveLength(0);
+    expect(final.firing).toBe(false);
+  });
+});
+
+describe('classifyQueueDepth — recovery / hysteresis', () => {
+  const high = { queueDepth: 14, cap: 16, liveSlots: 1 };  // 87.5%
+  const mid = { queueDepth: 10, cap: 16, liveSlots: 1 };   // 62.5% — below high, ABOVE clear
+  const low = { queueDepth: 6, cap: 16, liveSlots: 1 };    // 37.5% — below clear (0.5)
+
+  it('stays firing in the hysteresis band (below high, above clear) — no recovery emit yet', () => {
+    const snaps = [...Array(SUSTAINED_HIGH_SAMPLES).fill(high), mid, mid];
+    const { emits, final } = run(snaps);
+    expect(emits.filter(e => e.level === 'info')).toHaveLength(0);
+    expect(final.firing).toBe(true);
+  });
+
+  it('emits one INFO recovery when ratio drops below the clear floor', () => {
+    const snaps = [...Array(SUSTAINED_HIGH_SAMPLES).fill(high), low];
+    const { emits, final } = run(snaps);
+    expect(emits.filter(e => e.level === 'warn')).toHaveLength(1);
+    const infos = emits.filter(e => e.level === 'info');
+    expect(infos).toHaveLength(1);
+    expect(infos[0].message).toContain('queue depth recovered');
+    expect(final.firing).toBe(false);
+  });
+
+  it('can re-arm after a recover→high cycle (fires a second WARN)', () => {
+    const snaps = [
+      ...Array(SUSTAINED_HIGH_SAMPLES).fill(high), // warn #1
+      low,                                          // recover
+      ...Array(SUSTAINED_HIGH_SAMPLES).fill(high), // warn #2
+    ];
+    const { emits } = run(snaps);
+    expect(emits.filter(e => e.level === 'warn')).toHaveLength(2);
+    expect(emits.filter(e => e.level === 'info')).toHaveLength(1);
+  });
+});
+
+describe('classifyQueueDepth — inert states', () => {
+  it('idle pool (depth 0) never fires', () => {
+    const snaps = Array.from({ length: 10 }, () => ({ queueDepth: 0, cap: 16, liveSlots: 1 }));
+    expect(run(snaps).emits).toHaveLength(0);
+  });
+
+  it('all-slots-down (cap 0) never fires — that hard-shed is the shed-token path, not the gauge', () => {
+    const snaps = Array.from({ length: 10 }, () => ({ queueDepth: 8, cap: 0, liveSlots: 0 }));
+    expect(run(snaps).emits).toHaveLength(0);
+  });
+
+  it('exactly at the high ratio boundary counts as high', () => {
+    const cap = 16;
+    const atBoundary = { queueDepth: Math.ceil(QUEUE_HIGH_RATIO * cap), cap, liveSlots: 1 };
+    expect(toSample(atBoundary).ratio).toBeGreaterThanOrEqual(QUEUE_HIGH_RATIO);
+    const { emits } = run(Array.from({ length: SUSTAINED_HIGH_SAMPLES }, () => atBoundary));
+    expect(emits.filter(e => e.level === 'warn')).toHaveLength(1);
+  });
+
+  it('clear floor is below the high band (hysteresis gap is non-empty)', () => {
+    expect(QUEUE_CLEAR_RATIO).toBeLessThan(QUEUE_HIGH_RATIO);
+  });
+});

--- a/taxonomy-editor/src/server/__tests__/workerPoolShedToken.test.ts
+++ b/taxonomy-editor/src/server/__tests__/workerPoolShedToken.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment node
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3373 — the clean worker-pool-shed stdout token (deliverable 1). The subtle bug this locks out:
+// resolveEmbeddings SWALLOWS each fallback's error and re-throws a generic 'All embedding fallbacks
+// failed', so the shed's ActionableError.code is GONE by computeEmbeddings' catch — a discrimination
+// check there would silently never fire (dead code). The token is therefore emitted at the offload
+// boundary via logWorkerPoolShedIfApplicable, exercised here directly with the REAL
+// isWorkerPoolShedError guard so a future change to the code contract fails loudly.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { apiWarn, mockRecorder } = vi.hoisted(() => ({ apiWarn: vi.fn(), mockRecorder: { record: vi.fn() } }));
+
+// ── Mocks: just enough for aiBackends.ts to import; offThreadEmbedding stays REAL (pure guard) ──
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({
+  getGlobalRecorder: () => mockRecorder, setGlobalRecorder: vi.fn(),
+}));
+vi.mock('../logger.js', () => ({
+  log: {
+    api: { info: vi.fn(), warn: apiWarn, error: vi.fn(), debug: vi.fn() },
+    server: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    fr: { info: vi.fn(), warn: vi.fn() },
+  },
+  getRequestContext: vi.fn(() => ({})),
+  getRequestId: vi.fn(() => 'req-test'),
+  LOG_MAX_LINE_BYTES: 65536,
+}));
+vi.mock('../config.js', async (importActual) => {
+  const actual = await importActual<typeof import('../config.js')>();
+  return {
+    ...actual,
+    getApiKey: vi.fn(async () => 'fake-key'),
+    getApiKeys: vi.fn(async () => ['fake-key']),
+    getProjectRoot: vi.fn(() => '/fake-root'),
+    resolveDataPath: vi.fn(() => '/fake/data'),
+  };
+});
+vi.mock('../../../../lib/embeddings/onnxEmbedding.js', () => ({
+  warmup: vi.fn(async () => false), tryWarmup: vi.fn(async () => false),
+  computeEmbedding: vi.fn(async () => []), computeEmbeddings: vi.fn(async () => []),
+}));
+vi.mock('../../../../lib/search/tavily.js', () => ({ tavilySearch: vi.fn(), buildSearchAugmentedPrompt: vi.fn() }));
+vi.mock('../../../../lib/ai-client/index.js', async (importActual) => {
+  const actual = await importActual<typeof import('../../../../lib/ai-client/index.js')>();
+  return { ...actual, callProvider: vi.fn(), withRetry: vi.fn(async (fn: () => Promise<unknown>) => fn()) };
+});
+
+// ── Imports after mocks ──────────────────────────────────────────────────────
+import { logWorkerPoolShedIfApplicable } from '../ai/aiBackends.js';
+import { ActionableError } from '../../../../lib/debate/errors.js';
+import { WORKER_POOL_SHED_CODE } from '../../../../lib/embeddings/offThreadEmbedding.js';
+
+/** A genuine stamped shed error, exactly as offThreadEmbedding's markShed() produces. */
+function makeShedError(): ActionableError {
+  const err = new ActionableError({
+    goal: 'Compute embeddings off the main thread', problem: 'shed: queue full',
+    location: 'test', nextSteps: ['retry'],
+  });
+  (err as ActionableError & { code: string }).code = WORKER_POOL_SHED_CODE;
+  return err;
+}
+
+describe('logWorkerPoolShedIfApplicable (t/3373 deliverable 1)', () => {
+  beforeEach(() => { apiWarn.mockClear(); });
+
+  it('emits the clean stdout token for a genuine worker-pool shed', () => {
+    logWorkerPoolShedIfApplicable(makeShedError(), { requester: 'embeddings-compute', inputCount: 42 });
+    expect(apiWarn).toHaveBeenCalledTimes(1);
+    const [fields, message] = apiWarn.mock.calls[0];
+    expect(message).toBe('embeddings worker-pool shed');
+    // component:'api' is the DevOps-matched Log-Analytics sink — must NOT be overridden away.
+    expect(fields).toMatchObject({ component: 'api', requester: 'embeddings-compute', inputCount: 42 });
+    // Carries the poolStats snapshot so the alert has depth/cap context.
+    expect(fields).toHaveProperty('queueDepth');
+    expect(fields).toHaveProperty('cap');
+    expect(fields).toHaveProperty('liveSlots');
+  });
+
+  it('stays SILENT for a generic error (the resolveEmbeddings re-throw shape) — no false token', () => {
+    logWorkerPoolShedIfApplicable(new Error('All embedding fallbacks failed (tried: onnx-batch-worker)'),
+      { requester: 'embeddings-compute', inputCount: 42 });
+    expect(apiWarn).not.toHaveBeenCalled();
+  });
+
+  it('stays SILENT for a non-shed ActionableError (e.g. a timeout) — code discriminates, not the class', () => {
+    const timeout = new ActionableError({ goal: 'g', problem: 'timed out', location: 'l', nextSteps: ['n'] });
+    logWorkerPoolShedIfApplicable(timeout, { requester: 'x', inputCount: 1 });
+    expect(apiWarn).not.toHaveBeenCalled();
+  });
+});

--- a/taxonomy-editor/src/server/ai/aiBackends.ts
+++ b/taxonomy-editor/src/server/ai/aiBackends.ts
@@ -36,7 +36,7 @@ import {
 } from '../../../../lib/embeddings/onnxEmbedding.js';
 // t/3183 (t/2977 Item B): off-main-thread ONNX compute via the shared worker (t/3181). Consumed
 // only when EMBEDDING_WORKER_OFFLOAD is on; flag-off never touches this path (byte-identical).
-import { computeEmbeddingsOffThread } from '../../../../lib/embeddings/offThreadEmbedding.js';
+import { computeEmbeddingsOffThread, isWorkerPoolShedError, poolStats } from '../../../../lib/embeddings/offThreadEmbedding.js';
 import {
   resolveBackend,
   callProvider,
@@ -785,6 +785,22 @@ export async function resolveEmbeddingsChunked(
 // t/1641/t/1643: `_explicitApiKey` is retained for call-site arity (server.ts passes
 // the free-tier key) but is no longer consumed — embeddings are computed by the local
 // Python encoder or the in-process ONNX fallback, both 384-dim/all-MiniLM-L6-v2, no API.
+/**
+ * t/3373: emit the clean, greppable worker-pool-shed WARN token IFF `err` is a queue-shed (i.e. its
+ * ActionableError carries WORKER_POOL_SHED_CODE). Does NOT throw or swallow — the offload wrapper
+ * re-throws so the resolve/fallback/503 path is byte-identical. Must be called at the offload
+ * boundary (before resolveEmbeddings, which discards the shed code into a generic error). Exported
+ * so the shed-vs-generic discrimination is unit-testable without the full computeEmbeddings surface.
+ * component:'api' is the proven Log-Analytics sink (t/3110/t/3308 lesson); DevOps matches the token.
+ */
+export function logWorkerPoolShedIfApplicable(err: unknown, ctx: { requester: string; inputCount: number }): void {
+  if (!isWorkerPoolShedError(err)) return;
+  log.api.warn(
+    { component: 'api', subsystem: 'ai-backends', requester: ctx.requester, inputCount: ctx.inputCount, ...poolStats() },
+    'embeddings worker-pool shed',
+  );
+}
+
 export async function computeEmbeddings(
   texts: string[], ids?: string[], _explicitApiKey?: string,
   opts?: { requester?: string },
@@ -843,7 +859,16 @@ export async function computeEmbeddings(
     // which the canary sees — no silent in-thread fallback.
     chain.push({
       name: 'onnx-batch-worker',
-      compute: (t) => computeEmbeddingsOffThread(t, { requester }).then(vecs => vecs.map(v => Array.from(v))),
+      compute: (t) => computeEmbeddingsOffThread(t, { requester })
+        .then(vecs => vecs.map(v => Array.from(v)))
+        .catch((err: unknown) => {
+          // t/3373: emit the clean shed token HERE, then re-throw UNCHANGED (byte-identical resolve
+          // path). It must be here — resolveEmbeddings swallows each fallback's error and re-throws a
+          // generic 'All embedding fallbacks failed', so the shed's ActionableError.code is gone by
+          // computeEmbeddings' catch. See logWorkerPoolShedIfApplicable.
+          logWorkerPoolShedIfApplicable(err, { requester, inputCount: t.length });
+          throw err;
+        }),
     });
   } else if (await onnxTryWarmup()) {
     // Flag OFF → today's exact in-thread call (warms + uses the main-thread session) → byte-identical.

--- a/taxonomy-editor/src/server/embedQueueDepthMonitor.ts
+++ b/taxonomy-editor/src/server/embedQueueDepthMonitor.ts
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3373 — pre-shed early-warning for the embedding worker-offload pool (t/3211 arm-2's real
+// trigger). The pool's own queue-shed WARN (offThreadEmbedding.ts) is flight-recorder-only and
+// fires AFTER a user already ate a 503. The t/3211 alert wants to fire BEFORE the shed — when
+// sustained queue depth approaches the dynamic admission cap. This periodically samples
+// poolStats() (t/3374) and emits ONE stdout WARN (→ Log Analytics) on sustained-high onset,
+// and an INFO on recovery. No per-tick spam; transition-throttled with hysteresis.
+//
+// Distinct from eventLoopMonitor.ts (loop lag): same cheap-sampler shape, different signal —
+// this is embed-queue saturation, that is event-loop starvation.
+
+import { poolStats } from '../../../lib/embeddings/offThreadEmbedding.js';
+import { getGlobalRecorder } from '../../../lib/flight-recorder/index.js';
+import { log } from './logger.js';
+
+/** Depth/cap fraction at/above which the queue is "high" — the pre-shed band. */
+export const QUEUE_HIGH_RATIO = 0.75;
+/** Hysteresis floor: ratio must fall below this to clear a firing state (avoids threshold flapping). */
+export const QUEUE_CLEAR_RATIO = 0.5;
+/** Consecutive high samples required before firing — sustained pressure, not a single burst spike. */
+export const SUSTAINED_HIGH_SAMPLES = 3;
+const SAMPLE_INTERVAL_MS = 5000;
+
+export interface QueueDepthSample {
+  /** Resident tasks (queued + in-flight). */
+  queueDepth: number;
+  /** Dynamic admission cap = MAX_QUEUE_DEPTH × liveSlots. 0 when every slot is respawning. */
+  cap: number;
+  /** Slots currently able to serve. */
+  liveSlots: number;
+  /** queueDepth / cap, or 0 when cap ≤ 0 (idle / all-slots-down → never "high"). */
+  ratio: number;
+}
+
+export interface GaugeState {
+  consecutiveHigh: number;
+  firing: boolean;
+}
+
+export const INITIAL_GAUGE_STATE: GaugeState = { consecutiveHigh: 0, firing: false };
+
+/** Derive a sample from a poolStats() snapshot. ratio=0 when cap≤0 so idle / all-down never fires. */
+export function toSample(s: { queueDepth: number; cap: number; liveSlots: number }): QueueDepthSample {
+  const ratio = s.cap > 0 ? s.queueDepth / s.cap : 0;
+  return { queueDepth: s.queueDepth, cap: s.cap, liveSlots: s.liveSlots, ratio };
+}
+
+/**
+ * Pure transition: prior gauge state + a sample → next state and any emission.
+ * - WARN once on sustained-high ONSET (≥`sustained` consecutive high samples) — the pre-shed signal.
+ * - INFO once on recovery (ratio drops below `clearRatio` while firing) — hysteresis, no flap.
+ * - Otherwise silent. Throttled by construction: at most one emit per state transition.
+ * Extracted from the timer glue so both arms are unit-testable without fake timers.
+ */
+export function classifyQueueDepth(
+  prev: GaugeState,
+  s: QueueDepthSample,
+  opts: { highRatio?: number; clearRatio?: number; sustained?: number } = {},
+): { next: GaugeState; emit: { level: 'warn' | 'info'; message: string } | null } {
+  const highRatio = opts.highRatio ?? QUEUE_HIGH_RATIO;
+  const clearRatio = opts.clearRatio ?? QUEUE_CLEAR_RATIO;
+  const sustained = opts.sustained ?? SUSTAINED_HIGH_SAMPLES;
+
+  const high = s.cap > 0 && s.ratio >= highRatio;
+  const consecutiveHigh = high ? prev.consecutiveHigh + 1 : 0;
+  const gauge = `depth ${s.queueDepth}/${s.cap} (${(s.ratio * 100).toFixed(0)}%) liveSlots ${s.liveSlots}`;
+
+  if (!prev.firing && consecutiveHigh >= sustained) {
+    return {
+      next: { consecutiveHigh, firing: true },
+      emit: {
+        level: 'warn',
+        message: `embeddings worker-pool queue depth high — sustained pre-shed early-warning — ${gauge}`,
+      },
+    };
+  }
+  if (prev.firing && s.ratio < clearRatio) {
+    return {
+      next: { consecutiveHigh, firing: false },
+      emit: { level: 'info', message: `embeddings worker-pool queue depth recovered — ${gauge}` },
+    };
+  }
+  return { next: { consecutiveHigh, firing: prev.firing }, emit: null };
+}
+
+let timer: NodeJS.Timeout | null = null;
+let state: GaugeState = { ...INITIAL_GAUGE_STATE };
+
+/**
+ * Start the periodic queue-depth gauge. Idempotent (a second call is a no-op while running).
+ * The interval is `unref()`d so it never keeps the process alive. Returns the stop fn.
+ */
+export function startEmbedQueueDepthMonitor(intervalMs: number = SAMPLE_INTERVAL_MS): () => void {
+  if (timer) return stopEmbedQueueDepthMonitor;
+  state = { ...INITIAL_GAUGE_STATE };
+  timer = setInterval(() => {
+    const sample = toSample(poolStats());
+    const { next, emit } = classifyQueueDepth(state, sample);
+    state = next;
+    if (!emit) return;
+    if (emit.level === 'warn') {
+      // Sustained-high onset — curated FR ring + stdout. `log.api` keeps component:'api' (the proven
+      // Log-Analytics sink DevOps matches on, t/3110/t/3308 lesson); `subsystem` carries the label so
+      // the child's component binding is NOT overridden. The FR record's own `component` is FR taxonomy.
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'embed-queue', level: 'warn',
+        message: emit.message, data: { ...sample },
+      });
+      log.api.warn({ subsystem: 'embed-queue', ...sample }, emit.message);
+    } else {
+      // Recovery — Pino/stdout only; never the capacity-bounded FR ring.
+      log.api.info({ subsystem: 'embed-queue', ...sample }, emit.message);
+    }
+  }, intervalMs);
+  timer.unref();
+  return stopEmbedQueueDepthMonitor;
+}
+
+/** Stop the gauge (idempotent). */
+export function stopEmbedQueueDepthMonitor(): void {
+  if (timer) { clearInterval(timer); timer = null; }
+}
+
+/** Test-only: stop and reset module state so cases don't leak into one another. */
+export function __resetEmbedQueueMonitorForTest(): void {
+  stopEmbedQueueDepthMonitor();
+  state = { ...INITIAL_GAUGE_STATE };
+}

--- a/taxonomy-editor/src/server/server.ts
+++ b/taxonomy-editor/src/server/server.ts
@@ -22,6 +22,7 @@ import { getGlobalRecorder, setGlobalRecorder } from '../../../lib/flight-record
 import { warmup as warmupEmbeddings } from '../../../lib/embeddings/onnxEmbedding.js';
 import { prewarmEmbeddingsCache, getEmbeddingsCacheStatus } from './ai/aiBackends.js';
 import { startEventLoopMonitor } from './eventLoopMonitor.js';
+import { startEmbedQueueDepthMonitor } from './embedQueueDepthMonitor.js';
 import { startGroundingSweep } from './groundingSweepScheduler.js';
 
 const require = createRequire(import.meta.url);
@@ -1328,6 +1329,11 @@ server.listen(PORT, BIND_HOST, () => {
   // so a starvation event (t/3165: 7–8s in-process ONNX froze the loop → ingress-fabricated
   // 500) is directly greppable instead of inferred. Unref'd interval — never holds the process.
   startEventLoopMonitor();
+  // t/3373: pre-shed early-warning for the embedding worker-offload pool (t/3211 arm-2's real
+  // trigger). Samples poolStats() and emits ONE stdout WARN (component:'api' → Log Analytics) when
+  // sustained queue depth approaches the dynamic cap — BEFORE a caller eats the 503 queue-shed.
+  // Unref'd interval; inert at K=1 idle (queueDepth 0).
+  startEmbedQueueDepthMonitor();
   // t/3172 (G8b): scheduled full-taxonomy grounding sweep — path-agnostic correctness backstop for
   // batch/PS/Python writes that bypass the inline G8a hook. Gated on GROUNDING_SWEEP_ENABLED
   // (default OFF): inert until the sequenced enable (t/3203 + TL lock-symmetry sign-off). Unref'd.


### PR DESCRIPTION
## What
Makes the **t/3211 arm-2 alert alertable** (the t/3110/t/3308 telemetry-sink lesson). Two emissions, both to **stdout `component:'api'`** (the proven Log-Analytics sink DevOps matches on):

1. **Clean worker-pool-shed token** — `logWorkerPoolShedIfApplicable()` (new exported helper) emits a stable `'embeddings worker-pool shed'` with `poolStats()` context. Emitted at the **offload chain-member boundary**, not `computeEmbeddings`' catch — because `resolveEmbeddings` swallows each fallback's error and re-throws a generic `'All embedding fallbacks failed'`, discarding the shed `ActionableError.code`; a catch-level check would be **dead code**. Re-throws unchanged → resolve/503 path byte-identical.
2. **Pre-shed queue-depth gauge** — new `embedQueueDepthMonitor.ts` (modeled on `eventLoopMonitor.ts`): unref'd sampler over `poolStats()` → one WARN on sustained-high onset (≥75% of the dynamic `MAX_QUEUE_DEPTH×liveSlots` cap for N consecutive samples), one INFO on recovery (hysteresis). Inert at K=1 idle / all-slots-down. Wired near `startEventLoopMonitor` in `server.ts`.

## Tests
- `embedQueueDepthMonitor.test.ts` — pure classifier state-machine: onset threshold, throttle (one emit/transition), hysteresis, re-arm, idle/all-down inert, boundary.
- `workerPoolShedToken.test.ts` — shed-vs-generic discrimination against the **real** `isWorkerPoolShedError` guard (locks out the dead-code regression).

## Notes
- Depends on **t/3374** (`poolStats`/`isWorkerPoolShedError`/`WORKER_POOL_SHED_CODE`, merged `b2652ca1`).
- **Draft** pending **Quality (TL)** review (new observability surface; single-scope; follows the eventLoopMonitor pattern; no cross-role interface or data-model change → not Main-TL, no Second-Opinion trigger).
- Local `npm run verify` env caveats (NOT from this diff): undici major-skew guard fires on local Node 7.x, and `lib/` transitive deps (`micromark-*`) don't resolve in the worktree — both pass under CI's fresh install. New tests pass; all runnable `computeEmbeddings` tests (probe/batchCap503/largeRecomputeWarn/cache) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)