### PR TITLE
fix(chat): adopt useLongPressContextMenu for touch support in PromptDiffPane (t/3388)

### DIFF
--- a/taxonomy-editor/src/renderer/components/chat/PromptDiffPane.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/PromptDiffPane.tsx
@@ -10,6 +10,7 @@ import type { SpeakerId } from '../../types/debate';
 import { humanizeSpeakerIds } from '../../utils/humanizeSpeakers';
 import { resolveSpeaker } from '../shared/SpeakerIdentity';
 import { useFlag } from '../../hooks/useFeatureFlags';
+import { useLongPressContextMenu, type ContextMenuLikeEvent } from '../../hooks/useLongPressContextMenu';
 import './PromptDiffPane.css';
 
 const STAGE_COLORS: Record<string, string> = {
@@ -516,12 +517,13 @@ function ValidationPanelContainer({ node, height, onResize, onFind }: {
   const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number; text: string } | null>(null);
   const dragRef = useRef<{ startY: number; startH: number } | null>(null);
 
-  const handleContextMenu = useCallback((e: React.MouseEvent) => {
+  const handleContextMenu = useCallback((e: ContextMenuLikeEvent) => {
     const sel = window.getSelection()?.toString().trim();
     if (!sel) return; // no selection — let default menu show
     e.preventDefault();
     setCtxMenu({ x: e.clientX, y: e.clientY, text: sel });
   }, []);
+  const longPress = useLongPressContextMenu(handleContextMenu);
 
   // Close context menu on any click
   useEffect(() => {
@@ -594,7 +596,14 @@ function ValidationPanelContainer({ node, height, onResize, onFind }: {
       </div>
       {/* Content */}
       {!collapsed && (
-        <div className="pdp-flex1-auto" onContextMenu={handleContextMenu}>
+        <div
+          className="pdp-flex1-auto"
+          onContextMenu={longPress.onContextMenu}
+          onTouchStart={longPress.onTouchStart}
+          onTouchMove={longPress.onTouchMove}
+          onTouchEnd={longPress.onTouchEnd}
+          onTouchCancel={longPress.onTouchCancel}
+        >
           <ValidationPanel
             validation={node.validation}
             qualityCheck={node.qualityCheck}
@@ -996,12 +1005,13 @@ export function PromptDiffPane({ pane, paneIndex, isReference, isFocused, onClos
 
   // Context menu for copying selected text
   const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number; text: string } | null>(null);
-  const handleContextMenu = useCallback((e: React.MouseEvent) => {
+  const handleContextMenu = useCallback((e: ContextMenuLikeEvent) => {
     const sel = window.getSelection()?.toString().trim();
     if (!sel) return;
     e.preventDefault();
     setCtxMenu({ x: e.clientX, y: e.clientY, text: sel });
   }, []);
+  const contentLongPress = useLongPressContextMenu(handleContextMenu);
   useEffect(() => {
     if (!ctxMenu) return;
     const close = () => setCtxMenu(null);
@@ -1080,7 +1090,11 @@ export function PromptDiffPane({ pane, paneIndex, isReference, isFocused, onClos
       <div
         ref={contentRef}
         onScroll={handleScroll}
-        onContextMenu={handleContextMenu}
+        onContextMenu={contentLongPress.onContextMenu}
+        onTouchStart={contentLongPress.onTouchStart}
+        onTouchMove={contentLongPress.onTouchMove}
+        onTouchEnd={contentLongPress.onTouchEnd}
+        onTouchCancel={contentLongPress.onTouchCancel}
         className="pdp-content"
         // eslint-disable-next-line local/no-inline-style -- dynamic: overflow-x/white-space/word-break depend on wordWrap
         style={{


### PR DESCRIPTION
## Summary
- Wire `useLongPressContextMenu` (t/3382, #2061) onto PromptDiffPane's two `onContextMenu` call sites: the validation panel content wrapper and the main diff content pane
- Retype each `handleContextMenu` callback's event param from `React.MouseEvent` to `ContextMenuLikeEvent` to satisfy the hook's contract (both handlers only read `preventDefault`/`clientX`/`clientY`, so no behavior change)
- Desktop right-click behavior unchanged; touch long-press now reaches the same handler

## Self-cert
Self-certifying under /trivial-change per ticket description.
Change: Adopt existing useLongPressContextMenu hook at 2 call sites, following t/3382's established pattern
Files: PromptDiffPane.tsx
Lines changed: 18 insertions, 4 deletions
Verify gate: `bash scripts/check-renderer-tsc.sh` run locally (node_modules junctioned from main checkout) — 0 new errors from this change; 3 pre-existing unrelated errors in `lib/brief` and `lib/sanitize` (missing optional deps, untouched files)
Deviations: none

## Test plan
- [ ] Desktop: right-click on validation panel content and main diff content still opens the copy-selection context menu
- [ ] Touch/iPad: long-press (500ms) on selected text in either pane opens the same context menu
- [ ] Long-press cancels if touch drifts >10px (scroll doesn't false-trigger)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)