### PR TITLE
feat(devops): env-reconcile Phase-2 flip — live --remove-env-vars + 3 SO guards (t/3345)

### DIFF
--- a/operations/devops/Sync-StagingEnv.ps1
+++ b/operations/devops/Sync-StagingEnv.ps1
@@ -1,15 +1,19 @@
 <#
 .SYNOPSIS
-    Syncs main.bicep baseEnv literal entries to the staging Container App
-    env template. Idempotent — exits 0 with no-op if already in sync. (t/2630)
+    Reconciles the staging Container App env template to main.bicep: syncs baseEnv literal drift AND
+    (Phase-2, t/3345) REMOVES orphaned keys — live keys bicep no longer declares. Idempotent — exits 0
+    no-op if already in sync. (t/2630; Phase-2 flip TL GV t/3345#15 + Second Opinion e/144#2.)
+
+    Fail-closed guards before any removal: the membership-superset guard (Test-ManagedNamesSuperset),
+    the mass-removal circuit breaker (orphan-count cap), and the staging-only app-name guard.
 
 .PARAMETER MockCurrentEnvPath
     Testing only: path to a JSON file whose content replaces the az containerapp
     show query. Eliminates the real Azure call so tests run without credentials.
 
 .PARAMETER DryRun
-    Testing only: skip the az containerapp update call. Exits 2 if drift
-    detected, 0 if in sync. Proves the drift-detection path without touching Azure.
+    Testing only: skip the az containerapp update calls. Exits 2 if drift OR an orphan removal would
+    occur, 0 if in sync, 1 if a fail-closed guard trips. Proves the plan without touching Azure.
 #>
 [CmdletBinding()]
 Param(
@@ -69,11 +73,13 @@ if ($MockCurrentEnvPath) {
 }
 
 $CurrentMap = @{}
+$SecretNamesBefore = [System.Collections.Generic.List[string]]::new()
 foreach ($e in @($CurrentEnvJson)) {
-    # az returns secret-backed vars as {secretRef:'x', value:''} — skip them.
-    # Filtering only on value-property presence misses this case (empty string passes).
+    # az returns secret-backed vars as {secretRef:'x', value:''} — skip them from the reconcile map
+    # (filtering only on value-property presence misses this: empty string passes). Record their names
+    # so the post-removal verification (SO e/144#2 cond 2) can assert none were touched.
     $secretRefProp = $e.PSObject.Properties['secretRef']
-    if ($null -ne $secretRefProp -and $secretRefProp.Value -ne '') { continue }
+    if ($null -ne $secretRefProp -and $secretRefProp.Value -ne '') { $SecretNamesBefore.Add($e.name); continue }
     $valProp = $e.PSObject.Properties['value']
     if ($null -ne $valProp) { $CurrentMap[$e.name] = $valProp.Value }
 }
@@ -104,33 +110,80 @@ if ($Drifted.Count -gt 0) {
     $Drifted | ForEach-Object { Write-Host "  $_" }
 }
 
-# Phase-1 (t/3345): warn about orphaned keys; Phase-2 will auto-remove after TL GV.
+# ── Orphan handling — Phase-2 LIVE removal (t/3345; TL GV t/3345#15; Second Opinion e/144#2) ──
+# The reconcile now DELETES live env keys bicep no longer declares. Two SO fail-closed guards run
+# BEFORE any removal — and in DryRun too, so they abort the PLAN, not just the apply.
+$StagingAppName   = 'taxonomy-editor-staging'  # SO cond 3: removal is staging-only (guard below)
+$OrphanRemovalCap = 3                           # SO cond 1: mass-removal circuit breaker
 if ($Orphans.Count -gt 0) {
-    Write-Host ("::warning::Staging env has $($Orphans.Count) orphaned key(s) not in bicep managed set: " +
-        "$($Orphans -join ', '). These were removed from bicep but persist in the live app template. " +
-        "Unset manually until Phase-2 lands: " +
-        "az containerapp update --name $AppName -g $ResourceGroup " +
-        "--remove-env-vars $($Orphans -join ' ') (t/3345)")
+    Write-Host ("Orphan(s) on the live template not in the bicep managed set (removed from bicep): " +
+        "$($Orphans -join ', ') (t/3345)")
+
+    # SO cond 1 (e/144#2) — mass-removal CIRCUIT BREAKER. The membership-superset guard catches an
+    # empty/short managed set (incl. the vacuous ∅⊆everything case), but cap the blast radius
+    # regardless: real drift arrives 1–2 keys at a time, so an orphan set larger than the cap signals
+    # a bicep-PARSE failure, not drift → abort WITHOUT removal, fail-closed, naming the trip.
+    if ($Orphans.Count -gt $OrphanRemovalCap) {
+        Write-Error ("::error::Orphan-removal CIRCUIT BREAKER: $($Orphans.Count) orphans exceed the cap " +
+            "of $OrphanRemovalCap — [$($Orphans -join ', ')]. A set this large signals a bicep-parse " +
+            "failure, not real drift. Aborting WITHOUT removal to prevent a staging env mass-wipe; " +
+            "investigate Get-BicepBaseEnv parsing. (t/3345, SO e/144#2 cond 1)")
+        exit 1
+    }
+
+    # SO cond 3 (e/144#2) — STAGING-ONLY, enforced in CODE not convention. Live --remove-env-vars is
+    # destructive and this incremental model is WRONG for prod (prod reconciles via a wholesale ARM
+    # redeploy). A future "reconcile prod too" reuse must hit this guard, not succeed accidentally.
+    if ($AppName -ne $StagingAppName) {
+        Write-Error ("::error::Refusing orphan removal: -AppName '$AppName' is not the staging app " +
+            "'$StagingAppName'. This incremental reconcile is staging-only; prod reconciles via its " +
+            "wholesale ARM redeploy. (t/3345, SO e/144#2 cond 3)")
+        exit 1
+    }
 }
 
 if ($DryRun) {
-    Write-Host "[DryRun] Would call: az containerapp update --set-env-vars ..."
+    if ($Orphans.Count -gt 0) { Write-Host "[DryRun] Would REMOVE orphan(s): $($Orphans -join ', ')" }
+    if ($Drifted.Count -gt 0) { Write-Host "[DryRun] Would set-env-vars for drifted key(s)." }
     exit 2
 }
 
-# Synchronous (no --no-wait) so failures surface immediately and the following
-# New-ContainerAppRevision inherits the updated template (t/2630 TL condition)
+# ── LIVE apply (synchronous, no --no-wait, so failures surface + the next revision inherits the
+#    updated template — t/2630 TL condition) ──
 if ($Drifted.Count -gt 0) {
     $EnvArgs = @($BicepEnv.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value)" })
-    Write-Host "Syncing to Azure..."
+    Write-Host "Syncing baseEnv drift to Azure..."
     az containerapp update --name $AppName -g $ResourceGroup --set-env-vars @EnvArgs
-    if ($LASTEXITCODE -ne 0) {
-        Write-Error "az containerapp update failed (exit $LASTEXITCODE)"
+    if ($LASTEXITCODE -ne 0) { Write-Error "az containerapp update (--set-env-vars) failed (exit $LASTEXITCODE)"; exit 1 }
+    Write-Host "Staging baseEnv drift synced."
+}
+
+if ($Orphans.Count -gt 0) {
+    # SO cond 2 (e/144#2) — LOUD removal log (job summary, not verbose-only).
+    Write-Host ("::warning::Phase-2 reconcile REMOVING $($Orphans.Count) orphaned staging env key(s): " +
+        "$($Orphans -join ', ') (t/3345)")
+    az containerapp update --name $AppName -g $ResourceGroup --remove-env-vars @Orphans
+    if ($LASTEXITCODE -ne 0) { Write-Error "az containerapp update (--remove-env-vars) failed (exit $LASTEXITCODE)"; exit 1 }
+
+    # SO cond 2 (e/144#2) — POST-REMOVAL VERIFICATION. Re-read the live template and assert the removal
+    # did EXACTLY what was intended: orphans gone, every bicep-managed key still present, every
+    # secretRef key untouched. Turns a silent over-delete into a same-run RED (a deleted GEMINI_PAID_KEY
+    # is caught here, not from a backend outage).
+    $After = az containerapp show --name $AppName -g $ResourceGroup `
+        --query 'properties.template.containers[0].env' -o json | ConvertFrom-Json
+    if ($LASTEXITCODE -ne 0) { Write-Error "post-removal az containerapp show failed (exit $LASTEXITCODE)"; exit 1 }
+    $afterNames = @(@($After) | ForEach-Object { $_.name })
+    $afterSecretNames = @(@($After) | Where-Object {
+        $sp = $_.PSObject.Properties['secretRef']; $null -ne $sp -and $sp.Value -ne '' } | ForEach-Object { $_.name })
+    $verifyFails = [System.Collections.Generic.List[string]]::new()
+    foreach ($o in $Orphans)           { if ($o -in $afterNames)          { $verifyFails.Add("orphan '$o' still present") } }
+    foreach ($k in $BicepEnv.Keys)     { if ($k -notin $afterNames)       { $verifyFails.Add("bicep-managed '$k' MISSING") } }
+    foreach ($s in $SecretNamesBefore) { if ($s -notin $afterSecretNames) { $verifyFails.Add("secretRef '$s' MISSING") } }
+    if ($verifyFails.Count -gt 0) {
+        Write-Error ("::error::POST-REMOVAL VERIFICATION FAILED (t/3345, SO e/144#2 cond 2): " +
+            "$($verifyFails -join '; '). Removal did not match intent — investigate immediately.")
         exit 1
     }
-    Write-Host "Staging baseEnv synced successfully"
-}
-if ($Orphans.Count -gt 0) {
-    Write-Host ("Orphaned key(s) not removed (Phase-1 warn-only, pending Phase-2 TL GV): " +
-        "$($Orphans -join ', ') (t/3345)")
+    Write-Host ("Post-removal verification PASSED: orphan(s) gone; all $($BicepEnv.Count) bicep-managed " +
+        "+ $($SecretNamesBefore.Count) secretRef key(s) intact. (t/3345 Phase-2)")
 }

--- a/tests/ManagedNamesSuperset.Tests.ps1
+++ b/tests/ManagedNamesSuperset.Tests.ps1
@@ -59,4 +59,20 @@ Describe 'Test-ManagedNamesSuperset' {
         $v.Ok | Should -BeFalse
         $v.Missing | Should -Be @('B')
     }
+
+    It 'VACUOUS-TRUTH trap (SO e/144#2 cond 1): empty LiteralKeys + empty ManagedNames → NOT Ok' {
+        # The subset-of-empty classic: "every literal key ∈ managed" holds VACUOUSLY when the bicep
+        # parse yields nothing (∅ ⊆ everything). The empty-ManagedNames guard must win so a broken
+        # parse never green-lights a reconcile (which would then orphan the whole live env). The
+        # downstream orphan-count circuit breaker in Sync-StagingEnv is the second net for a
+        # short-but-nonempty partial parse that slips past this.
+        (Test-ManagedNamesSuperset -LiteralKeys @() -ManagedNames @()).Ok | Should -BeFalse
+    }
+
+    It 'VACUOUS-TRUTH (documented): empty LiteralKeys + non-empty ManagedNames → Ok (nothing to protect)' {
+        # This IS a legitimate vacuous pass (no literal keys to be missing). Safe on its own — there is
+        # nothing to orphan-remove when bicep declares keys but none are literal-value. Kept explicit so
+        # the intentional vacuity is not mistaken for the dangerous empty-managed case above.
+        (Test-ManagedNamesSuperset -LiteralKeys @() -ManagedNames @('A', 'B')).Ok | Should -BeTrue
+    }
 }

--- a/tests/StagingEnvSync.Tests.ps1
+++ b/tests/StagingEnvSync.Tests.ps1
@@ -115,4 +115,33 @@ Describe 'Sync-StagingEnv' {
             -PassThru -Wait -NoNewWindow
         $proc.ExitCode | Should -Be 0
     }
+
+    It 'SO cond-1 circuit breaker: >3 orphans → abort (exit 1), even in DryRun (t/3345 Phase-2, e/144#2)' {
+        # many-orphans-env.json has 4 non-bicep plain keys (ORPH_A..D). Real drift is 1-2 keys; a set
+        # this large signals a parse failure → the mass-removal breaker must abort WITHOUT removal
+        # (exit 1), not proceed to a would-remove. Aborts in DryRun too (guards the PLAN, not just apply).
+        $envMany = Join-Path $fixtureDir 'many-orphans-env.json'
+        $proc = Start-Process pwsh `
+            -ArgumentList '-NonInteractive', '-File', $syncScript,
+                          '-BicepPath',           $bicepFixture,
+                          '-MockCurrentEnvPath',  $envMany,
+                          '-DryRun' `
+            -PassThru -Wait -NoNewWindow
+        $proc.ExitCode | Should -Be 1
+    }
+
+    It 'SO cond-3 staging-only guard: orphan removal refused on a non-staging app name → exit 1 (t/3345 Phase-2, e/144#2)' {
+        # orphaned-env.json has one true orphan (passes the breaker). With -AppName set to the PROD app,
+        # the staging-only guard must refuse the removal (exit 1) rather than reconcile prod with this
+        # incremental model. Enforced in code, not workflow convention.
+        $orphanedEnv = Join-Path $fixtureDir 'orphaned-env.json'
+        $proc = Start-Process pwsh `
+            -ArgumentList '-NonInteractive', '-File', $syncScript,
+                          '-BicepPath',           $bicepFixture,
+                          '-MockCurrentEnvPath',  $orphanedEnv,
+                          '-AppName',             'taxonomy-editor',
+                          '-DryRun' `
+            -PassThru -Wait -NoNewWindow
+        $proc.ExitCode | Should -Be 1
+    }
 }

--- a/tests/fixtures/staging-env-sync/many-orphans-env.json
+++ b/tests/fixtures/staging-env-sync/many-orphans-env.json
@@ -1,0 +1,12 @@
+[
+  { "name": "AI_TRIAD_DATA_ROOT",   "value": "/mnt/shared" },
+  { "name": "TAXONOMY_CACHE_DIR",   "value": "/mnt/shared" },
+  { "name": "HOME",                 "value": "/home/aitriad" },
+  { "name": "NODE_ENV",             "value": "production" },
+  { "name": "WEBSITE_AUTH_ENABLED", "value": "true" },
+  { "name": "AZURE_KEYVAULT_URL",   "secretRef": "kv-url" },
+  { "name": "ORPH_A",               "value": "1" },
+  { "name": "ORPH_B",               "value": "1" },
+  { "name": "ORPH_C",               "value": "1" },
+  { "name": "ORPH_D",               "value": "1" }
+]


### PR DESCRIPTION
**The t/3345 Phase-2 flip** — warn-only → LIVE orphan removal. TL GV cleared (t/3345#15); Second Opinion PROCEED with 3 conditions (e/144#2), all implemented here. **DRAFT** — held for your closing GV; the destructive op should not merge-on-green without it.

Sync-StagingEnv now deletes live staging env keys bicep no longer declares, with three fail-closed guards (all run in DryRun too — they abort the PLAN):
- **cond 1 circuit breaker** — abort if orphan-count > cap (3); bounds any partial-parse blast radius beyond the superset guard's empty/vacuous catch.
- **cond 2 loud log + post-removal verify** — `::warning::` summary of deleted keys, then re-read the live template and assert orphans gone / bicep-managed present / secretRef untouched → over-delete = same-run RED.
- **cond 3 staging-only** — refuse removal on any AppName != `taxonomy-editor-staging`.

Tests: +2 vacuous-truth (subset-of-empty → not Ok) on Test-ManagedNamesSuperset; +2 StagingEnvSync (breaker >3 → exit 1; non-staging → exit 1). **19/19 green.** The live-removal path + post-verify prove on the real staging deploy (real-env-first).

**@TL: closing GV.** On merge I run the controlled staging deploy that exercises the live removal, verify, and close t/3345.