### PR TITLE
feat(debate): thread greatest-hits exclusion into topic-critique framing (t/3392)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/debateSlices.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/debateSlices.test.ts
@@ -15,6 +15,16 @@ import { useDebateStore } from '../../useDebateStore';
 // atomic edges `setState` (node + edges persisted together, t/1773 AC2).
 import { useTaxonomyStore } from '../../useTaxonomyStore';
 import { executeTurnWithRetry, runModeratorSelection } from '@lib/debate/orchestration';
+// t/3392: computeStructuralScore is mocked wholesale in storeTestHarness.ts (fixed canned
+// output — unrelated tests don't exercise real scoring math), so the correct test boundary is
+// the CALL ARGUMENTS it receives, not its output: assert the exclusion filter changed what's
+// passed in, not what the canned mock returns.
+import { computeStructuralScore } from '@lib/debate/topicCritique';
+
+// t/3392: mocked here (not in the shared harness) — only this file's greatest-hits-exclusion
+// tests need it. vi.mock is file-scoped and hoisted regardless of placement.
+const { mockGetGreatestHits } = vi.hoisted(() => ({ mockGetGreatestHits: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../shared/getGreatestHits', () => ({ getGreatestHits: mockGetGreatestHits }));
 
 // ── 15. loadSessions ────────────────────────────────────────
 
@@ -500,6 +510,62 @@ describe('Topic critique slice: reEvaluateSuggestedTopic', () => {
     await useDebateStore.getState().reEvaluateSuggestedTopic('   ');
 
     expect(mockApi.generateText).not.toHaveBeenCalled();
+  });
+});
+
+describe('Topic critique slice: greatest-hits exclusion reshapes framing (t/3392)', () => {
+  afterEach(() => {
+    mockTaxonomyState.accelerationist.nodes = [];
+  });
+
+  function setUpOneNode() {
+    mockTaxonomyState.accelerationist.nodes = [
+      { id: 'acc-test-001', label: 'Test Node', description: 'Excludable test node', category: 'beliefs' },
+    ] as any;
+    mockApi.computeQueryEmbedding.mockResolvedValue({ vector: [1, 0] });
+    mockApi.computeEmbeddings.mockResolvedValue({ vectors: [[1, 0]] });
+  }
+
+  // computeStructuralScore is mocked with a fixed canned return in storeTestHarness.ts, so these
+  // assert on the CALL ARGUMENTS it receives — proving the exclusion filter changed the corpus fed
+  // to structural scoring (which is what would, with the real function, change activated_nodes /
+  // the frame prompt / rewritten_topic). Both-arms per the ticket's AC.
+
+  it('excludes the greatest-hits node from the structural-score input when the toggle is on', async () => {
+    setUpOneNode();
+    mockGetGreatestHits.mockResolvedValue(['acc-test-001']);
+    useDebateStore.setState({ activeDebate: makeSession({ exclude_greatest_hits: true }) as any });
+
+    await useDebateStore.getState().runTopicCritique();
+
+    const call = vi.mocked(computeStructuralScore).mock.calls[0][0];
+    expect(Object.keys(call.embeddings)).not.toContain('acc-test-001');
+    expect(call.povNodes.map(n => n.id)).not.toContain('acc-test-001');
+  });
+
+  it('leaves the node in the structural-score input when the toggle is off (regression guard)', async () => {
+    setUpOneNode();
+    // List is present but the flag is off — must be ignored, proving the toggle (not just list
+    // availability) gates the exclusion.
+    mockGetGreatestHits.mockResolvedValue(['acc-test-001']);
+    useDebateStore.setState({ activeDebate: makeSession({ exclude_greatest_hits: false }) as any });
+
+    await useDebateStore.getState().runTopicCritique();
+
+    const call = vi.mocked(computeStructuralScore).mock.calls[0][0];
+    expect(Object.keys(call.embeddings)).toContain('acc-test-001');
+    expect(call.povNodes.map(n => n.id)).toContain('acc-test-001');
+  });
+
+  it('degrades to unfiltered when the toggle is on but the exclusion list is unavailable', async () => {
+    setUpOneNode();
+    mockGetGreatestHits.mockResolvedValue(undefined);
+    useDebateStore.setState({ activeDebate: makeSession({ exclude_greatest_hits: true }) as any });
+
+    await useDebateStore.getState().runTopicCritique();
+
+    const call = vi.mocked(computeStructuralScore).mock.calls[0][0];
+    expect(Object.keys(call.embeddings)).toContain('acc-test-001');
   });
 });
 

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/topicCritiqueSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/topicCritiqueSlice.ts
@@ -12,7 +12,51 @@ import type { LineageFrameEntry } from '@lib/debate/topicCritique';
 import { useTaxonomyStore } from '../../useTaxonomyStore';
 import { getConfiguredModel } from '../shared/modelConfig';
 import { generateTextWithProgress } from '../shared/generation';
+import { getGreatestHits } from '../shared/getGreatestHits';
 import { getLineageMapping, getL2Categories, isLineageDataLoaded } from '../../../data/lineageCategories';
+
+// t/3392: the same corpus-narrowing the per-turn taxonomy relevance path applies (t/1998,
+// taxonomyContext.ts) must also apply to topic-critique framing, or "exclude greatest hits" only
+// prunes the debater shortlist while the frame prompt still sees the full corpus. Fetches the
+// exclusion list once per critique call; returns undefined when the toggle is off OR the list is
+// requested-but-unavailable — callers get the unfiltered (today's) behavior in both cases, with a
+// WARN on the latter so a missing calibration file degrades loudly, not silently (fallback-path
+// logging convention, docs/error-handling.md).
+async function getFramingExclusionSet(excludeFlag: boolean | undefined, debateId: string): Promise<Set<string> | undefined> {
+  if (!excludeFlag) return undefined;
+  const ids = await getGreatestHits();
+  if (ids && ids.length > 0) return new Set(ids);
+  getGlobalRecorder()?.record({
+    type: 'system.error',
+    debate_id: debateId,
+    component: 'debate-store',
+    level: 'warn',
+    message: 'Greatest-hits exclusion is On but the exclusion list is unavailable — topic-critique framing NOT filtered (t/3392)',
+    data: { reason: ids ? 'empty_list' : 'list_unavailable' },
+  });
+  return undefined;
+}
+
+/** Drop excluded node ids from the pov/situation node lists and the embeddings map fed to
+ *  computeStructuralScore — the exclusion must apply to ALL THREE consistently (t/3392), since
+ *  computeStructuralScore looks up the pov node for an activated embedding by id. */
+function applyFramingExclusion<P extends { id: string }, S extends { id: string }>(
+  povNodes: P[],
+  situationNodes: S[],
+  nodeEmbeddings: Record<string, { pov: string; vector: number[] }>,
+  exclude: Set<string> | undefined,
+): { povNodes: P[]; situationNodes: S[]; nodeEmbeddings: Record<string, { pov: string; vector: number[] }> } {
+  if (!exclude || exclude.size === 0) return { povNodes, situationNodes, nodeEmbeddings };
+  const filteredEmbeddings: Record<string, { pov: string; vector: number[] }> = {};
+  for (const [id, entry] of Object.entries(nodeEmbeddings)) {
+    if (!exclude.has(id)) filteredEmbeddings[id] = entry;
+  }
+  return {
+    povNodes: povNodes.filter(n => !exclude.has(n.id)),
+    situationNodes: situationNodes.filter(n => !exclude.has(n.id)),
+    nodeEmbeddings: filteredEmbeddings,
+  };
+}
 
 export interface TopicCritiqueSlice {
   topicCritiqueLoading: boolean;
@@ -76,11 +120,16 @@ export const createTopicCritiqueSlice: StateCreator<DebateStore, [], [], TopicCr
         nodeEmbeddings[allNodeIds[i]] = { pov: povNode?.pov ?? 'situations', vector: nodeVectors[i] };
       }
 
+      // t/3392: apply the debate's greatest-hits exclusion to framing, same as the per-turn path.
+      const exclusionSet = await getFramingExclusionSet(activeDebate.exclude_greatest_hits, activeDebate.id);
+      const framingSituationNodes = sitNodes.map(n => ({ id: n.id }));
+      const filtered = applyFramingExclusion(allPovNodes, framingSituationNodes, nodeEmbeddings, exclusionSet);
+
       const structuralScore = computeStructuralScore({
         topicEmbedding,
-        povNodes: allPovNodes,
-        situationNodes: sitNodes.map(n => ({ id: n.id })),
-        embeddings: nodeEmbeddings,
+        povNodes: filtered.povNodes,
+        situationNodes: filtered.situationNodes,
+        embeddings: filtered.nodeEmbeddings,
       });
 
       let lineageFrame: LineageFrameEntry[] = [];
@@ -134,11 +183,13 @@ export const createTopicCritiqueSlice: StateCreator<DebateStore, [], [], TopicCr
       if (critique.rewritten_topic && critique.rewritten_topic !== topic) {
         try {
           const { vector: suggestedEmbedding } = await api.computeQueryEmbedding(critique.rewritten_topic);
+          // t/3392: same filtered set as the original-topic score above — the composite-score
+          // comparison a few lines down must compare apples to apples under the same exclusion.
           const suggestedStructural = computeStructuralScore({
             topicEmbedding: suggestedEmbedding,
-            povNodes: allPovNodes,
-            situationNodes: sitNodes.map(n => ({ id: n.id })),
-            embeddings: nodeEmbeddings,
+            povNodes: filtered.povNodes,
+            situationNodes: filtered.situationNodes,
+            embeddings: filtered.nodeEmbeddings,
           });
           const suggestedPrompt = critiqueTopicPrompt(critique.rewritten_topic, formatStructuralContext(suggestedStructural));
           const { text: suggestedText } = await generateTextWithProgress(suggestedPrompt, model, `Scoring suggested topic (${model})`, set);
@@ -238,11 +289,16 @@ export const createTopicCritiqueSlice: StateCreator<DebateStore, [], [], TopicCr
         nodeEmbeddings[allNodeIds[i]] = { pov: povNode?.pov ?? 'situations', vector: nodeVectors[i] };
       }
 
+      // t/3392: same exclusion as runTopicCritique — re-evaluation must frame under the same
+      // corpus the original critique + the debate itself use.
+      const exclusionSet = await getFramingExclusionSet(activeDebate.exclude_greatest_hits, activeDebate.id);
+      const filtered = applyFramingExclusion(allPovNodes, sitNodes.map(n => ({ id: n.id })), nodeEmbeddings, exclusionSet);
+
       const suggestedStructural = computeStructuralScore({
         topicEmbedding: suggestedEmbedding,
-        povNodes: allPovNodes,
-        situationNodes: sitNodes.map(n => ({ id: n.id })),
-        embeddings: nodeEmbeddings,
+        povNodes: filtered.povNodes,
+        situationNodes: filtered.situationNodes,
+        embeddings: filtered.nodeEmbeddings,
       });
 
       const suggestedPrompt = critiqueTopicPrompt(suggestedText, formatStructuralContext(suggestedStructural));


### PR DESCRIPTION
## t/3392 — "exclude greatest hits" now reshapes debate framing, not just the debater shortlist

PI request (Jeffrey, p/314#52-55). `runTopicCritique`/`reEvaluateSuggestedTopic` fed the FULL taxonomy corpus to `computeStructuralScore` regardless of the debate's greatest-hits exclusion toggle, so framing (`rewritten_topic`, structural score) was identical toggle-on vs off.

### AC1 — flag availability (traced empirically, t/2294 discipline)
`runTopicCritique` only fires from a `useEffect` in `ClarificationPanel.tsx` gated on `activeDebate` already existing; `createDebate` (sessionSlice.ts) sets `exclude_greatest_hits` synchronously **before** the debate object is ever exposed. The flag is always populated at critique time — no setup-option sourcing needed.

### Design (per CL's spec, t/3392#1) — Rosetta-only, no `lib/debate` change
- **`getFramingExclusionSet`** — fetches the exclusion list via the existing `getGreatestHits()` helper (same one the per-turn path uses, t/1998); WARNs and returns `undefined` on requested-but-unavailable (fallback-path logging convention), matching the per-turn path's loud-degrade semantics.
- **`applyFramingExclusion`** — drops excluded ids from `povNodes` + `situationNodes` + the embeddings map fed to `computeStructuralScore` consistently (the fn looks up the pov node for an activated embedding by id).
- Applied in **both** `runTopicCritique` scoring calls (original topic AND the suggested/rewritten-topic rescore — the composite-score comparison between them must be apples-to-apples under the same exclusion) and in `reEvaluateSuggestedTopic`.

### Tests (both-arms, call-argument assertions)
`computeStructuralScore` is mocked wholesale in this test file's shared harness (canned output — unrelated tests don't exercise real scoring math), so the correct boundary is proving the exclusion filter changed the **input** fed to it:
1. Excludes the node from `computeStructuralScore`'s `embeddings`/`povNodes` when the toggle is on.
2. Leaves it in when the toggle is off — regression guard, with the exclusion list present-but-ignored (proves the toggle, not list-availability, gates it).
3. Degrades to unfiltered when the toggle is on but the list is unavailable.

**RED arm proven** — temporarily reverted the fix and confirmed exactly test 1 fails.

### Verification
renderer tsc clean · full `useDebateStore` suite 285/285 · eslint: 3 pre-existing complexity/console warnings on `topicCritiqueSlice.ts`, confirmed identical (same values) via a `git stash` baseline diff — not introduced or worsened by this change.

Draft — routing to CL for the prompt/structural-score review per t/3392#1 (framing is a prompt/metric-bearing surface; no TL/SO pass needed, not a schema/gate change).

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>
Co-Authored-By: Computational Linguist (Orca) <main.research-comp-linguist@ai-triad-research.orca.local>

🤖 Generated with [Claude Code](https://claude.com/claude-code)