### PR TITLE
fix(t/3379): enum-clamp about[].match_level in formalize_node_lf (keep both ref types)

### DIFF
--- a/research/comp-linguist/tools/formalize_node_lf.py
+++ b/research/comp-linguist/tools/formalize_node_lf.py
@@ -63,6 +63,10 @@ def parse_lf(text):
 
 PARTICULAR_SORTS = frozenset({"agentive-physical-object", "non-agentive-functional-artifact",
                               "perdurant", "normative-description", "non-agentive-social-object"})
+# Canonical EntityMatchLevel enum (logical-form-schema.md; PS $script:LogicalFormMatchLevels).
+# `universal` is a valid args[].sort (t/3251) but NEVER a match_level — the t/3379 leak. about[] keeps
+# BOTH ent-* and term: refs (Option A, SO-ratified e/145) but its match_level is enum-clamped here.
+VALID_MATCH_LEVELS = frozenset({"exact", "instance_of", "subclass", "superclass", "related"})
 
 
 def _repair_bare(ref, allowed):
@@ -102,11 +106,18 @@ def validate(lf, allowed, camp, cat):
     for ab in (lf.get("about") or []):
         if not isinstance(ab, dict):
             continue
-        ab["ref"] = _repair_bare(ab.get("ref", ""), allowed)
-        if ab.get("ref") in allowed:
-            if not ab.get("match_level"):
-                ab["match_level"] = "exact"
-            kept_about.append(ab)
+        ref = _repair_bare(ab.get("ref", ""), allowed)
+        # about[] is a mixed topical index: keep BOTH ent-* and term: refs (Option A, SO e/145).
+        # Only grounded refs survive (R6 / t/2294 — a ref not in the node's own entity_refs/concept_refs
+        # is dropped, never minted); the `in allowed` gate also enforces the {ent-*|term:*} vocabulary.
+        if ref not in allowed:
+            continue
+        ab["ref"] = ref
+        # Authoritative match_level from the ref's register entry (mirrors args[]), never the model's
+        # guess; enum-clamp so a concept's sort=`universal` can never leak into match_level (t/3379).
+        ml = allowed[ref][1]
+        ab["match_level"] = ml if ml in VALID_MATCH_LEVELS else "exact"
+        kept_about.append(ab)
     lf["about"] = kept_about
     lf["modality"] = {"holder": f"camp:{POV.get(camp, camp)}", "attitude": CAT_ATT.get(cat, "belief")}
     lf.setdefault("status", "proposed")

--- a/research/comp-linguist/tools/test_formalize_node_lf.py
+++ b/research/comp-linguist/tools/test_formalize_node_lf.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Regression tests for formalize_node_lf.validate() about[] handling (t/3379).
+
+Option A (SO-ratified, e/145): about[] is a mixed topical index that keeps BOTH ent-* and term:
+refs; its match_level is enum-clamped to EntityMatchLevel so a concept's sort=`universal` can
+never leak into about[].match_level (the t/3379 recurrence). The module loads entities.json at
+import, so we skip cleanly when the data repo is absent (mirrors validation.data.test.ts)."""
+import importlib.util
+import os
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("flf", os.path.join(_HERE, "formalize_node_lf.py"))
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)  # import-time load of entities.json
+    except (FileNotFoundError, OSError) as e:
+        pytest.skip(f"data repo not available for formalize_node_lf import: {e}")
+    return mod
+
+
+flf = _load_module()
+
+# term:* concept ref -> ("universal", "exact"); ent-* -> (dolce_sort, entity_match_level)
+ALLOWED = {
+    "ent-034": ("agentive-physical-object", "exact"),
+    "term:regulation_precautionary": ("universal", "exact"),
+    "ent-x": ("perdurant", "instance_of"),
+}
+
+
+def _run(about):
+    lf = {"predicate": "x", "args": [], "about": about, "polarity": "positive",
+          "temporal": {"type": "unspecified", "value": None}, "formalization_confidence": 0.9}
+    return flf.validate(lf, ALLOWED, "acc", "Beliefs")["about"]
+
+
+def test_concept_ref_kept_and_universal_clamped():
+    """t/3379: a term: concept about-ref survives (Option A), and match_level='universal'
+    (the concept's sort leaking in) is clamped to the authoritative 'exact'."""
+    out = _run([{"ref": "term:regulation_precautionary", "match_level": "universal"}])
+    assert out == [{"ref": "term:regulation_precautionary", "match_level": "exact"}]
+
+
+def test_entity_ref_kept_with_authoritative_match_level():
+    out = _run([{"ref": "ent-x", "match_level": "exact"}])  # model says exact; register says instance_of
+    assert out == [{"ref": "ent-x", "match_level": "instance_of"}]  # authoritative wins
+
+
+def test_ungrounded_ref_dropped():
+    out = _run([{"ref": "ent-hallucinated", "match_level": "exact"}])
+    assert out == []  # R6 / t/2294 — never mint a ref not in the node's own refs
+
+
+def test_mixed_index_preserved():
+    out = _run([{"ref": "ent-034", "match_level": "exact"},
+                {"ref": "term:regulation_precautionary", "match_level": "universal"}])
+    refs = [a["ref"] for a in out]
+    assert refs == ["ent-034", "term:regulation_precautionary"]
+    assert all(a["match_level"] in flf.VALID_MATCH_LEVELS for a in out)


### PR DESCRIPTION
Unconditional prevention piece of **t/3381** (Option A, SO-ratified e/145). Closes the generation-side leak behind the t/3379 recurrence.

**Root cause:** the Python generator's `about[]` path only filled `match_level="exact"` *if empty*, trusting the LLM otherwise — so a `term:` concept about-ref (register entry `("universal","exact")`) the model mislabeled `match_level="universal"` survived out-of-enum. The `args[]` path already authoritatively overwrites from the register; `about[]` didn't.

**Fix:** authoritatively set `about[].match_level` from the ref's register entry + enum-clamp to `EntityMatchLevel`. **Keeps both `ent-*` and `term:` refs** (Option A mixed topical index — NOT the ent-only drop discarded in t/3379#4). Ungrounded refs still dropped (R6/t/2294). Adds `VALID_MATCH_LEVELS` (parity with PS `$script:LogicalFormMatchLevels`).

**Test:** `test_formalize_node_lf.py`, 4 cases (concept kept + universal→exact; entity authoritative; ungrounded dropped; mixed index) — passes locally, skips if the data repo is absent.

Remaining in t/3381 (not this PR): ref-format enforcement in the other 3 ports (Zod/PS/schema, TL-routed), PS↔TS parity fixture, blind golden expansion + re-measure against the pre-committed rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)