### PR TITLE
feat(devops): extend durable telemetry sink to merge-guard + joint-gv guards (t/3395)

### DIFF
--- a/operations/devops/done-evidence-predicate.mjs
+++ b/operations/devops/done-evidence-predicate.mjs
@@ -4,6 +4,7 @@
 import { execFileSync } from 'node:child_process'; // used only by the CLI shim's git query
 import { fileURLToPath } from 'node:url'; // resolve repo dirs from the module path, not cwd
 import fs from 'node:fs'; // existsSync guard for the (optionally absent) data repo
+import { appendGateTelemetry, gateTelemetryDir } from './gate-telemetry.mjs'; // shared durable sink (t/3395)
 
 /**
  * Pure verdict for the done-requires-EVIDENCE gate (t/3360, G1 cross-check audit).
@@ -172,22 +173,18 @@ if (process.argv[1] && process.argv[1].replace(/\\/g, '/').endsWith('done-eviden
     // Append a queryable execution record — the source the post-flip re-audit reads for fire/fail-open
     // rates + fail-open visibility. BEST-EFFORT and fully isolated: the verdict is already computed, and
     // any sink failure is swallowed so telemetry can NEVER change the gate's block/allow decision.
-    try {
-      const rec = buildSinkRecord({
-        nowIso: new Date().toISOString(),
-        rawTicketId: process.argv[3] || null,
-        key,
-        verdict,
-        hitCount,
-        gitOk,
-        warns,
-      });
-      const dir = fileURLToPath(new URL('./.gate-telemetry/', import.meta.url)); // operations/devops/.gate-telemetry/
-      fs.mkdirSync(dir, { recursive: true });
-      fs.appendFileSync(`${dir}done-evidence.jsonl`, `${JSON.stringify(rec)}\n`);
-    } catch {
-      // telemetry is best-effort — never let a sink failure break the gate
-    }
+    const rec = buildSinkRecord({
+      nowIso: new Date().toISOString(),
+      rawTicketId: process.argv[3] || null,
+      key,
+      verdict,
+      hitCount,
+      gitOk,
+      warns,
+    });
+    // Shared durable sink (t/3395): appendGateTelemetry is itself best-effort + swallows all errors,
+    // so this can never affect the verdict — the isolation invariant lives in the helper now.
+    appendGateTelemetry({ dir: gateTelemetryDir(import.meta.url), fileName: 'done-evidence.jsonl', record: rec });
     if (verdict.block) process.stdout.write('fire');
   }
 }

--- a/operations/devops/gate-telemetry.mjs
+++ b/operations/devops/gate-telemetry.mjs
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Shared durable telemetry sink for DevOps run-gate predicates (t/3394 / t/3395).
+ *
+ * WHY: the Orca platform execution-telemetry writer died in the late-May update (confirmed Orca
+ * Support t/3394#2) — `recent_executions`/`fire_count_24h` are unfed and run-gate script stdout/stderr
+ * land nowhere queryable. So every blocking gate's fires/allows/fail-* events are invisible (the
+ * t/3085 silently-dead-safety-net class). Each gate appends its own queryable JSONL record here to
+ * restore an observable execution history; this module is the single shared append primitive so the
+ * three blocking predicates don't each carry a divergent copy (TL e/147#5 — the class fix).
+ *
+ * ISOLATION INVARIANT (load-bearing): a gate calls appendGateTelemetry AFTER it has already computed
+ * its verdict, and any failure here is swallowed (returns false, never throws) — so telemetry can
+ * NEVER change a gate's block/allow/fail-closed decision. Best-effort by construction.
+ */
+
+/** Pure resolver: the `.gate-telemetry/` dir alongside the calling predicate module. */
+export function gateTelemetryDir(moduleUrl) {
+  return fileURLToPath(new URL('./.gate-telemetry/', moduleUrl));
+}
+
+/**
+ * Append one JSON line to `<dir>/<fileName>`, creating the dir if needed. Returns true on success,
+ * false on ANY failure (disk full, permission, bad path) — the caller must not depend on the result
+ * and must never let it affect the gate verdict. `.gate-telemetry/` is gitignored (runtime data).
+ */
+export function appendGateTelemetry({ dir, fileName, record } = {}) {
+  try {
+    if (!dir || !fileName) return false;
+    fs.mkdirSync(dir, { recursive: true });
+    fs.appendFileSync(path.join(dir, fileName), `${JSON.stringify(record)}\n`);
+    return true;
+  } catch {
+    return false; // best-effort — telemetry must never break the gate
+  }
+}

