### PR TITLE
feat(devops): durable telemetry sink for done-evidence gate (t/3394)

### DIFF
--- a/operations/devops/.gitignore
+++ b/operations/devops/.gitignore
@@ -1,0 +1,4 @@
+# Durable telemetry sink for the done-evidence gate (t/3394). The platform execution-telemetry
+# writer died in the late-May Orca update (Orca Support t/3394#2), so the gate predicate appends its
+# own queryable execution records here for the post-flip re-audit. Runtime data — never committed.
+.gate-telemetry/

--- a/operations/devops/done-evidence-predicate.mjs
+++ b/operations/devops/done-evidence-predicate.mjs
@@ -92,6 +92,28 @@ export function countEvidenceAcrossRepos({ key, repoDirs, runGit, existsDir, war
   return { hitCount, gitOk };
 }
 
+/**
+ * PURE builder for a durable telemetry record (t/3394). The platform execution-telemetry writer died
+ * in the late-May Orca update (confirmed Orca Support t/3394#2): `recent_executions`/`fire_count` are
+ * unfed and run-gate stderr lands NOWHERE queryable. So the shim appends this record to a DevOps-owned
+ * JSONL, restoring the execution history the post-flip re-audit (t/3360 cond-3b) needs — including the
+ * fail-open WARNs that were otherwise invisible (the t/3085 silently-dead-safety-net class).
+ * Pure + exported so the record shape is unit-tested; the append itself stays in the impure shim,
+ * wrapped so a sink failure can NEVER change the verdict.
+ */
+export function buildSinkRecord({ nowIso, rawTicketId, key, verdict, hitCount, gitOk, warns } = {}) {
+  return {
+    ts: nowIso ?? null,
+    ticket_id: rawTicketId ?? null,
+    key: key ?? null,
+    decision: verdict && verdict.block ? 'block' : 'allow',
+    reason: verdict ? verdict.reason : null,
+    hitCount: hitCount ?? null,
+    gitOk: gitOk ?? null,
+    failOpen: warns ?? [],
+  };
+}
+
 // CLI shim (the ONLY impure part). Convention (worktree-path-guard / merge-guard): BLOCK == write
 // 'fire' to stdout; ALLOW == exit 0 with no stdout. The feedback rule invokes THIS module by abs
 // path so the rule runs the exact logic the both-arms test proves (test == runtime, TL GV t/3270#4).
@@ -107,6 +129,7 @@ if (process.argv[1] && process.argv[1].replace(/\\/g, '/').endsWith('done-eviden
     //                mirrors the .aitriad.json resolution priority in root AGENTS.md).
     const repoRoot = fileURLToPath(new URL('../../', import.meta.url));
     const dataRoot = process.env.AI_TRIAD_DATA_ROOT || fileURLToPath(new URL('../../../ai-triad-data', import.meta.url));
+    const warns = []; // fail-open reasons collected for both the stderr WARN and the durable sink record
     const { hitCount, gitOk } = countEvidenceAcrossRepos({
       key,
       repoDirs: [repoRoot, dataRoot],
@@ -133,15 +156,38 @@ if (process.argv[1] && process.argv[1].replace(/\\/g, '/').endsWith('done-eviden
         });
         return out.split(/\r?\n/).filter((l) => l.trim()).length;
       },
-      // Fallback-Path Logging (SO cond 3): make every fail-open VISIBLE. stderr is captured into the
-      // feedback-rule execution log, so a gate that quietly dies (git unreachable / PATH drift) is
-      // detectable instead of masquerading as "all Done transitions evidence-checked" (t/3085 class).
+      // Fallback-Path Logging (SO cond 3): make every fail-open VISIBLE. NOTE (t/3394): the platform
+      // execution-telemetry writer is DEAD since the late-May Orca update — stderr lands nowhere
+      // queryable — so this WARN is also captured into the durable sink below (that is what the
+      // re-audit actually reads); stderr is kept as a best-effort second channel.
       warn: (info) => {
+        warns.push(info);
         const where = info.dir ? ` repo=${info.dir}` : '';
         const why = info.error ? ` error=${info.error}` : '';
         process.stderr.write(`WARN done-evidence gate FAIL-OPEN (${info.reason})${where}${why}\n`);
       },
     });
-    if (doneEvidenceVerdict({ statusTarget, hitCount, gitOk }).block) process.stdout.write('fire');
+    const verdict = doneEvidenceVerdict({ statusTarget, hitCount, gitOk });
+    // Durable telemetry sink (t/3394; Orca Support t/3394#2 confirmed no live platform sink exists).
+    // Append a queryable execution record — the source the post-flip re-audit reads for fire/fail-open
+    // rates + fail-open visibility. BEST-EFFORT and fully isolated: the verdict is already computed, and
+    // any sink failure is swallowed so telemetry can NEVER change the gate's block/allow decision.
+    try {
+      const rec = buildSinkRecord({
+        nowIso: new Date().toISOString(),
+        rawTicketId: process.argv[3] || null,
+        key,
+        verdict,
+        hitCount,
+        gitOk,
+        warns,
+      });
+      const dir = fileURLToPath(new URL('./.gate-telemetry/', import.meta.url)); // operations/devops/.gate-telemetry/
+      fs.mkdirSync(dir, { recursive: true });
+      fs.appendFileSync(`${dir}done-evidence.jsonl`, `${JSON.stringify(rec)}\n`);
+    } catch {
+      // telemetry is best-effort — never let a sink failure break the gate
+    }
+    if (verdict.block) process.stdout.write('fire');
   }
 }

