### PR TITLE
fix(debate-workspace): add touch long-press support for selection context menu (t/3382)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.test.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import { render, screen, fireEvent, within, act } from '@testing-library/react';
 import { DebateWorkspace } from './DebateWorkspace';
 import { usePreferencesStore } from '../../store/preferencesStore';
 
@@ -738,6 +738,66 @@ describe('find bar', () => {
     fireEvent.keyDown(document, { key: 'f', ctrlKey: true });
     const input = screen.getByPlaceholderText('Find in debate…');
     expect(input).toBeInTheDocument();
+  });
+});
+
+// ── Selection context menu (t/3382 — touch long-press support) ─
+
+describe('selection context menu', () => {
+  const realGetSelection = window.getSelection;
+
+  function mockSelection(text: string) {
+    window.getSelection = vi.fn(() => ({
+      toString: () => text,
+      anchorNode: null,
+      rangeCount: 0,
+    })) as unknown as typeof window.getSelection;
+  }
+
+  beforeEach(() => {
+    mockStore.debateLoading = false;
+    mockStore.activeDebate = makeDebate();
+  });
+
+  afterEach(() => {
+    window.getSelection = realGetSelection;
+    vi.useRealTimers();
+  });
+
+  it('shows the menu on desktop right-click when text is selected', () => {
+    mockSelection('hello world');
+    const { container } = render(<DebateWorkspace />);
+    fireEvent.contextMenu(container.querySelector('.debate-scroll-content')!);
+    expect(container.querySelector('.debate-context-menu')).toBeTruthy();
+  });
+
+  it('does not show the menu on right-click without a selection', () => {
+    mockSelection('');
+    const { container } = render(<DebateWorkspace />);
+    fireEvent.contextMenu(container.querySelector('.debate-scroll-content')!);
+    expect(container.querySelector('.debate-context-menu')).toBeNull();
+  });
+
+  it('shows the menu after touchend when a selection survives the release (t/3382)', () => {
+    vi.useFakeTimers();
+    mockSelection('selected phrase');
+    const { container } = render(<DebateWorkspace />);
+    fireEvent.touchEnd(container.querySelector('.debate-scroll-content')!, {
+      changedTouches: [{ clientX: 50, clientY: 80 }],
+    });
+    act(() => { vi.advanceTimersByTime(60); });
+    expect(container.querySelector('.debate-context-menu')).toBeTruthy();
+  });
+
+  it('does not show the menu after touchend with no selection (native scroll/tap)', () => {
+    vi.useFakeTimers();
+    mockSelection('');
+    const { container } = render(<DebateWorkspace />);
+    fireEvent.touchEnd(container.querySelector('.debate-scroll-content')!, {
+      changedTouches: [{ clientX: 50, clientY: 80 }],
+    });
+    act(() => { vi.advanceTimersByTime(60); });
+    expect(container.querySelector('.debate-context-menu')).toBeNull();
   });
 });
 

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
@@ -1183,15 +1183,12 @@ function useDebateSelectionMenu(activeDebate: DWStore['activeDebate'], defaultTi
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
   const [commentPopover, setCommentPopover] = useState<CommentPopoverState | null>(null);
 
-  // Phase 7: Context menu handler
-  const handleContextMenu = useCallback((e: React.MouseEvent) => {
+  const buildMenuState = useCallback((container: EventTarget | null, x: number, y: number): ContextMenuState | null => {
     const selection = window.getSelection();
     const selectedText = selection?.toString().trim() || '';
-    if (!selectedText) return; // No selection → use default browser menu
+    if (!selectedText) return null; // No selection → use default browser menu
 
-    e.preventDefault();
-
-    const { entryId, isPoverStatement } = findSelectedEntry(selection?.anchorNode, e.currentTarget);
+    const { entryId, isPoverStatement } = findSelectedEntry(selection?.anchorNode, container);
 
     // Compute text offsets + active tier within the debate-statement-content element
     let startOffset = 0;
@@ -1205,19 +1202,38 @@ function useDebateSelectionMenu(activeDebate: DWStore['activeDebate'], defaultTi
       }
     }
 
-    setContextMenu({
-      x: e.clientX,
-      y: e.clientY,
-      selectedText,
-      entryId,
-      isPoverStatement,
-      tier,
-      startOffset,
-      endOffset,
-    });
+    return { x, y, selectedText, entryId, isPoverStatement, tier, startOffset, endOffset };
   }, [activeDebate?.transcript, defaultTier]);
 
-  return { contextMenu, setContextMenu, commentPopover, setCommentPopover, handleContextMenu };
+  // Phase 7: Context menu handler (desktop right-click)
+  const handleContextMenu = useCallback((e: React.MouseEvent) => {
+    const menu = buildMenuState(e.currentTarget, e.clientX, e.clientY);
+    if (!menu) return; // No selection → use default browser menu
+    e.preventDefault();
+    setContextMenu(menu);
+  }, [buildMenuState]);
+
+  // Touch devices don't fire `contextmenu` on long-press-to-select (t/3382) — iOS/Android
+  // intercept the gesture with their native selection callout instead. Watch for a selection
+  // that survives touchend and show the same menu at the release point.
+  const touchMenuTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => { if (touchMenuTimerRef.current) clearTimeout(touchMenuTimerRef.current); }, []);
+
+  const handleTouchEnd = useCallback((e: React.TouchEvent) => {
+    const container = e.currentTarget;
+    const touch = e.changedTouches[0];
+    if (!touch) return;
+    const x = touch.clientX;
+    const y = touch.clientY;
+    if (touchMenuTimerRef.current) clearTimeout(touchMenuTimerRef.current);
+    // The selection finalizes slightly after touchend on mobile Safari/Chrome; wait one tick.
+    touchMenuTimerRef.current = setTimeout(() => {
+      const menu = buildMenuState(container, x, y);
+      if (menu) setContextMenu(menu);
+    }, 50);
+  }, [buildMenuState]);
+
+  return { contextMenu, setContextMenu, commentPopover, setCommentPopover, handleContextMenu, handleTouchEnd };
 }
 
 // ── Main component ───────────────────────────────────────