--- a/operations/devops/gate-telemetry.test.mjs
+++ b/operations/devops/gate-telemetry.test.mjs
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Tests for the shared run-gate durable telemetry sink (t/3395). The load-bearing property is that
+// appendGateTelemetry is BEST-EFFORT: it writes a JSON line on success and returns false (never
+// throws) on any failure, so a gate can call it after computing its verdict without the sink ever
+// affecting the block/allow decision. Run:
+//   node --test operations/devops/gate-telemetry.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { appendGateTelemetry, gateTelemetryDir } from './gate-telemetry.mjs';
+
+function tmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'gate-telemetry-test-'));
+}
+
+test('gateTelemetryDir resolves a .gate-telemetry/ dir next to the module URL', () => {
+  // Drive-lettered file URL: fileURLToPath requires an absolute (drive) path on Windows, and a real
+  // import.meta.url always has one. POSIX ignores the drive segment harmlessly.
+  const dir = gateTelemetryDir(new URL('file:///C:/some/where/operations/devops/x.mjs'));
+  assert.ok(
+    dir.replace(/\\/g, '/').includes('operations/devops/.gate-telemetry'),
+    `expected the .gate-telemetry dir under operations/devops, got: ${dir}`,
+  );
+});
+
+test('appendGateTelemetry writes one JSON line and creates the dir', () => {
+  const base = tmpDir();
+  const dir = path.join(base, '.gate-telemetry'); // does not exist yet → must be created
+  const ok = appendGateTelemetry({ dir, fileName: 'x.jsonl', record: { a: 1, b: 'two' } });
+  assert.equal(ok, true);
+  const lines = fs.readFileSync(path.join(dir, 'x.jsonl'), 'utf8').split(/\n/).filter(Boolean);
+  assert.equal(lines.length, 1);
+  assert.deepEqual(JSON.parse(lines[0]), { a: 1, b: 'two' });
+});
+
+test('appendGateTelemetry APPENDS (one line per call, order preserved)', () => {
+  const dir = path.join(tmpDir(), '.gate-telemetry');
+  appendGateTelemetry({ dir, fileName: 'x.jsonl', record: { n: 1 } });
+  appendGateTelemetry({ dir, fileName: 'x.jsonl', record: { n: 2 } });
+  const lines = fs.readFileSync(path.join(dir, 'x.jsonl'), 'utf8').split(/\n/).filter(Boolean);
+  assert.deepEqual(lines.map((l) => JSON.parse(l).n), [1, 2]);
+});
+
+test('appendGateTelemetry returns false and does NOT throw on a bad target (best-effort)', () => {
+  // Point at a path whose parent is a FILE, so mkdirSync/appendFileSync must fail — proving the
+  // isolation invariant: a broken sink can never surface as an exception into the gate.
+  const base = tmpDir();
+  const asFile = path.join(base, 'not-a-dir');
+  fs.writeFileSync(asFile, 'x');
+  const dir = path.join(asFile, 'nested'); // parent is a file → mkdir fails
+  let threw = false;
+  let result;
+  try {
+    result = appendGateTelemetry({ dir, fileName: 'x.jsonl', record: { a: 1 } });
+  } catch {
+    threw = true;
+  }
+  assert.equal(threw, false);
+  assert.equal(result, false);
+});
+
+test('appendGateTelemetry returns false on missing dir/fileName (never throws)', () => {
+  assert.equal(appendGateTelemetry({ fileName: 'x.jsonl', record: {} }), false);
+  assert.equal(appendGateTelemetry({ dir: tmpDir(), record: {} }), false);
+  assert.equal(appendGateTelemetry(), false);
+});

