### PR TITLE
feat(touch): add useLongPressSelectionMenu — fit-or-extend for text-selection menus (t/3382)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/__tests__/useLongPressSelectionMenu.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/__tests__/useLongPressSelectionMenu.test.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useLongPressSelectionMenu } from '../useLongPressSelectionMenu';
+
+function touchEndEvent(x: number, y: number): React.TouchEvent {
+  return { currentTarget: 'CONTAINER', changedTouches: [{ clientX: x, clientY: y }] } as unknown as React.TouchEvent;
+}
+
+describe('useLongPressSelectionMenu', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('desktop onContextMenu builds + shows the menu when buildMenu returns non-null', () => {
+    const buildMenu = vi.fn(() => ({ x: 1, y: 2, text: 'hi' }));
+    const onMenu = vi.fn();
+    const { result } = renderHook(() => useLongPressSelectionMenu(buildMenu, onMenu));
+    const preventDefault = vi.fn();
+    act(() => {
+      result.current.onContextMenu({ currentTarget: 'C', clientX: 10, clientY: 20, preventDefault } as unknown as React.MouseEvent);
+    });
+    expect(buildMenu).toHaveBeenCalledWith('C', 10, 20);
+    expect(preventDefault).toHaveBeenCalled();
+    expect(onMenu).toHaveBeenCalledWith({ x: 1, y: 2, text: 'hi' });
+  });
+
+  it('desktop onContextMenu does nothing (no preventDefault) when buildMenu returns null', () => {
+    const buildMenu = vi.fn(() => null);
+    const onMenu = vi.fn();
+    const { result } = renderHook(() => useLongPressSelectionMenu(buildMenu, onMenu));
+    const preventDefault = vi.fn();
+    act(() => {
+      result.current.onContextMenu({ currentTarget: 'C', clientX: 10, clientY: 20, preventDefault } as unknown as React.MouseEvent);
+    });
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(onMenu).not.toHaveBeenCalled();
+  });
+
+  it('touchend shows the menu after the settle delay when a selection survives', () => {
+    const buildMenu = vi.fn(() => ({ text: 'selected' }));
+    const onMenu = vi.fn();
+    const { result } = renderHook(() => useLongPressSelectionMenu(buildMenu, onMenu));
+    act(() => { result.current.onTouchEnd(touchEndEvent(30, 40)); });
+    expect(onMenu).not.toHaveBeenCalled(); // not yet — waiting for the settle delay
+    act(() => { vi.advanceTimersByTime(50); });
+    expect(buildMenu).toHaveBeenCalledWith('CONTAINER', 30, 40);
+    expect(onMenu).toHaveBeenCalledWith({ text: 'selected' });
+  });
+
+  it('touchend calls buildMenu but never onMenu when no selection survives', () => {
+    const buildMenu = vi.fn(() => null);
+    const onMenu = vi.fn();
+    const { result } = renderHook(() => useLongPressSelectionMenu(buildMenu, onMenu));
+    act(() => { result.current.onTouchEnd(touchEndEvent(0, 0)); });
+    act(() => { vi.advanceTimersByTime(50); });
+    expect(buildMenu).toHaveBeenCalled();
+    expect(onMenu).not.toHaveBeenCalled();
+  });
+
+  it('a second touchend before the first settles cancels the first check (debounced)', () => {
+    const buildMenu = vi.fn(() => ({ ok: true }));
+    const onMenu = vi.fn();
+    const { result } = renderHook(() => useLongPressSelectionMenu(buildMenu, onMenu));
+    act(() => { result.current.onTouchEnd(touchEndEvent(0, 0)); });
+    act(() => { vi.advanceTimersByTime(20); }); // before the first settle
+    act(() => { result.current.onTouchEnd(touchEndEvent(5, 5)); });
+    act(() => { vi.advanceTimersByTime(50); });
+    expect(onMenu).toHaveBeenCalledTimes(1); // only the second check fires
+    expect(buildMenu).toHaveBeenLastCalledWith('CONTAINER', 5, 5);
+  });
+
+  it('respects a custom settleDelayMs', () => {
+    const buildMenu = vi.fn(() => ({ ok: true }));
+    const onMenu = vi.fn();
+    const { result } = renderHook(() => useLongPressSelectionMenu(buildMenu, onMenu, 200));
+    act(() => { result.current.onTouchEnd(touchEndEvent(0, 0)); });
+    act(() => { vi.advanceTimersByTime(50); });
+    expect(onMenu).not.toHaveBeenCalled();
+    act(() => { vi.advanceTimersByTime(150); });
+    expect(onMenu).toHaveBeenCalledTimes(1);
+  });
+});

