### PR TITLE
fix(touch): add long-press-to-context-menu for iPad/phone (t/3382)

### DIFF
--- a/taxonomy-editor/src/renderer/components/shared/LineageDetailView.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/LineageDetailView.tsx
@@ -1,7 +1,8 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
+import { useLongPressContextMenu } from '../../hooks/useLongPressContextMenu';
 import { useTaxonomyStore } from '../../hooks/useTaxonomyStore';
 import { getLineageInfo, getAllLineages } from '../../data/lineageLookup';
 import { getCategoryLabel, classifyLineage, getL2CategoryLabel } from '../../data/lineageCategories';
@@ -20,6 +21,34 @@ const SEE_ALSO_STOPWORDS = new Set([
   'not', 'no', 'but', 'if', 'then', 'than', 'so', 'also', 'such', 'other',
   'about', 'their', 'they', 'them', 'theory', 'view', 'based',
 ]);
+
+// t/3382: touch devices never fire `contextmenu` on a long-press — extracted so
+// useLongPressContextMenu can be called once per button instance (can't call a hook inside .map()).
+function SeeAlsoButton({ label, active, onSelect, onOpenMenu }: {
+  label: string;
+  active: boolean;
+  onSelect: () => void;
+  onOpenMenu: (x: number, y: number) => void;
+}) {
+  const longPress = useLongPressContextMenu(useCallback((e) => {
+    e.preventDefault();
+    onOpenMenu(e.clientX, e.clientY);
+  }, [onOpenMenu]));
+  return (
+    <button
+      className={`btn btn-sm${active ? '' : ' btn-ghost'}`}
+      onClick={onSelect}
+      onContextMenu={longPress.onContextMenu}
+      onTouchStart={longPress.onTouchStart}
+      onTouchMove={longPress.onTouchMove}
+      onTouchEnd={longPress.onTouchEnd}
+      onTouchCancel={longPress.onTouchCancel}
+      title={`Preview: ${label} (right-click → Go To)`}
+    >
+      {label}
+    </button>
+  );
+}
 
 function tokenize(s: string): Set<string> {
   const tokens = s.toLowerCase().match(/[a-z][a-z0-9-]{2,}/g) ?? [];
@@ -155,15 +184,13 @@ export function LineageDetailView({ value, onSelectValue, onOpenLink }: LineageD
       <div className="lineage-detail-label">See Also</div>
       <div className="lineage-detail-links lineage-detail-links-relative">
         {seeAlsoItems.map(({ key, label }) => (
-          <button
+          <SeeAlsoButton
             key={key}
-            className={`btn btn-sm${secondaryValue === key ? '' : ' btn-ghost'}`}
-            onClick={() => setSecondaryValue(secondaryValue === key ? null : key)}
-            onContextMenu={(e) => { e.preventDefault(); setCtxMenu({ x: e.clientX, y: e.clientY, key }); }}
-            title={`Preview: ${label} (right-click → Go To)`}
-          >
-            {label}
-          </button>
+            label={label}
+            active={secondaryValue === key}
+            onSelect={() => setSecondaryValue(secondaryValue === key ? null : key)}
+            onOpenMenu={(x, y) => setCtxMenu({ x, y, key })}
+          />
         ))}
         {ctxMenu && (
           <div

--- a/taxonomy-editor/src/renderer/components/taxonomy/GraphAttributesPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/GraphAttributesPanel.tsx
@@ -1,7 +1,8 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useLongPressContextMenu } from '../../hooks/useLongPressContextMenu';
 import type { GraphAttributes, PossibleFallacy } from '../../types/taxonomy';
 import { useTaxonomyStore } from '../../hooks/useTaxonomyStore';
 import type { PolicyRegistryEntry } from '../../hooks/useTaxonomyStore';
@@ -138,13 +139,24 @@ function Badge({ field, value, onClick, onContextMenu }: {
   onContextMenu?: (e: React.MouseEvent, field: string, value: string) => void;
 }) {
   const color = BADGE_COLORS[value] || '#475569';
+  // t/3382: touch devices never fire `contextmenu` on a long-press — the long-press handlers below
+  // invoke the same onContextMenu callback so the affordance works on iPad/phone too.
+  const longPress = useLongPressContextMenu(useCallback((e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    onContextMenu?.(e as React.MouseEvent, field, value);
+  }, [onContextMenu, field, value]));
   return (
     <span
       className={`ga-badge ${onClick ? 'ga-badge-clickable' : ''}`}
       // eslint-disable-next-line local/no-inline-style -- border/text color comes from the badge's value-specific color lookup
       style={{ borderColor: color, color }}
       onClick={onClick ? (e) => { e.stopPropagation(); onClick(field, value); } : undefined}
-      onContextMenu={onContextMenu ? (e) => { e.preventDefault(); e.stopPropagation(); onContextMenu(e, field, value); } : undefined}
+      onContextMenu={onContextMenu ? longPress.onContextMenu : undefined}
+      onTouchStart={onContextMenu ? longPress.onTouchStart : undefined}
+      onTouchMove={onContextMenu ? longPress.onTouchMove : undefined}
+      onTouchEnd={onContextMenu ? longPress.onTouchEnd : undefined}
+      onTouchCancel={onContextMenu ? longPress.onTouchCancel : undefined}
       title={onClick ? `Find all nodes with ${formatValue(field)} = ${formatValue(value)}` : undefined}
     >
       {formatValue(value)}

--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
@@ -8,6 +8,7 @@ import type { Pov, PovNode, Category, TabId } from '../../types/taxonomy';
 import { useTaxonomyStore } from '../../hooks/useTaxonomyStore';
 import type { AggregatedCrux } from '../../hooks/useTaxonomyStore';
 import { useDebateStore } from '../../hooks/useDebateStore';
+import { useLongPressContextMenu } from '../../hooks/useLongPressContextMenu';
 import { DeleteConfirmDialog } from '../shared/DeleteConfirmDialog';
 import { DescriptionSection, type DescriptionMention } from './NodeDescriptionSection';
 import { TypeaheadSelect } from '../shared/TypeaheadSelect';
@@ -824,21 +825,48 @@ interface IntellectualLineageSectionProps {
   showAttributeInfo: (field: string, value: string) => void;
 }
 
+// t/3382: touch devices never fire `contextmenu` on a long-press — extracted so
+// useLongPressContextMenu can be called once per chip instance (can't call a hook inside .map()).
+function LineageChip({ label, selected, onSelect, onShowInfo }: {
+  label: string;
+  selected: boolean;
+  onSelect: () => void;
+  onShowInfo: () => void;
+}) {
+  const longPress = useLongPressContextMenu(useCallback((e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    onShowInfo();
+  }, [onShowInfo]));
+  return (
+    <span
+      className={`ga-promoted-chip ga-promoted-chip-interactive${selected ? ' ga-promoted-chip-selected' : ''}`}
+      onClick={(e) => { e.stopPropagation(); onSelect(); }}
+      onContextMenu={longPress.onContextMenu}
+      onTouchStart={longPress.onTouchStart}
+      onTouchMove={longPress.onTouchMove}
+      onTouchEnd={longPress.onTouchEnd}
+      onTouchCancel={longPress.onTouchCancel}
+      title={`Click to view lineage info: "${label}"`}
+    >
+      {label}
+    </span>
+  );
+}
+
 function IntellectualLineageSection({ node, expandedLineage, setExpandedLineage, showAttributeInfo }: IntellectualLineageSectionProps) {
   return (
     <div className="form-group">
       <label>Intellectual Lineage</label>
       <div className="ga-promoted-list">
         {[...node.graph_attributes!.intellectual_lineage!].map(v => typeof v === 'string' ? v : (v as { name?: string })?.name).filter((v): v is string => typeof v === 'string' && v.length > 0).sort((a, b) => a.localeCompare(b)).map((l, i) => (
-          <span
+          <LineageChip
             key={i}
-            className={`ga-promoted-chip ga-promoted-chip-interactive${expandedLineage === l ? ' ga-promoted-chip-selected' : ''}`}
-            onClick={(e) => { e.stopPropagation(); setExpandedLineage(expandedLineage === l ? null : l); }}
-            onContextMenu={(e) => { e.preventDefault(); e.stopPropagation(); showAttributeInfo('intellectual_lineage', l); }}
-            title={`Click to view lineage info: "${l}"`}
-          >
-            {l}
-          </span>
+            label={l}
+            selected={expandedLineage === l}
+            onSelect={() => setExpandedLineage(expandedLineage === l ? null : l)}
+            onShowInfo={() => showAttributeInfo('intellectual_lineage', l)}
+          />
         ))}
       </div>
       {expandedLineage && (() => {

--- a/taxonomy-editor/src/renderer/hooks/__tests__/useLongPressContextMenu.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/__tests__/useLongPressContextMenu.test.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useLongPressContextMenu } from '../useLongPressContextMenu';
+
+function touchEvent(x: number, y: number): React.TouchEvent {
+  return { touches: [{ clientX: x, clientY: y }] } as unknown as React.TouchEvent;
+}
+
+describe('useLongPressContextMenu', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('desktop onContextMenu forwards directly to the handler, unchanged', () => {
+    const onContextMenu = vi.fn();
+    const { result } = renderHook(() => useLongPressContextMenu(onContextMenu));
+    const fakeEvent = { clientX: 10, clientY: 20, preventDefault: vi.fn(), stopPropagation: vi.fn() };
+    act(() => { result.current.onContextMenu(fakeEvent as never); });
+    expect(onContextMenu).toHaveBeenCalledWith(fakeEvent);
+  });
+
+  it('a touch held for the long-press duration invokes the handler with the touch coordinates', () => {
+    const onContextMenu = vi.fn();
+    const { result } = renderHook(() => useLongPressContextMenu(onContextMenu));
+    act(() => { result.current.onTouchStart(touchEvent(30, 40)); });
+    expect(onContextMenu).not.toHaveBeenCalled();
+    act(() => { vi.advanceTimersByTime(500); });
+    expect(onContextMenu).toHaveBeenCalledTimes(1);
+    const call = onContextMenu.mock.calls[0][0];
+    expect(call.clientX).toBe(30);
+    expect(call.clientY).toBe(40);
+  });
+
+  it('releasing the touch before the duration elapses cancels the long-press', () => {
+    const onContextMenu = vi.fn();
+    const { result } = renderHook(() => useLongPressContextMenu(onContextMenu));
+    act(() => { result.current.onTouchStart(touchEvent(0, 0)); });
+    act(() => { vi.advanceTimersByTime(300); });
+    act(() => { result.current.onTouchEnd(); });
+    act(() => { vi.advanceTimersByTime(500); });
+    expect(onContextMenu).not.toHaveBeenCalled();
+  });
+
+  it('moving past the cancel threshold (scroll/drag) cancels the long-press', () => {
+    const onContextMenu = vi.fn();
+    const { result } = renderHook(() => useLongPressContextMenu(onContextMenu));
+    act(() => { result.current.onTouchStart(touchEvent(0, 0)); });
+    act(() => { result.current.onTouchMove(touchEvent(50, 0)); }); // 50px > 10px threshold
+    act(() => { vi.advanceTimersByTime(500); });
+    expect(onContextMenu).not.toHaveBeenCalled();
+  });
+
+  it('a small jitter under the cancel threshold does not cancel the long-press', () => {
+    const onContextMenu = vi.fn();
+    const { result } = renderHook(() => useLongPressContextMenu(onContextMenu));
+    act(() => { result.current.onTouchStart(touchEvent(0, 0)); });
+    act(() => { result.current.onTouchMove(touchEvent(3, 3)); }); // well under 10px
+    act(() => { vi.advanceTimersByTime(500); });
+    expect(onContextMenu).toHaveBeenCalledTimes(1);
+  });
+
+  it('onTouchCancel clears a pending long-press', () => {
+    const onContextMenu = vi.fn();
+    const { result } = renderHook(() => useLongPressContextMenu(onContextMenu));
+    act(() => { result.current.onTouchStart(touchEvent(0, 0)); });
+    act(() => { result.current.onTouchCancel(); });
+    act(() => { vi.advanceTimersByTime(500); });
+    expect(onContextMenu).not.toHaveBeenCalled();
+  });
+});

--- a/taxonomy-editor/src/renderer/hooks/useLongPressContextMenu.ts
+++ b/taxonomy-editor/src/renderer/hooks/useLongPressContextMenu.ts
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3382: touch devices (iPad/phone) never fire a `contextmenu` event on a long-press the way a
+// desktop right-click does, so every `onContextMenu`-only handler in the renderer was unreachable
+// on touch. This hook adds a long-press-to-context-menu affordance without changing any existing
+// handler's signature: every `onContextMenu` callback in this codebase only reads
+// `preventDefault`/`stopPropagation`/`clientX`/`clientY` off the event, so a long-press synthesizes
+// a minimal object satisfying that same shape and calls the SAME handler — desktop right-click and
+// touch long-press converge on one code path.
+
+import { useCallback, useRef } from 'react';
+
+const LONG_PRESS_MS = 500;
+// Cancel the long-press if the touch drifts more than this many px (a scroll/drag, not a hold).
+const MOVE_CANCEL_PX = 10;
+
+/** The minimal event shape every onContextMenu handler in this codebase reads. */
+export interface ContextMenuLikeEvent {
+  clientX: number;
+  clientY: number;
+  preventDefault: () => void;
+  stopPropagation: () => void;
+}
+
+export interface LongPressContextMenuHandlers {
+  onContextMenu: (e: React.MouseEvent) => void;
+  onTouchStart: (e: React.TouchEvent) => void;
+  onTouchMove: (e: React.TouchEvent) => void;
+  onTouchEnd: () => void;
+  onTouchCancel: () => void;
+}
+
+/**
+ * Spread the returned handlers onto the same element that currently has `onContextMenu={handler}`.
+ * Desktop right-click behavior is unchanged; a touch long-press now invokes the identical handler.
+ */
+export function useLongPressContextMenu(
+  onContextMenu: (e: ContextMenuLikeEvent) => void,
+): LongPressContextMenuHandlers {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startRef = useRef<{ x: number; y: number } | null>(null);
+
+  const clear = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    startRef.current = null;
+  }, []);
+
+  const onTouchStart = useCallback((e: React.TouchEvent) => {
+    const touch = e.touches[0];
+    if (!touch) return;
+    startRef.current = { x: touch.clientX, y: touch.clientY };
+    timerRef.current = setTimeout(() => {
+      onContextMenu({
+        clientX: touch.clientX,
+        clientY: touch.clientY,
+        preventDefault: () => {},
+        stopPropagation: () => {},
+      });
+      startRef.current = null;
+    }, LONG_PRESS_MS);
+  }, [onContextMenu]);
+
+  const onTouchMove = useCallback((e: React.TouchEvent) => {
+    if (!startRef.current) return;
+    const touch = e.touches[0];
+    if (!touch) return;
+    const dx = touch.clientX - startRef.current.x;
+    const dy = touch.clientY - startRef.current.y;
+    if (Math.hypot(dx, dy) > MOVE_CANCEL_PX) clear();
+  }, [clear]);
+
+  return {
+    onContextMenu,
+    onTouchStart,
+    onTouchMove,
+    onTouchEnd: clear,
+    onTouchCancel: clear,
+  };
+}


### PR DESCRIPTION
## t/3382 — right-click context menu unreachable on touch devices

Touch devices never fire a `contextmenu` event on a long-press the way desktop right-click does, so every `onContextMenu`-only affordance was unreachable on iPad/phone (PM-reported, screenshot attached to the ticket).

### Fix
New **`useLongPressContextMenu`** hook (`src/renderer/hooks/`): wraps an existing `onContextMenu` callback so a 500ms touch long-press invokes the *same* handler as a desktop right-click. Every `onContextMenu` call site in this codebase only reads `preventDefault`/`stopPropagation`/`clientX`/`clientY` off the event, so the hook synthesizes a minimal object satisfying that shape — **no existing handler signature changes**. Cancels on >10px move (a scroll/drag, not a hold) or early release.

### Wired into my scope (Rosetta Stone)
- `GraphAttributesPanel.tsx` — the `Badge` component
- `NodeDetail.tsx` — intellectual-lineage chips (extracted a `LineageChip` sub-component since a hook can't be called inside `.map()`)
- `LineageDetailView.tsx` — "See Also" buttons (same extraction pattern, `SeeAlsoButton`)

### Cross-scope note
5 more components share the identical `onContextMenu`-only pattern, owned by other roles: `SimilarSearchPanel.tsx` (EdgeBrowser), `SituationDetail.tsx` (DebateUI), `DebateWorkspace.tsx` (DebateWorkspace), `EntryDetailRouter.parts.tsx` + `CommitmentsPanel.tsx` (DebateDiagnostics), `PromptDiffPane.tsx` (Chat). Notifying each owner to adopt `useLongPressContextMenu` in their own files — not touching their scope here.

### Test note
`LineageDetailView.tsx` has no pre-existing test file (not introduced by this change). The hook itself has 6 unit tests covering long-press timing, move-cancel, and early-release; the wiring risk into an untested component is low for this UI-only change, so I didn't add disproportionate mocking infrastructure just for this fix.

### Verification
renderer tsc clean · eslint clean (3 pre-existing complexity warnings on the 3 touched files' main functions, confirmed identical values via `git stash` diff — not introduced or worsened by this change) · `GraphAttributesPanel.test.tsx` + `NodeDetail.test.tsx` + new hook test: 22/22 passing.

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>

🤖 Generated with [Claude Code](https://claude.com/claude-code)