### PR TITLE
fix(devops): done-evidence gate searches both repos (code + ai-triad-data) (t/3360)

### DIFF
--- a/operations/devops/done-evidence-predicate.mjs
+++ b/operations/devops/done-evidence-predicate.mjs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { execFileSync } from 'node:child_process'; // used only by the CLI shim's git query
+import { fileURLToPath } from 'node:url'; // resolve repo dirs from the module path, not cwd
+import fs from 'node:fs'; // existsSync guard for the (optionally absent) data repo
 
 /**
  * Pure verdict for the done-requires-EVIDENCE gate (t/3360, G1 cross-check audit).
@@ -17,9 +19,16 @@ import { execFileSync } from 'node:child_process'; // used only by the CLI shim'
  * convention). `ticket_type` is NOT in the payload, so carve-outs (chore/docs/no-code) CANNOT be
  * mechanical — that gap is sized during the warn phase before any blocking flip.
  *
+ * TWO-REPO EVIDENCE (t/3360#5, warn-phase measurement): the fleet is a two-repo split — code here,
+ * structured data in the sibling `ai-triad-data` repo. The warn-phase corpus showed the dominant
+ * real false-positive class was NOT no-code tickets (those are near-absent) but real work whose
+ * commit landed in the DATA repo — invisible to an `origin/main` grep of THIS repo alone. So evidence
+ * is now searched across BOTH repos (see countEvidenceAcrossRepos); a hit in either counts.
+ *
  * Split (merge-guard pattern, t/3270/t/3318, Guard Testability t/2971): the impure `git log` query
  * lives in the CLI shim; `doneEvidenceVerdict` is a PURE function of { statusTarget, hitCount, gitOk }
- * so both arms stay unit-testable (test == runtime). Returns { block, reason }.
+ * and `countEvidenceAcrossRepos` is a PURE aggregation over injectable runGit/existsDir — so both
+ * arms (including the data-repo leg) stay unit-testable (test == runtime). Returns { block, reason }.
  *
  * git-error mode = FAIL-OPEN (warn-phase proposal; TL confirms at the flip, t/3360#3): a git hiccup
  * must not brick EVERY Done transition — this gate is an evidence backstop, not the record of truth,
@@ -31,7 +40,7 @@ export function doneEvidenceVerdict({ statusTarget, hitCount, gitOk } = {}) {
   if (String(statusTarget).toLowerCase() !== 'done') return { block: false, reason: 'not-done-transition' };
   // FAIL-OPEN on any git failure / unparseable key (gitOk=false) — see header.
   if (!gitOk) return { block: false, reason: 'git-unavailable-fail-open' };
-  // A landed commit references the ticket key → committed evidence exists.
+  // A landed commit (in EITHER repo) references the ticket key → committed evidence exists.
   if (hitCount > 0) return { block: false, reason: 'evidence-present' };
   // Done + git OK + zero commits referencing the ticket → no committed evidence.
   return { block: true, reason: 'no-committed-evidence' };
@@ -47,6 +56,33 @@ export function normalizeTicketKey(raw) {
   return m ? `t/${m[1]}` : null;
 }
 
+/**
+ * PURE aggregation of committed evidence across the fleet's two git repos (t/3360#5).
+ * Injectable seams keep it unit-testable without real git (test == runtime):
+ *   - runGit(dir)   → number of origin/main commits in `dir` whose message references the key;
+ *                     throws on a real git error.
+ *   - existsDir(dir)→ whether the repo path is present.
+ * Semantics:
+ *   - a null/empty key → { hitCount: 0, gitOk: false } (fail-open: never block on a key we can't form);
+ *   - an ABSENT repo (existsDir false) contributes 0 hits and is NOT an error — e.g. a checkout with no
+ *     sibling data repo; only a real git failure on a PRESENT repo flips gitOk=false (→ fail-open);
+ *   - hits SUM across repos; a hit in EITHER repo is evidence.
+ */
+export function countEvidenceAcrossRepos({ key, repoDirs, runGit, existsDir } = {}) {
+  if (!key) return { hitCount: 0, gitOk: false };
+  let hitCount = 0;
+  let gitOk = true;
+  for (const dir of repoDirs ?? []) {
+    if (!existsDir(dir)) continue; // genuinely-absent repo is not a git error
+    try {
+      hitCount += runGit(dir);
+    } catch {
+      gitOk = false; // real git failure on a present repo → fail-open
+    }
+  }
+  return { hitCount, gitOk };
+}
+
 // CLI shim (the ONLY impure part). Convention (worktree-path-guard / merge-guard): BLOCK == write
 // 'fire' to stdout; ALLOW == exit 0 with no stdout. The feedback rule invokes THIS module by abs
 // path so the rule runs the exact logic the both-arms test proves (test == runtime, TL GV t/3270#4).