--- a/taxonomy-editor/src/renderer/hooks/useLongPressSelectionMenu.ts
+++ b/taxonomy-editor/src/renderer/hooks/useLongPressSelectionMenu.ts
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3382 (DebateWorkspace fit-or-extend, t/3382#4): `useLongPressContextMenu`'s blind
+// touchstart+500ms timer fits a fixed target (a chip, a badge), but a TEXT-SELECTION context menu
+// needs a different trigger model — the user drags native selection handles for a variable
+// duration, so the menu must appear only once the selection is FINAL, not at a blind timer mark.
+// This sibling hook generalizes DebateWorkspace's own proven `handleTouchEnd` (t/3382#4): on
+// touchend, wait briefly for the mobile browser to finalize the selection, then invoke the
+// caller's menu-builder — which also receives the full event target (not the narrower
+// ContextMenuLikeEvent shape), so callers needing `currentTarget` (e.g. to bound a DOM walk-up)
+// are covered.
+
+import { useCallback, useEffect, useRef } from 'react';
+
+// Mobile Safari/Chrome finalize a touch-driven text selection a beat after touchend fires.
+const DEFAULT_SETTLE_MS = 50;
+
+export interface LongPressSelectionMenuHandlers {
+  onContextMenu: (e: React.MouseEvent) => void;
+  onTouchEnd: (e: React.TouchEvent) => void;
+}
+
+/**
+ * @param buildMenu Pure: given the triggering element and release coordinates, return the menu
+ *   state to show, or null if there's nothing to show (e.g. no selection) — in which case the
+ *   native context menu / native selection callout is left alone.
+ * @param onMenu Called with the built menu state when `buildMenu` returns non-null.
+ * @param settleDelayMs Touch-only: delay after touchend before checking the selection. Default 50ms.
+ */
+export function useLongPressSelectionMenu<T>(
+  buildMenu: (container: EventTarget | null, x: number, y: number) => T | null,
+  onMenu: (menu: T) => void,
+  settleDelayMs: number = DEFAULT_SETTLE_MS,
+): LongPressSelectionMenuHandlers {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => {
+    if (timerRef.current !== null) clearTimeout(timerRef.current);
+  }, []);
+
+  const onContextMenu = useCallback((e: React.MouseEvent) => {
+    const menu = buildMenu(e.currentTarget, e.clientX, e.clientY);
+    if (!menu) return; // no selection → let the native/desktop context menu win
+    e.preventDefault();
+    onMenu(menu);
+  }, [buildMenu, onMenu]);
+
+  const onTouchEnd = useCallback((e: React.TouchEvent) => {
+    const container = e.currentTarget;
+    const touch = e.changedTouches[0];
+    if (!touch) return;
+    const x = touch.clientX;
+    const y = touch.clientY;
+    if (timerRef.current !== null) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      const menu = buildMenu(container, x, y);
+      if (menu) onMenu(menu);
+    }, settleDelayMs);
+  }, [buildMenu, onMenu, settleDelayMs]);
+
+  return { onContextMenu, onTouchEnd };
+}


### PR DESCRIPTION
## t/3382 fit-or-extend — text-selection context menus need a different trigger model

DebateWorkspace found `useLongPressContextMenu` (landed #2061) doesn't fit their text-selection flow (t/3382#4): the blind touchstart+500ms timer fires before the native selection-handle drag finishes, and the fixed `ContextMenuLikeEvent` shape lacks `currentTarget`, which their handler needs to bound a DOM walk-up.

Per TL ruling (t/3382#3): extend the hook, don't fork the logic.

### `useLongPressSelectionMenu<T>(buildMenu, onMenu, settleDelayMs?)`
Generalized from **DebateWorkspace's own already-proven implementation** (their `handleTouchEnd` in the held #2062) rather than reinvented:
- `buildMenu(container, x, y) => T | null` — pure, receives the **full** event target (not a narrowed shape) so callers needing `currentTarget` are covered; returns `null` when there's nothing to show (no selection), leaving the native menu/callout alone.
- `onTouchEnd` — **debounced ~50ms settle delay after release** before checking the selection (mobile Safari/Chrome finalize a touch-driven selection a beat after touchend), not a blind pre-release timer.
- `onContextMenu` — desktop right-click, same semantics as the original hook.

### Consumer impact
DebateWorkspace can replace their local `handleContextMenu`/`handleTouchEnd`/`touchMenuTimerRef` in #2062 with `useLongPressSelectionMenu(buildMenuState, setContextMenu)` — same tested behavior (their own #2062 tests should pass unchanged against the DOM), no duplicated timer logic. Pinging them to consume once this merges.

### Verification
renderer tsc clean · eslint clean · 6 new unit tests (build+show, no-menu no-op, settle-delay timing, debounce-on-rapid-release, custom delay).

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>
Co-Authored-By: DebateWorkspace (Orca) <main.taxonomy-editor-src-renderer-components-debate-workspace@ai-triad-research.orca.local>

🤖 Generated with [Claude Code](https://claude.com/claude-code)