### PR TITLE
fix(edge-browser): adopt useLongPressContextMenu in SimilarSearchPanel (t/3383)

### DIFF
--- a/taxonomy-editor/src/renderer/components/edge-browser/SimilarSearchPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/edge-browser/SimilarSearchPanel.tsx
@@ -5,6 +5,7 @@ import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
 import { nodePovFromId, SITUATION_PREFIX } from '@lib/debate/nodeIdUtils';
 import { POV_KEYS } from '@lib/debate/types';
 import { useTaxonomyStore } from '../../hooks/useTaxonomyStore';
+import { useLongPressContextMenu, type ContextMenuLikeEvent } from '../../hooks/useLongPressContextMenu';
 import { ApiKeyErrorMessage } from '../settings/ApiKeyErrorMessage';
 import { useDescriptionMode, resolveDescription } from '../shared/DescriptionToggle';
 import './SimilarSearchPanel.css';
@@ -23,6 +24,37 @@ interface ResolvedRow {
 interface SimilarSearchPanelProps {
   width?: number;
   onAnalyze?: (elementB: { label: string; description: string; category: string }) => void;
+}
+
+// t/3382 follow-up: extracted so useLongPressContextMenu can be called once per row
+// instance (can't call a hook inside .map()).
+function SimilarSearchRow({ row, showIds, onRowClick, onContextMenu }: {
+  row: ResolvedRow;
+  showIds: boolean;
+  onRowClick: (id: string) => void;
+  onContextMenu: (e: ContextMenuLikeEvent, row: ResolvedRow) => void;
+}) {
+  const longPress = useLongPressContextMenu(useCallback((e) => onContextMenu(e, row), [onContextMenu, row]));
+  return (
+    <tr
+      className="similar-table-row"
+      onClick={() => onRowClick(row.id)}
+      onContextMenu={longPress.onContextMenu}
+      onTouchStart={longPress.onTouchStart}
+      onTouchMove={longPress.onTouchMove}
+      onTouchEnd={longPress.onTouchEnd}
+      onTouchCancel={longPress.onTouchCancel}
+    >
+      <td className="similar-table-match">
+        {Math.round(row.score * 100)}%
+      </td>
+      {showIds && (
+        <td className="similar-table-id">{row.id}</td>
+      )}
+      <td className="similar-table-label">{row.label}</td>
+      <td className="similar-table-desc">{row.description}</td>
+    </tr>
+  );
 }
 
 export function SimilarSearchPanel({ width, onAnalyze }: SimilarSearchPanelProps) {
@@ -208,7 +240,7 @@ export function SimilarSearchPanel({ width, onAnalyze }: SimilarSearchPanelProps
     if (tab) navigateToNode(tab, id);
   };
 
-  const handleContextMenu = (e: React.MouseEvent, row: ResolvedRow) => {
+  const handleContextMenu = (e: ContextMenuLikeEvent, row: ResolvedRow) => {
     e.preventDefault();
     setContextMenu({ x: e.clientX, y: e.clientY, row });
   };
@@ -320,21 +352,13 @@ export function SimilarSearchPanel({ width, onAnalyze }: SimilarSearchPanelProps
                   </tr>
                 ) : (
                   filteredAndSorted.map((r) => (
-                    <tr
+                    <SimilarSearchRow
                       key={r.id}
-                      className="similar-table-row"
-                      onClick={() => handleRowClick(r.id)}
-                      onContextMenu={(e) => handleContextMenu(e, r)}
-                    >
-                      <td className="similar-table-match">
-                        {Math.round(r.score * 100)}%
-                      </td>
-                      {showIds && (
-                        <td className="similar-table-id">{r.id}</td>
-                      )}
-                      <td className="similar-table-label">{r.label}</td>
-                      <td className="similar-table-desc">{r.description}</td>
-                    </tr>
+                      row={r}
+                      showIds={showIds}
+                      onRowClick={handleRowClick}
+                      onContextMenu={handleContextMenu}
+                    />
                   ))
                 )}
               </tbody>


### PR DESCRIPTION
## Summary
- t/3382 (#2061) added `useLongPressContextMenu` for touch support on `onContextMenu`-only handlers; `SimilarSearchPanel.tsx`'s per-row context menu had the same touch gap.
- Extracts a `SimilarSearchRow` sub-component (module scope, mirroring `NodeDetail.tsx`'s `LineageChip` pattern) since hooks can't be called inside `.map()`.
- Desktop right-click behavior is unchanged; touch long-press now opens the same "Analyze Distinction" context menu.

Self-cert: /trivial-change (drop-in wrap per ticket's own spec, no new interfaces, no schema/data-model change).

## Test plan
- [x] `npx tsc --noEmit -p .` — clean for this file
- [x] `npx eslint src/renderer/components/edge-browser/SimilarSearchPanel.tsx` — 0 errors (pre-existing inline-style warnings elsewhere unaffected)
- [x] `npx vitest run src/renderer/components/edge-browser/` — 22/22 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: EdgeBrowser (Orca) <main.taxonomy-editor-src-renderer-components-edge-browser@ai-triad-research.orca.local>