--- a/operations/devops/merge-guard-predicate.mjs
+++ b/operations/devops/merge-guard-predicate.mjs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { execFileSync } from 'node:child_process'; // used only by the --jointgv CLI fetch shim
+import { appendGateTelemetry, gateTelemetryDir } from './gate-telemetry.mjs'; // shared durable sink (t/3395)
 
 /**
  * Pure command-string predicate for the pre-self-merge head-guard (t/3270, TL GV t/3270#2).
@@ -87,6 +88,26 @@ export function parsePrRef(command) {
   return null;
 }
 
+/**
+ * PURE builder for a durable telemetry record (t/3395) — mirrors done-evidence's buildSinkRecord but
+ * for the merge guards. The platform telemetry writer is dead (t/3394#2), so the shim appends this to
+ * the shared sink after computing its verdict. `mode` is 'head-guard' (t/3270) or 'jointgv' (t/3318);
+ * the HIGH-VALUE event is the jointgv fail-CLOSED block (couldn't verify labels → reason
+ * 'failclosed-unverifiable', failClosed:true). Command is truncated (it's a `gh pr merge …` line, no
+ * secrets, but bounded for log hygiene). Pure + exported so the shape is unit-tested.
+ */
+export function buildMergeGuardSinkRecord({ nowIso, mode, command, verdict, failClosed } = {}) {
+  return {
+    ts: nowIso ?? null,
+    gate: 'merge-guard',
+    mode: mode ?? null,
+    decision: verdict && verdict.block ? 'block' : 'allow',
+    reason: verdict ? verdict.reason : null,
+    failClosed: !!failClosed,
+    command: typeof command === 'string' ? command.slice(0, 300) : null,
+  };
+}
+
 // CLI shim (t/3270#4 / t/3318, TL GV): the feedback rules invoke THIS module directly so the rule
 // runs the exact logic the both-arms test proves — test == runtime. (A hand-copied inline node -e
 // would let a typo in the un-tested copy brick every merge or silently negate the gate; TL's