@@ -56,21 +92,30 @@ if (process.argv[1] && process.argv[1].replace(/\\/g, '/').endsWith('done-eviden
   const statusTarget = process.argv[2] || '';
   if (String(statusTarget).toLowerCase() === 'done') {
     const key = normalizeTicketKey(process.argv[3] || '');
-    let hitCount = 0;
-    let gitOk = true;
-    if (!key) {
-      gitOk = false; // unparseable id → fail-open (don't block on an id we can't turn into a key)
-    } else {
-      try {
-        const out = execFileSync('git', ['log', 'origin/main', `--grep=${key}`, '--oneline'], {
+    // Resolve both repo roots from THIS module's path (not cwd, which the hook runtime doesn't fix):
+    //   repo root  = <root>/  (this file is <root>/operations/devops/done-evidence-predicate.mjs)
+    //   data repo  = $AI_TRIAD_DATA_ROOT, else the sibling <root>/../ai-triad-data (monorepo fallback,
+    //                mirrors the .aitriad.json resolution priority in root AGENTS.md).
+    const repoRoot = fileURLToPath(new URL('../../', import.meta.url));
+    const dataRoot = process.env.AI_TRIAD_DATA_ROOT || fileURLToPath(new URL('../../../ai-triad-data', import.meta.url));
+    const { hitCount, gitOk } = countEvidenceAcrossRepos({
+      key,
+      repoDirs: [repoRoot, dataRoot],
+      existsDir: (d) => {
+        try {
+          return fs.existsSync(d);
+        } catch {
+          return false;
+        }
+      },
+      runGit: (d) => {
+        const out = execFileSync('git', ['-C', d, 'log', 'origin/main', `--grep=${key}`, '--oneline'], {
           encoding: 'utf8',
           timeout: 8000,
         });
-        hitCount = out.split(/\r?\n/).filter((l) => l.trim()).length;
-      } catch {
-        gitOk = false; // git error → fail-open (see header)
-      }
-    }
+        return out.split(/\r?\n/).filter((l) => l.trim()).length;
+      },
+    });
     if (doneEvidenceVerdict({ statusTarget, hitCount, gitOk }).block) process.stdout.write('fire');
   }
 }

--- a/operations/devops/done-evidence-predicate.test.mjs
+++ b/operations/devops/done-evidence-predicate.test.mjs
@@ -8,7 +8,22 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { doneEvidenceVerdict, normalizeTicketKey } from './done-evidence-predicate.mjs';
+import { doneEvidenceVerdict, normalizeTicketKey, countEvidenceAcrossRepos } from './done-evidence-predicate.mjs';
+
+// A tiny fake-git harness for the pure two-repo aggregation: map repo dir → hit count, or the
+// sentinel 'ERR' to make that repo's git call throw. Absent-from-map dirs are treated as present-but-0
+// unless listed in `absent`. Keeps countEvidenceAcrossRepos runtime-identical to the shim (t/3360#5).
+function harness({ hits = {}, absent = [] } = {}) {
+  return {
+    existsDir: (d) => !absent.includes(d),
+    runGit: (d) => {
+      if (hits[d] === 'ERR') throw new Error('git failed');
+      return hits[d] ?? 0;
+    },
+  };
+}
+const CODE = '/repo';
+const DATA = '/data';
 
 // ── doneEvidenceVerdict: BLOCK arm ──
 test('BLOCK arm: Done + git OK + zero commits referencing the ticket', () => {
@@ -64,4 +79,65 @@ test('normalizeTicketKey: accepts t/KEY, bare number, and uppercase; rejects jun
   assert.equal(normalizeTicketKey(''), null);
   assert.equal(normalizeTicketKey(null), null);
   assert.equal(normalizeTicketKey(undefined), null);
+});
+
+// ── countEvidenceAcrossRepos: two-repo evidence aggregation (t/3360#5) ──
+// The warn-phase corpus showed the dominant real FP class was a commit that landed in the DATA repo,
+// invisible to an origin/main grep of the code repo alone. These prove a hit in EITHER repo is evidence
+// and that the fail-open seams behave, feeding straight into doneEvidenceVerdict (test == runtime).
+
+test('data-repo hit only → evidence present (the t/3050 class: was a false-block before)', () => {
+  const { hitCount, gitOk } = countEvidenceAcrossRepos({
+    key: 't/3050', repoDirs: [CODE, DATA], ...harness({ hits: { [CODE]: 0, [DATA]: 2 } }),
+  });
+  assert.equal(gitOk, true);
+  assert.equal(hitCount, 2);
+  assert.equal(doneEvidenceVerdict({ statusTarget: 'Done', hitCount, gitOk }).reason, 'evidence-present');
+});
+
+test('code-repo hit only → evidence present', () => {
+  const { hitCount, gitOk } = countEvidenceAcrossRepos({
+    key: 't/3372', repoDirs: [CODE, DATA], ...harness({ hits: { [CODE]: 3, [DATA]: 0 } }),
+  });
+  assert.equal(hitCount, 3);
+  assert.equal(doneEvidenceVerdict({ statusTarget: 'Done', hitCount, gitOk }).block, false);
+});
+
+test('hits SUM across both repos', () => {
+  const { hitCount } = countEvidenceAcrossRepos({
+    key: 't/1', repoDirs: [CODE, DATA], ...harness({ hits: { [CODE]: 1, [DATA]: 1 } }),
+  });
+  assert.equal(hitCount, 2);
+});
+
+test('BLOCK arm survives: neither repo has a referencing commit → no evidence, git OK', () => {
+  const { hitCount, gitOk } = countEvidenceAcrossRepos({
+    key: 't/9999999', repoDirs: [CODE, DATA], ...harness({ hits: { [CODE]: 0, [DATA]: 0 } }),
+  });
+  assert.equal(gitOk, true);
+  assert.equal(hitCount, 0);
+  assert.equal(doneEvidenceVerdict({ statusTarget: 'Done', hitCount, gitOk }).reason, 'no-committed-evidence');
+});
+
+test('absent data repo is NOT an error → counts code repo only, still blocks with no evidence', () => {
+  const { hitCount, gitOk } = countEvidenceAcrossRepos({
+    key: 't/42', repoDirs: [CODE, DATA], ...harness({ hits: { [CODE]: 0 }, absent: [DATA] }),
+  });
+  assert.equal(gitOk, true); // absent sibling repo must not fail-open the gate
+  assert.equal(hitCount, 0);
+  assert.equal(doneEvidenceVerdict({ statusTarget: 'Done', hitCount, gitOk }).block, true);
+});
+
+test('real git error on a PRESENT repo → gitOk false → fail-open', () => {
+  const { gitOk } = countEvidenceAcrossRepos({
+    key: 't/42', repoDirs: [CODE, DATA], ...harness({ hits: { [CODE]: 'ERR', [DATA]: 0 } }),
+  });
+  assert.equal(gitOk, false);
+  assert.equal(doneEvidenceVerdict({ statusTarget: 'Done', hitCount: 0, gitOk }).reason, 'git-unavailable-fail-open');
+});
+
+test('unparseable/empty key → fail-open (gitOk false), never blocks', () => {
+  const r = countEvidenceAcrossRepos({ key: null, repoDirs: [CODE, DATA], ...harness({}) });
+  assert.equal(r.gitOk, false);
+  assert.equal(r.hitCount, 0);
 });


### PR DESCRIPTION
## What
Extends the `done-evidence` warn-phase predicate to search for a referencing commit across **both** fleet repos — the code repo (`origin/main`) **and** the sibling `ai-triad-data` repo — instead of the code repo alone. A referencing commit in either counts as evidence.

## Why (t/3360#5 warn-phase measurement)
Ran the predicate's exact check against the 40 most-recent Done transitions: **38/40 found a referencing commit; 2 would-fire (5%)**. Neither would-fire was a no-code ticket — both were **real work invisible to a code-repo-only grep**:
- **t/3050** — commit landed in the sibling **`ai-triad-data`** repo (`3cffb1e6`). This PR fixes that class mechanically.
- **t/3115** — work landed under a **sibling key** (t/3148); irreducible from the payload, handled by the emergency escape (residual, tracked for the flip).

No-code/process/docs Done transitions are near-absent fleet-wide (PM/Docs/Historian/Risk = 0 completed), so the real FP class is *evidence-in-another-locus*, not no-code.

## How
- New **pure** `countEvidenceAcrossRepos({key, repoDirs, runGit, existsDir})` aggregates hits across repos via injectable seams (test == runtime). `doneEvidenceVerdict` unchanged.
- An **absent** sibling repo contributes 0 hits and is **not** a git error; only a real git failure on a *present* repo flips `gitOk=false` (fail-open preserved).
- Shim resolves `repoRoot` from `import.meta.url` (not cwd) and `dataRoot` from `$AI_TRIAD_DATA_ROOT` else the `../ai-triad-data` fallback; queries via `git -C`.

## Evidence
- **15/15** unit tests (7 new both-arms for the aggregation incl. absent-repo + git-error arms).
- **Live real-env**: `t/3050`(data-only)→ALLOW, `t/3372`(code)→ALLOW, `t/9999999`→FIRE, `In Progress`→ALLOW.

## Scope
Warn-phase **accuracy** fix — the rule stays `type:context`. The blocking flip (`type:context→block`) remains the separate deliberate step gated on the mandatory Second-Opinion consult (t/3361) + TL Gate Verification. Self-certified warn-phase code; not the promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)