### PR TITLE
ci(devops): promote embedding-onnx-equivalence advisory→required + ORT-pin path filter (t/3240)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,11 +125,18 @@ jobs:
             # 'embeddings' gates embedding-onnx-equivalence (t/3198): the real-ONNX bit-exact
             # worker↔in-thread check. Narrower than 'lib' — only the embeddings subtree (worker,
             # in-thread module, harness) or a ci.yml edit can change the equivalence outcome, so
-            # a broad lib change need not pay the build:server + model-download cost. Advisory job
-            # (not in ci-gate needs), so a too-narrow filter cannot false-green a required context.
+            # a broad lib change need not pay the build:server + model-download cost. PROMOTED to
+            # REQUIRED (in ci-gate needs, t/3240) — so a too-narrow filter would let an ORT-kernel
+            # change land on main UNOBSERVED; the onnxruntime-node manifest+lockfile are included below.
             embeddings:
               - 'lib/embeddings/**'
               - '.github/workflows/ci.yml'
+              # SO cond 2 (t/3240#7): an onnxruntime-node version bump changes the ONNX kernels and
+              # could break bit-exact equivalence, so an ORT-pin PR must bear the gate. A lockfile path
+              # fires the job on EVERY dep bump (not just ORT) — ACCEPTED BY DESIGN per TL (~51s,
+              # skip = OK, also catches transitive ORT bumps); do NOT narrow it.
+              - 'taxonomy-editor/package.json'
+              - 'taxonomy-editor/pnpm-lock.yaml'
             python:
               - 'scripts/**'
               - '.github/ci/**'
@@ -1505,9 +1512,13 @@ jobs:
   # validation in main.bicep; path-filtered to bicep-resources changes, skip = OK.
   # joint-gv-automerge-guard (t/3332) is gated here: blocks event-time auto-merge
   # on joint-gv PRs; always runs on pull_request, no path filter, skip = never OK.
+  # embedding-onnx-equivalence (t/3198/t/3240) is gated here: real-ONNX bit-exact
+  # worker↔in-thread equivalence; path-filtered to embeddings changes + the ORT
+  # manifest/lockfile, skip = OK. Promoted advisory→required per TL GV t/3240#5 +
+  # Second Opinion e/143#2.
   ci-gate:
     name: ci-gate
-    needs: [changes, test-powershell, test-electron, test-container, python-embed-smoke, test-python, dependency-coverage, lockfile-overrides-check, lib-lint, renderer-tsc, contrast-check, test-server-prod-config, workflow-lint, bicep-env-drift, schema-version-bump, render-smoke, bicep-aca-resources, joint-gv-automerge-guard]
+    needs: [changes, test-powershell, test-electron, test-container, python-embed-smoke, test-python, dependency-coverage, lockfile-overrides-check, lib-lint, renderer-tsc, contrast-check, test-server-prod-config, workflow-lint, bicep-env-drift, schema-version-bump, render-smoke, bicep-aca-resources, joint-gv-automerge-guard, embedding-onnx-equivalence]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
**Gate promotion — fully GV-cleared.** TL GV APPROVED (t/3240#5) + fire-arm demo (t/3240#6) + Second Opinion PROCEED (e/143#2). 3 independent green bit-exact CI cycles + a recorded DIVERGENCE fire. DevOps pre-approved the workflow (p/27#41); Shared Lib GO to land (p/27#51).

(1) Add `embedding-onnx-equivalence` to `ci-gate` needs — a red bit-exact result now blocks merge (was advisory). Path-filtered (skip=OK) → non-embedding PRs unaffected.
(2) **SO cond 2** — extend the `embeddings` path filter to also match `taxonomy-editor/package.json` + `pnpm-lock.yaml` so an onnxruntime-node pin bump bears the gate. Lockfile fires on every dep bump — **accepted by design per TL** (~51s, skip=OK, catches transitive ORT bumps). Stale 'advisory' comment updated.

**No context-swap** — ci-gate stays the sole required context; this adds a needs dependency, not a new required context (t/3240#4/#5). YAML validated. This PR itself touches ci.yml → the embeddings filter matches → the now-required job runs + gates it (expect bit-exact pass).

On merge, Shared Lib confirms the gate is live + closes t/3240.