### PR TITLE
fix(touch): adopt useLongPressContextMenu in DebateDiagnostics (t/3386)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/EntryDetailRouter.parts.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/EntryDetailRouter.parts.tsx
@@ -10,8 +10,9 @@
  * hand-authored so the JSX itself stays byte-identical. No DOM/routing/logic changes.
  */
 
-import React from 'react';
+import React, { useCallback } from 'react';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
+import { useLongPressContextMenu } from '../../../hooks/useLongPressContextMenu';
 import { speakerLabel } from './helpers';
 import { api } from '@bridge';
 import type { EntryTab } from './types';
@@ -564,14 +565,27 @@ export function EntryTabContent({ p, m }: PartProps) {
   const { setTextCopyMenu, tabContentRef } = p;
   const { activeTab } = m;
 
+  // t/3386: touch devices never fire `contextmenu` on a long-press — see t/3382.
+  const longPress = useLongPressContextMenu(useCallback((e) => {
+    const sel = window.getSelection()?.toString();
+    if (sel && sel.trim().length > 0) {
+      e.preventDefault();
+      setTextCopyMenu({ x: e.clientX, y: e.clientY, text: sel });
+    }
+  }, [setTextCopyMenu]));
+
   return (
-    <div ref={tabContentRef} tabIndex={0} onContextMenu={(e) => {
-      const sel = window.getSelection()?.toString();
-      if (sel && sel.trim().length > 0) {
-        e.preventDefault();
-        setTextCopyMenu({ x: e.clientX, y: e.clientY, text: sel });
-      }
-    }} className="edr-tab-content" style={activeTab === 'tax-refs' ? { padding: '8px 10px' } : { padding: 0 }}>
+    <div
+      ref={tabContentRef}
+      tabIndex={0}
+      onContextMenu={longPress.onContextMenu}
+      onTouchStart={longPress.onTouchStart}
+      onTouchMove={longPress.onTouchMove}
+      onTouchEnd={longPress.onTouchEnd}
+      onTouchCancel={longPress.onTouchCancel}
+      className="edr-tab-content"
+      style={activeTab === 'tax-refs' ? { padding: '8px 10px' } : { padding: 0 }}
+    >
       <EntryTabPanesPrimary p={p} m={m} />
       <EntryTabPanesSecondary p={p} m={m} />
       <EntryTabPanesTertiary p={p} m={m} />

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/CommitmentsPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/CommitmentsPanel.tsx
@@ -1,12 +1,13 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import type { CommitmentStore, ArgumentNetworkNode, ArgumentNetworkEdge } from '../../../../types/debate';
 import { POVER_INFO } from '../../../../types/debate';
 import type { SpeakerId } from '../../../../types/debate';
 import { bandColor, RISK_BANDS } from '../../../../lib/bandColor';
 import { POV_META, type PovMetaKey } from '@lib/electron-shared/povMeta';
+import { useLongPressContextMenu, type ContextMenuLikeEvent } from '../../../../hooks/useLongPressContextMenu';
 import './CommitmentsPanel.css';
 
 // NOTE: speakerLabel and AifBadge stay in DiagnosticsWindow.tsx (parent).
@@ -52,6 +53,34 @@ function computeAttackTargetMean(
   return atkCount > 0 ? atkSum / atkCount : 0.5;
 }
 
+// t/3386: touch devices never fire `contextmenu` on a long-press — see t/3382. Extracted so
+// useLongPressContextMenu can be called once per row instance (can't call a hook inside .map()).
+function CommitmentItemRow({ item, nodeId, isLast, onContextMenu }: {
+  item: string;
+  nodeId: string | null;
+  isLast: boolean;
+  onContextMenu: (e: ContextMenuLikeEvent) => void;
+}) {
+  const longPress = useLongPressContextMenu(onContextMenu);
+  return (
+    // eslint-disable-next-line local/no-inline-style -- index-driven border bottom
+    <div
+      className="commit-panel-item-row"
+      style={{ borderBottom: isLast ? 'none' : '1px solid var(--border-subtle)' }}
+      onContextMenu={longPress.onContextMenu}
+      onTouchStart={longPress.onTouchStart}
+      onTouchMove={longPress.onTouchMove}
+      onTouchEnd={longPress.onTouchEnd}
+      onTouchCancel={longPress.onTouchCancel}
+    >
+      {nodeId && (
+        <span className="commit-panel-node-badge">{nodeId}</span>
+      )}
+      {item}
+    </div>
+  );
+}
+
 export function CommitmentsPanel({ commitments, nodes, edges, onGoToNode }: {
   commitments: Record<string, CommitmentStore>;
   nodes: ArgumentNetworkNode[];
@@ -87,10 +116,10 @@ export function CommitmentsPanel({ commitments, nodes, edges, onGoToNode }: {
     return null;
   };
 
-  const handleContextMenu = (e: React.MouseEvent, text: string) => {
+  const handleContextMenu = useCallback((e: ContextMenuLikeEvent, text: string) => {
     e.preventDefault();
     setCtxMenu({ x: e.clientX, y: e.clientY, text, nodeId: findNodeId(text) });
-  };
+  }, [findNodeId]);
 
   useEffect(() => {
     if (!ctxMenu) return;
@@ -178,23 +207,15 @@ export function CommitmentsPanel({ commitments, nodes, edges, onGoToNode }: {
                 borderLeft: `3px solid ${cat.color}`,
                 background: `${cat.color}08`,
               }}>
-                {items.map((item, i) => {
-                  const nodeId = findNodeId(item);
-                  return (
-                    // eslint-disable-next-line local/no-inline-style -- index-driven border bottom
-                    <div
-                      key={i}
-                      onContextMenu={(e) => handleContextMenu(e, item)}
-                      className="commit-panel-item-row"
-                      style={{ borderBottom: i < items.length - 1 ? '1px solid var(--border-subtle)' : 'none' }}
-                    >
-                      {nodeId && (
-                        <span className="commit-panel-node-badge">{nodeId}</span>
-                      )}
-                      {item}
-                    </div>
-                  );
-                })}
+                {items.map((item, i) => (
+                  <CommitmentItemRow
+                    key={i}
+                    item={item}
+                    nodeId={findNodeId(item)}
+                    isLast={i === items.length - 1}
+                    onContextMenu={(e) => handleContextMenu(e, item)}
+                  />
+                ))}
               </div>
             );
           })()}


### PR DESCRIPTION
## Summary
t/3382 follow-up — adopts `useLongPressContextMenu` at the 2 DebateDiagnostics-scope call sites with the same touch gap (onContextMenu never fires on long-press on iPad/phone).

- `EntryTabContent` (`EntryDetailRouter.parts.tsx:568`) — single element, direct drop-in wrap.
- `CommitmentsPanel.tsx:187` — extracted `CommitmentItemRow` so the hook can be called once per instance (hooks can't be called inside `.map()`), mirroring `NodeDetail.tsx`'s `LineageChip` extraction from #2061.

Self-certified against /trivial-change per ticket note; no design review needed.

## Test plan
- [x] Renderer `tsc --noEmit` clean
- [x] Existing `EntryDetailRouter.test.tsx` + `CommitmentsPanel.test.tsx` (23 tests) pass unchanged — confirms behavior-preserving wiring
- [ ] Manual: long-press an entry-tab-content selection on a touch device shows the copy menu
- [ ] Manual: long-press a commitment item on a touch device shows the context menu

Closes t/3386
