### PR TITLE
feat(validation): add conflict_count === conflicts.length refine (t/3368 AC, t/3377)

### DIFF
--- a/taxonomy-editor/src/renderer/utils/validation.data.test.ts
+++ b/taxonomy-editor/src/renderer/utils/validation.data.test.ts
@@ -117,5 +117,16 @@ describe.skipIf(!dataRoot)('Schema safety net — validation.ts vs real producti
       const result = aggregateConflictsFileSchema.safeParse(poisoned);
       expect(result.success, 'a bogus status must fail the aggregate schema').toBe(false);
     });
+
+    // t/3368 AC (Second Opinion amendment, e/142#4/#5): conflict_count must track conflicts.length —
+    // the fork-B applier bug (1240 vs 1252) this cross-check targets is exactly why it's gated to land
+    // AFTER the counter fix, not before (would have insta-red the positive arm above on known-bad data).
+    it('rejects a seeded conflict_count/conflicts.length mismatch (both-arms gate discipline)', () => {
+      expect(existsSync(aggregatePath), `${aggregatePath} must exist`).toBe(true);
+      const data = JSON.parse(readFileSync(aggregatePath, 'utf8'));
+      const poisoned = { ...data, conflict_count: data.conflict_count + 1 };
+      const result = aggregateConflictsFileSchema.safeParse(poisoned);
+      expect(result.success, 'a conflict_count/conflicts.length mismatch must fail the aggregate schema').toBe(false);
+    });
   });
 });

--- a/taxonomy-editor/src/renderer/utils/validation.ts
+++ b/taxonomy-editor/src/renderer/utils/validation.ts
@@ -179,6 +179,14 @@ export const aggregateConflictsFileSchema = z.object({
   last_modified: z.string(),
   conflict_count: z.number().int(),
   conflicts: z.array(aggregateConflictItemSchema),
+}).superRefine((doc, ctx) => {
+  if (doc.conflict_count !== doc.conflicts.length) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['conflict_count'],
+      message: `conflict_count (${doc.conflict_count}) must equal conflicts.length (${doc.conflicts.length}) — an applier updated one without the other (t/3368)`,
+    });
+  }
 });
 
 export type ValidationErrors = Record<string, string>;


### PR DESCRIPTION
## Summary
- Adds the `.superRefine()` cross-check `conflict_count === conflicts.length` to `aggregateConflictsFileSchema`, deferred out of the original schema PR (t/3358, #2030) per TL's sequencing decision because the live file had a known 1240 vs 1252 drift.
- The counter fix has since landed (t/3368, PS) and pushed to data-of-record — verified `conflict_count == conflicts.length == 1252` with `demoted` status present.
- This is a **binding acceptance criterion on t/3368**, established by Second Opinion's reconciliation during t/3358's consult (e/142#4/#5) — not a fresh design, implementing per that already-approved spec.

## Test plan
- [x] New negative arm: seeded `conflict_count` mismatch fails `safeParse`
- [x] Existing positive arm (`conflicts.json parses without errors`) now covers the live file passing with the counter correct
- [x] `npx vitest run src/renderer/utils/validation.data.test.ts -t "Aggregate conflicts"` — 3/3 passed
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx eslint` on both changed files — clean
- Note: full `validation.data.test.ts` run has 1 unrelated pre-existing failure (`accelerationist.json` / `match_level: "universal"`) — known defect, flagged separately (p/34#9), not caused by or related to this change.

Refs: t/3377, t/3368 (AC), t/3358 (original schema, Done), e/142#4/#5 (Second Opinion reconciliation)

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>