--- a/operations/devops/done-evidence-predicate.test.mjs
+++ b/operations/devops/done-evidence-predicate.test.mjs
@@ -8,7 +8,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { doneEvidenceVerdict, normalizeTicketKey, countEvidenceAcrossRepos } from './done-evidence-predicate.mjs';
+import { doneEvidenceVerdict, normalizeTicketKey, countEvidenceAcrossRepos, buildSinkRecord } from './done-evidence-predicate.mjs';
 
 // A tiny fake-git harness for the pure two-repo aggregation: map repo dir → hit count, or the
 // sentinel 'ERR' to make that repo's git call throw. Absent-from-map dirs are treated as present-but-0
@@ -186,4 +186,51 @@ test('both repos error → gitOk false, one warn PER failing repo', () => {
   });
   assert.equal(gitOk, false);
   assert.equal(warns.length, 2);
+});
+
+// ── buildSinkRecord: durable telemetry record shape (t/3394) ──
+// The platform execution-telemetry writer is dead (Orca Support t/3394#2); the shim appends these
+// records so the re-audit has a queryable source. Prove the record maps the verdict + carries the
+// fail-open reasons (the otherwise-invisible signal).
+
+test('sink record: BLOCK verdict → decision=block, carries reason + counts', () => {
+  const r = buildSinkRecord({
+    nowIso: '2026-09-07T20:00:00.000Z', rawTicketId: 't/8888888', key: 't/8888888',
+    verdict: { block: true, reason: 'no-committed-evidence' }, hitCount: 0, gitOk: true, warns: [],
+  });
+  assert.equal(r.decision, 'block');
+  assert.equal(r.reason, 'no-committed-evidence');
+  assert.equal(r.ts, '2026-09-07T20:00:00.000Z');
+  assert.equal(r.key, 't/8888888');
+  assert.equal(r.hitCount, 0);
+  assert.equal(r.gitOk, true);
+  assert.deepEqual(r.failOpen, []);
+});
+
+test('sink record: ALLOW verdict → decision=allow', () => {
+  const r = buildSinkRecord({
+    nowIso: 'x', rawTicketId: 't/3372', key: 't/3372',
+    verdict: { block: false, reason: 'evidence-present' }, hitCount: 3, gitOk: true, warns: [],
+  });
+  assert.equal(r.decision, 'allow');
+  assert.equal(r.reason, 'evidence-present');
+});
+
+test('sink record: fail-open reasons are carried into failOpen (the re-audit signal)', () => {
+  const warns = [{ reason: 'git-error', dir: '/repo', error: 'boom' }];
+  const r = buildSinkRecord({
+    nowIso: 'x', rawTicketId: 't/42', key: 't/42',
+    verdict: { block: false, reason: 'git-unavailable-fail-open' }, hitCount: 0, gitOk: false, warns,
+  });
+  assert.equal(r.decision, 'allow'); // fail-open is an allow
+  assert.equal(r.reason, 'git-unavailable-fail-open');
+  assert.equal(r.gitOk, false);
+  assert.deepEqual(r.failOpen, warns);
+});
+
+test('sink record: empty/undefined args never throw and default cleanly', () => {
+  const r = buildSinkRecord();
+  assert.equal(r.decision, 'allow'); // no verdict → not a block
+  assert.equal(r.reason, null);
+  assert.deepEqual(r.failOpen, []);
 });


### PR DESCRIPTION
## What
Adds a DevOps-owned durable execution-telemetry sink to the done-evidence gate predicate, restoring the queryable execution history the post-flip re-audit (t/3360 condition-3b) needs.

## Why (Orca Support diagnosis, t/3394#2)
The platform execution-telemetry writer **died in the late-May Orca update**: `recent_executions`/`fire_count_24h`/`last_fired_at` are unfed for *all* rules (confirmed against high-traffic `scope-guard`), `executions/feedback-rules.jsonl` stalled 2026-05-29, and run-gate script **stderr lands nowhere queryable**. So the SO condition-3 / TL rider-1 fail-open observability the blocking flip was gated on is realized-broken (the t/3085 silently-dead-safety-net class). Orca Support confirmed no agent-side fix revives the platform writer and **endorsed this fallback**; they're reporting the regression upstream.

## How
- New **pure** `buildSinkRecord()` (exported, unit-tested) → `{ts, ticket_id, key, decision, reason, hitCount, gitOk, failOpen[]}`.
- The shim appends one JSONL line per Done-transition evaluation to `operations/devops/.gate-telemetry/done-evidence.jsonl`. **Best-effort + fully isolated**: the verdict is computed first, the append is wrapped in try/catch, so a sink failure can **never** change the gate's block/allow decision.
- `operations/devops/.gitignore` keeps the runtime sink untracked (invisible to `git status` → does not trip the shared-drift guard).
- Corrected the stale "stderr captured into the execution log" comment.

## Evidence
- **23/23** tests (+4 sink-record: block/allow/fail-open mapping, empty-args safety).
- **Live**: allow (evidence-present), block (no-evidence, emits `fire`), and non-Done (not logged) all correct; sink file confirmed gitignored; verdict output unchanged.

## Scope
Observability plumbing only — **no change to block/allow logic or the rule template**. Escape-abuse detection (TL rider 1) is partially enabled via "Done-without-a-sink-entry" cross-referencing; full disabled-window attribution still needs rule enable/disable history (also lost with the platform telemetry) — noted on t/3394. Endorsed by Orca Support (t/3394#2); TL notified on e/147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)