@@ -1282,7 +1298,7 @@ export function DebateWorkspace({ onExport, exportStatus }: {
 
   const { findVisible, findQuery, setFindQuery, findCurrentIndex, findTotal, findOffsets, findNext, findPrev, closeFind } = useDebateFind(activeDebate);
   const { coverageMap, strengthWeighted } = useDebateCoverage(activeDebate);
-  const { contextMenu, setContextMenu, commentPopover, setCommentPopover, handleContextMenu } = useDebateSelectionMenu(activeDebate, defaultTier);
+  const { contextMenu, setContextMenu, commentPopover, setCommentPopover, handleContextMenu, handleTouchEnd } = useDebateSelectionMenu(activeDebate, defaultTier);
 
   // useFlag is a hook — hoist above the early returns below (rules-of-hooks, t/2299).
   const chatRedesign = useFlag('DEBATE_CHAT_REDESIGN');
@@ -1330,7 +1346,7 @@ export function DebateWorkspace({ onExport, exportStatus }: {
       {/* Scrollable content: header (title+status+DEBATERS strip), debaters, transcript.
           The header scrolls with the transcript rather than staying pinned (user request):
           on a phone the fixed header consumed ~half the viewport. */}
-      <div className="debate-scroll-content" onContextMenu={handleContextMenu}>
+      <div className="debate-scroll-content" onContextMenu={handleContextMenu} onTouchEnd={handleTouchEnd}>
         <DebateHeader
           activeDebate={activeDebate}
           coverageMap={coverageMap}


### PR DESCRIPTION
## Summary
- Fixes t/3382: right-click context menu didn't fire on iPad/phone — `contextmenu` is a desktop-only event; touch devices intercept long-press-to-select with the native selection callout instead
- Extracts the menu-building logic (selection text, entry lookup, offset/tier computation) out of `handleContextMenu` into a shared `buildMenuState()` helper
- Adds a `handleTouchEnd` handler on `.debate-scroll-content` that, after a short delay for the selection to settle, shows the same context menu at the touch release point if a selection survived
- Desktop `onContextMenu` path is unchanged

## Test plan
- [x] `npx vitest run src/renderer/components/debate-workspace/DebateWorkspace.test.tsx` — 71/71 pass, including 4 new tests covering desktop right-click and touch long-press (with/without an active selection)
- [x] `npx tsc --noEmit` — no new errors (3 pre-existing server-side errors, unrelated)
- [x] `npx eslint` on changed files — 0 errors (pre-existing warnings only)
- [ ] Manual verification on an actual iPad/phone or Chrome DevTools touch emulation: select text in a debate transcript entry, release — the custom menu (Copy / Search Google / Similar Perspectives / Explain / Comment) should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)