@@ -100,6 +121,14 @@ export function parsePrRef(command) {
 // The head-guard path is byte-identical to before (its 13/13 test stays green); --auto is
 // 'auto-exempt' there, so the two guards never double-fire on one command.
 if (process.argv[1] && process.argv[1].replace(/\\/g, '/').endsWith('merge-guard-predicate.mjs')) {
+  // Durable telemetry (t/3395): append AFTER the verdict + any 'fire' write — writes to a file, never
+  // stdout, and is best-effort inside appendGateTelemetry, so it cannot affect the 'fire' contract.
+  const sink = (mode, command, verdict, failClosed) =>
+    appendGateTelemetry({
+      dir: gateTelemetryDir(import.meta.url),
+      fileName: 'merge-guard.jsonl',
+      record: buildMergeGuardSinkRecord({ nowIso: new Date().toISOString(), mode, command, verdict, failClosed }),
+    });
   if (process.argv[2] === '--jointgv') {
     const cmd = process.argv[3] || '';
     if (isAutoMergeCommand(cmd)) {
@@ -119,11 +148,19 @@ if (process.argv[1] && process.argv[1].replace(/\\/g, '/').endsWith('merge-guard
         process.stdout.write('fire'); // fail-closed: couldn't verify → block --auto
         labeled = null;
       }
-      if (labeled !== null && jointGvAutoMergeVerdict({ isAutoMerge: true, isJointGvLabeled: labeled }).block) {
-        process.stdout.write('fire');
+      if (labeled === null) {
+        // fail-closed block (the 'fire' above) — record the high-value unverifiable event
+        sink('jointgv', cmd, { block: true, reason: 'failclosed-unverifiable' }, true);
+      } else {
+        const verdict = jointGvAutoMergeVerdict({ isAutoMerge: true, isJointGvLabeled: labeled });
+        if (verdict.block) process.stdout.write('fire');
+        sink('jointgv', cmd, verdict, false);
       }
     }
-  } else if (mergeGuardVerdict(process.argv[2] || '').block) {
-    process.stdout.write('fire');
+  } else {
+    const command = process.argv[2] || '';
+    const verdict = mergeGuardVerdict(command);
+    if (verdict.block) process.stdout.write('fire');
+    sink('head-guard', command, verdict, false);
   }
 }

--- a/operations/devops/merge-guard-predicate.test.mjs
+++ b/operations/devops/merge-guard-predicate.test.mjs
@@ -15,6 +15,7 @@ import {
   jointGvAutoMergeVerdict,
   isAutoMergeCommand,
   parsePrRef,
+  buildMergeGuardSinkRecord,
 } from './merge-guard-predicate.mjs';
 
 const MODULE = fileURLToPath(new URL('./merge-guard-predicate.mjs', import.meta.url));
@@ -157,4 +158,60 @@ test('CLI --jointgv: no gh call + no fire on a MANUAL merge (not --auto)', () =>
 
 test('CLI --jointgv: no gh call + no fire on a non-merge command', () => {
   assert.equal(runShimJointGv('gh pr view 1947 --json labels'), '');
+});
+
+// ── buildMergeGuardSinkRecord: durable telemetry record shape (t/3395) ──
+// The platform telemetry writer is dead (t/3394#2); the shim appends these records so merge-guard
+// fires/allows — especially the jointgv fail-CLOSED block — stay observable.
+
+test('sink record: head-guard BLOCK (missing --match-head-commit) → decision=block + command captured', () => {
+  const cmd = 'gh pr merge 2059 --squash';
+  const r = buildMergeGuardSinkRecord({
+    nowIso: '2026-09-07T20:00:00.000Z', mode: 'head-guard', command: cmd,
+    verdict: mergeGuardVerdict(cmd), failClosed: false,
+  });
+  assert.equal(r.gate, 'merge-guard');
+  assert.equal(r.mode, 'head-guard');
+  assert.equal(r.decision, 'block');
+  assert.equal(r.reason, 'missing-match-head-commit');
+  assert.equal(r.failClosed, false);
+  assert.equal(r.command, cmd);
+});
+
+test('sink record: head-guard ALLOW (guarded merge) → decision=allow', () => {
+  const cmd = 'gh pr merge 2059 --squash --match-head-commit abc123';
+  const r = buildMergeGuardSinkRecord({ nowIso: 'x', mode: 'head-guard', command: cmd, verdict: mergeGuardVerdict(cmd) });
+  assert.equal(r.decision, 'allow');
+  assert.equal(r.reason, 'guarded');
+});
+
+test('sink record: jointgv fail-CLOSED block → decision=block, failClosed=true (the high-value event)', () => {
+  const r = buildMergeGuardSinkRecord({
+    nowIso: 'x', mode: 'jointgv', command: 'gh pr merge 1947 --auto',
+    verdict: { block: true, reason: 'failclosed-unverifiable' }, failClosed: true,
+  });
+  assert.equal(r.mode, 'jointgv');
+  assert.equal(r.decision, 'block');
+  assert.equal(r.reason, 'failclosed-unverifiable');
+  assert.equal(r.failClosed, true);
+});
+
+test('sink record: jointgv verified block (labeled joint-gv) → decision=block, failClosed=false', () => {
+  const r = buildMergeGuardSinkRecord({
+    nowIso: 'x', mode: 'jointgv', command: 'gh pr merge 1947 --auto',
+    verdict: jointGvAutoMergeVerdict({ isAutoMerge: true, isJointGvLabeled: true }), failClosed: false,
+  });
+  assert.equal(r.decision, 'block');
+  assert.equal(r.reason, 'auto-merge-on-joint-gv');
+  assert.equal(r.failClosed, false);
+});
+
+test('sink record: command is truncated to 300 chars; empty args never throw', () => {
+  const long = `gh pr merge 1 ${'x'.repeat(500)}`;
+  const r = buildMergeGuardSinkRecord({ nowIso: 'x', mode: 'head-guard', command: long, verdict: { block: false, reason: 'guarded' } });
+  assert.equal(r.command.length, 300);
+  const empty = buildMergeGuardSinkRecord();
+  assert.equal(empty.decision, 'allow');
+  assert.equal(empty.command, null);
+  assert.equal(empty.gate, 'merge-guard');
 });


### PR DESCRIPTION
## What
Class fix (t/3394 follow-up, TL e/147#5) — extends the #2070 durable-sink pattern to the other two blocking predicates so their executions are observable again after the late-May Orca telemetry-writer regression (t/3394#2).

## How
- **New shared `operations/devops/gate-telemetry.mjs`**: `gateTelemetryDir(moduleUrl)` + `appendGateTelemetry({dir,fileName,record})` — the single append primitive, **best-effort (returns false, never throws)** so it can never affect a gate verdict. `done-evidence-predicate.mjs` now consumes it (inline append removed → no divergent copy).
- **`merge-guard-predicate.mjs`**: new pure `buildMergeGuardSinkRecord`; both shim modes append to `.gate-telemetry/merge-guard.jsonl`. High-value event = the jointgv **fail-CLOSED** block (`failClosed:true`, reason `failclosed-unverifiable`). `'fire'` stdout is **byte-identical in all four existing cases** (verified live).

## Evidence
- **54/54** tests: gate-telemetry 5 (writes/appends; returns false + never throws on a bad target — the isolation invariant; missing-args), merge-guard 26 (+5 record-shape/fail-closed/truncation, existing 13 head-guard/jointgv arms green), done-evidence 23 green.
- **Live**: head-guard missing-flag→fire, guarded→allow (both records written); done-evidence verdict unchanged (evidenced→allow, absent→fire) with the sink still writing via the shared helper.

## Scope
Observability-only — **no change to any block/allow/fail-closed logic or rule templates**. `.gate-telemetry/` already gitignored (landed with #2070). Self-certified against the #2070 pattern; TL pre-cleared the isolated-append pattern (e/147#5), flagged-to-TL review level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)