### PR TITLE
feat(validation): aggregate strip-count WARN + logical_form frame-count CI floor (t/3378)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore.test.ts
@@ -56,9 +56,15 @@ vi.mock('@lib/debate/validateNodeId', () => ({
   validatePovNodeId: vi.fn().mockReturnValue({ valid: true }),
 }));
 
+const { mockRecord, mockStripInvalidLogicalForm } = vi.hoisted(() => ({
+  mockRecord: vi.fn(),
+  // t/3250: loadAll calls this per node. t/3378: tests override this per-case to simulate strips.
+  mockStripInvalidLogicalForm: vi.fn().mockReturnValue({ removed: false }),
+}));
+
 vi.mock('@lib/flight-recorder/index', () => ({
   getGlobalRecorder: vi.fn().mockReturnValue({
-    record: vi.fn(),
+    record: mockRecord,
   }),
 }));
 
@@ -68,7 +74,7 @@ vi.mock('../utils/validation', () => ({
   conflictFileSchema: { safeParse: vi.fn().mockReturnValue({ success: true }) },
   extractPovErrors: vi.fn().mockReturnValue({}),
   extractConflictErrors: vi.fn().mockReturnValue({}),
-  stripInvalidLogicalForm: vi.fn().mockReturnValue({ removed: false }), // t/3250: loadAll calls this per node
+  stripInvalidLogicalForm: mockStripInvalidLogicalForm,
 }));
 
 vi.mock('../utils/similarity', () => ({
@@ -1236,6 +1242,53 @@ describe('useTaxonomyStore', () => {
       await useTaxonomyStore.getState().loadAll();
       expect(useTaxonomyStore.getState().loading).toBe(false);
       expect(useTaxonomyStore.getState().saveError).toBeTruthy();
+    });
+  });
+
+  // t/3378: aggregate strip-count observability on top of the existing per-node WARN (t/3250) —
+  // a mass strip (the t/3375 class, 133 frames) should be visible without counting log lines.
+  describe('loadAll — logical_form strip summary (t/3378)', () => {
+    function mockOtherPovsEmpty(accFile: PovTaxonomyFile) {
+      mockApi.loadTaxonomyFile.mockImplementation((pov: string) => {
+        if (pov === 'accelerationist') return Promise.resolve(accFile);
+        return Promise.resolve({ nodes: [] });
+      });
+    }
+
+    it('emits an aggregate WARN with the strip count when frames are stripped on load', async () => {
+      const accFile = makePovFile([
+        makePovNode({ id: 'acc-beliefs-001' }),
+        makePovNode({ id: 'acc-beliefs-002' }),
+      ]);
+      mockOtherPovsEmpty(accFile);
+      mockStripInvalidLogicalForm.mockReturnValue({ removed: true, issue: 'bad frame' });
+
+      await useTaxonomyStore.getState().loadAll();
+
+      const summaryCall = mockRecord.mock.calls.find(([entry]) => entry.message?.includes('logical_form strip summary'));
+      expect(summaryCall).toBeTruthy();
+      expect(summaryCall![0]).toMatchObject({ level: 'warn', data: { pov: 'accelerationist', strippedCount: 2 } });
+    });
+
+    it('does not emit a strip summary on a clean load (no strips)', async () => {
+      mockOtherPovsEmpty(makePovFile([makePovNode()]));
+      mockStripInvalidLogicalForm.mockReturnValue({ removed: false });
+
+      await useTaxonomyStore.getState().loadAll();
+
+      const summaryCall = mockRecord.mock.calls.find(([entry]) => entry.message?.includes('logical_form strip summary'));
+      expect(summaryCall).toBeUndefined();
+    });
+
+    it('escalates to level "error" when the stripped count exceeds the systemic threshold (>5)', async () => {
+      const nodes = Array.from({ length: 6 }, (_, i) => makePovNode({ id: `acc-beliefs-${i}` }));
+      mockOtherPovsEmpty(makePovFile(nodes));
+      mockStripInvalidLogicalForm.mockReturnValue({ removed: true, issue: 'bad frame' });
+
+      await useTaxonomyStore.getState().loadAll();
+
+      const summaryCall = mockRecord.mock.calls.find(([entry]) => entry.message?.includes('logical_form strip summary'));
+      expect(summaryCall![0]).toMatchObject({ level: 'error', data: { strippedCount: 6 } });
     });
   });
 

--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/taxonomyDataSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/taxonomyDataSlice.ts
@@ -50,6 +50,24 @@ import { loadLineageInfoData } from '../../../data/lineageLookup';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { trackNodeMutation } from '../../../lib/analyticsEmitter';
 
+// t/3378: a per-load strip count above this is treated as systemic (not a one-off bad frame)
+// and escalated from warn to error — CL's threshold from the t/3375 observability follow-up.
+const LOGICAL_FORM_STRIP_SYSTEMIC_THRESHOLD = 5;
+
+// t/3378: aggregate summary on top of the existing per-node WARN (t/3250) — the per-node
+// records identify WHICH nodes were stripped; this summary makes the LOAD-WIDE blast radius
+// visible so a mass strip (the t/3375 class) doesn't require counting individual log lines to notice.
+function recordLogicalFormStripSummary(pov: string, strippedCount: number): void {
+  if (strippedCount === 0) return;
+  getGlobalRecorder()?.record({
+    type: 'system.error',
+    component: 'taxonomy-store',
+    level: strippedCount > LOGICAL_FORM_STRIP_SYSTEMIC_THRESHOLD ? 'error' : 'warn',
+    message: `logical_form strip summary: ${strippedCount} frame(s) stripped on load (t/3378)`,
+    data: { pov, strippedCount },
+  });
+}
+
 export type PinnedData =
   | { type: 'pov'; pov: Pov; node: PovNode }
   | { type: 'situations'; node: SituationNode }
@@ -258,13 +276,18 @@ export const createTaxonomyDataSlice: StateCreator<TaxonomyStore, [], [], Taxono
       const acc = await track(steps[0], api.loadTaxonomyFile('accelerationist'));
       const accFile = acc as PovTaxonomyFile;
       if (accFile?.nodes) {
+        let accStrippedCount = 0;
         for (const node of accFile.nodes) {
           const rec = node as unknown as Record<string, unknown>;
           normalizeNodeProperties(rec);
           // t/3250: graceful-degrade a malformed proposed logical_form (WARN + omit, never drop the node).
           const lf = stripInvalidLogicalForm(rec);
-          if (lf.removed) getGlobalRecorder()?.record({ type: 'system.error', component: 'taxonomy-store', level: 'warn', message: 'Stripped malformed node.logical_form (t/3250)', data: { pov: 'accelerationist', node_id: rec.id, issue: lf.issue } });
+          if (lf.removed) {
+            accStrippedCount++;
+            getGlobalRecorder()?.record({ type: 'system.error', component: 'taxonomy-store', level: 'warn', message: 'Stripped malformed node.logical_form (t/3250)', data: { pov: 'accelerationist', node_id: rec.id, issue: lf.issue } });
+          }
         }
+        recordLogicalFormStripSummary('accelerationist', accStrippedCount);
       }
       set({
         accelerationist: accFile,
@@ -308,13 +331,18 @@ export const createTaxonomyDataSlice: StateCreator<TaxonomyStore, [], [], Taxono
       const regData = polReg as { policies: PolicyRegistryEntry[] } | null;
       for (const povFile of [saf, skp] as PovTaxonomyFile[]) {
         if (povFile?.nodes) {
+          let povStrippedCount = 0;
           for (const node of povFile.nodes) {
             const rec = node as unknown as Record<string, unknown>;
             normalizeNodeProperties(rec);
             // t/3250: graceful-degrade a malformed proposed logical_form (WARN + omit, never drop the node).
             const lf = stripInvalidLogicalForm(rec);
-            if (lf.removed) getGlobalRecorder()?.record({ type: 'system.error', component: 'taxonomy-store', level: 'warn', message: 'Stripped malformed node.logical_form (t/3250)', data: { pov: povFile.pov, node_id: rec.id, issue: lf.issue } });
+            if (lf.removed) {
+              povStrippedCount++;
+              getGlobalRecorder()?.record({ type: 'system.error', component: 'taxonomy-store', level: 'warn', message: 'Stripped malformed node.logical_form (t/3250)', data: { pov: povFile.pov, node_id: rec.id, issue: lf.issue } });
+            }
           }
+          recordLogicalFormStripSummary(povFile.pov, povStrippedCount);
         }
       }
       set({

--- a/taxonomy-editor/src/renderer/utils/validation.data.test.ts
+++ b/taxonomy-editor/src/renderer/utils/validation.data.test.ts
@@ -43,6 +43,26 @@ describe.skipIf(!dataRoot)('Schema safety net — validation.ts vs real producti
         );
       }
     });
+
+    // t/3378: schema-parse passes even when a whole data layer silently vanishes — `logical_form`
+    // is optional (t/3375: a strip-then-save deleted 133 acc frames and nothing here caught it).
+    // A count-based floor catches a systemic drop that schema validation structurally cannot.
+    // Floors are the exact live counts (not "slightly below") — any legitimate removal requires a
+    // deliberate edit here, which is the intended friction (TL t/3375#2).
+    const LOGICAL_FORM_FRAME_FLOOR: Record<string, number> = {
+      'accelerationist.json': 133,
+      'safetyist.json': 274,
+      'skeptic.json': 234,
+    };
+
+    it.each(povFiles)('%s carries at least the baseline logical_form frame count (t/3378)', (filename) => {
+      const filePath = join(taxonomyDir, filename);
+      expect(existsSync(filePath), `${filePath} must exist`).toBe(true);
+      const data = JSON.parse(readFileSync(filePath, 'utf8')) as { nodes: { logical_form?: unknown }[] };
+      const count = data.nodes.filter(n => n.logical_form).length;
+      const floor = LOGICAL_FORM_FRAME_FLOOR[filename];
+      expect(count, `${filename}: ${count} logical_form frames, below the t/3378 floor of ${floor} — a mass strip may have silently deleted frames`).toBeGreaterThanOrEqual(floor);
+    });
   });
 
   describe('Situations file', () => {


### PR DESCRIPTION
## Summary
Observability half of the t/3375 prevention-per-incident follow-up (t/3376 is the write-side fix, separate PR).

- **Correction to the ticket's premise**: the load-time strip WARN already existed (t/3250) — this PR adds the missing aggregate: a per-POV strip-count summary, escalating `warn`->`error` above 5 frames stripped in one load.
- **Frame-count CI floor** in `validation.data.test.ts`: schema-parse passes even when `logical_form` (optional) silently vanishes — this asserts each POV file carries at least its baseline frame count, catching a systemic drop like t/3375's 133-frame loss that schema validation structurally cannot.
- Baselines verified against live data: acc 133, saf 274, skp 234 (641 total) — exact-floor per TL's "intended friction" call (t/3375#2).

## Test plan (GV both-arms evidence)
- **Strip summary** (`useTaxonomyStore.test.ts`, 3 new tests): clean load emits no summary; a load with strips emits one aggregate WARN per POV with the correct count; count > 5 escalates to `level: 'error'`. All passing.
- **Frame-count floor** (`validation.data.test.ts`): manually verified an inflated floor value (9999) fails loudly with the live count and floor in the assertion message, then reverted to the real baseline (133/274/234) which passes. Not committed as a test (would require mocking the data file) — verified by hand per the design's "both-arms" requirement; live baseline arm is in the suite.
- `npx vitest run` on both changed test files: 137/137 passing.
- `npx tsc --noEmit -p tsconfig.json`: clean.
- `npx eslint` on all 3 changed files: 0 errors (4 pre-existing complexity warnings in `taxonomyDataSlice.ts`, unrelated to this change).

Refs: t/3378, t/3375 (incident), t/3376 (write-side fix, separate PR), t/3250 (original per-node WARN)

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>