### PR TITLE
feat(t/3389): Option C phase-1c — Python generator splits term: refs to topical_candidates

### DIFF
--- a/research/comp-linguist/docs/logical-form-schema.md
+++ b/research/comp-linguist/docs/logical-form-schema.md
@@ -64,7 +64,8 @@ for both the argument bindings and the `about[]` projection. It never re-extract
 | `args[].ref` | string | **MUST be an `ent-*` id drawn from this claim's `entity_refs[].ref`** — never a re-invented id (t/2294). If the participant is not a registered entity, use a literal `lit:"…"` or an event var; record `sort` regardless. |
 | `args[].sort` | enum | The entity's DOLCE-lite sort, **pinned to the register's `DolceCategory` closed set** (`lib/entities/types.ts`): `agentive-physical-object \| non-agentive-functional-artifact \| perdurant \| normative-description \| non-agentive-social-object`. Copied verbatim from the referenced entity's `dolce_category`; for a `lit:`/event arg, CL-assigned from the same 5-value set. Copy-not-judge (rule 2). A `term:*` **concept** ref (node `logical_form`) instead takes sort **`universal`** — the 6th arg-slot sort for kinds, distinct from the 5 particular values (t/3251). |
 | `args[].match_level` | enum | Copied verbatim from the entity_ref: `exact \| instance_of \| subclass \| superclass \| related`. Load-bearing for the prover — a claim about a superclass matched to an instance is a different assertion (§6, R4). **⚠️ Exact-only in practice (t/3238):** the resolver (`ClaimEntityResolution.ps1`) hardcodes `match_level="exact"` and surface-matches only — **540/540** entity_refs corpus-wide are `exact`. The non-exact values are an **aspirational vocabulary** until a hierarchical/taxonomic resolver exists; the prover's match_level-sensitivity (§6/R4) and the t/3127/t/3128 axiom modules are therefore **untested on real data** and testable only via constructed golden cases (`analyses/logical-form-golden/` con-2..con-5). Making resolution ontology-aware is a separate resolution-strategy initiative, out of the FOL-track scope. |
-| `about[]` | array | **Topical grounding (additive, optional):** `[{ref, match_level}]` — the `ent-*` ids the claim is *about* (its topical subject). **Superset convention (pinned, D3b):** `about[]` is the **complete** topical index — every resolved entity the claim is about, **including** those that also fill an `args[]` role (a participant that is topical appears in *both*). Same ids as the claim's `entity_refs[]` (a logical-form projection, **no new resolution**). Governed by the `about[]` conditions below. |
+| `about[]` | array | **Topical grounding (additive, optional):** `[{ref, match_level}]` — the `ent-*` ids the claim is *about* (its topical subject). **Superset convention (pinned, D3b):** `about[]` is the **complete** topical index — every resolved entity the claim is about, **including** those that also fill an `args[]` role (a participant that is topical appears in *both*). Same ids as the claim's `entity_refs[]` (a logical-form projection, **no new resolution**). **`ent-*` only** (Option C, t/3389 — the mixed convention that also held `term:*` fell back). Governed by the `about[]` conditions below. |
+| `topical_candidates` | object \| absent | **Concept topical layer (Option C, t/3389).** `{validated:false, generator, golden_ref, blind_golden_precision, refs:[{ref, match_level}]}` — the `term:*` concept refs the claim is topically about, homed separately from `about[]` because the concept-anchored selection MISSED its pre-committed floor (0.636 < 0.80, t/3381). Quality-marked so a consumer sees the unvalidated status from the data. **Absent (not null)** when the claim has no concept refs. See §`topical_candidates` below. |
 | `polarity` | enum | `positive \| negative`. Negation of the core predication (`¬acquire(e1)`), not attitude negation. |
 | `modality` | object \| null | **`null` for `factual_claims`** (unattributed fact). Present for BDI/POV claims. |
 | `modality.holder` | enum | `camp:acc \| camp:saf \| camp:skp` (the attributing camp). Derived from the claim's POV/`stance`. |
@@ -128,6 +129,20 @@ holds(camp_acc, belief, p1) ∧ about(p1, ent_055) ∧ acquire(e1) ∧ agent(e1,
   projection of the claim's already-resolved `entity_refs[]`* (same `ent-` ids, no new resolution),
   so it does NOT double-ground what the mention-index layer captures. Different layer (LF topical
   grounding vs mention occurrences), same identities.
+
+### `topical_candidates` — the Option-C concept layer (t/3389; SO+TL e/145#13-#16)
+
+Option A (a mixed `about[]` holding both `ent-*` and `term:*`) was ratified **conditionally** on a
+re-measure; it **fell back to Option C** when the concept-anchored `about[]`-component scored
+**0.636 < the pre-committed 0.80 floor** (t/3381, blind golden — a *precision* failure: the generator
+over-attaches concepts). So `about[]` stays **`ent-*` only** (its validated convention, above) and the
+`term:*` concept refs move to `topical_candidates`:
+
+- **Shape:** `{validated:false, generator, golden_ref:"t/3381", blind_golden_precision:0.54, refs:[{ref, match_level}]}`. `refs[].ref` matches **`^(term:|ent-)`** (entities are hyphenated `ent-NNN`, not `ent:`); `match_level` is enum-clamped but **not** load-bearing in this layer.
+- **In-artifact quality marking (hard requirement, joint TL+SO):** the `validated:false` flag + the blind-golden precision live IN the data, so a consumer sees this is the unvalidated generator layer (~0.54 precision) without reading the register. The field name says "candidates," not "index."
+- **Fallback-in-effect, NOT endpoint:** the failure is fixable generator precision (t/3390). A repaired generator re-measured **≥0.80** on the same blind-golden methodology **reopens Option A** as a new decision — `topical_candidates` must not ossify into "the convention."
+- **Provenance lifecycle:** when a repaired generator regenerates a node, it MUST either update the provenance block (generator/golden_ref/precision) or revalidate-and-move the refs into `about[]` — **never fresh refs under stale `0.54` metadata** (the marking cuts both ways).
+- **Land order (never enforcement-before-data):** phase 1 additive-schema (all ports *accept* `topical_candidates`, `about[]` still tolerant of `term:`) → phase 2 /data-mutation migration of the corpus → phase 3 tighten `about[].ref` enforcement to `^ent-` last.
 
 ## Calibration + provenance (deliverable 3 preview)
 

--- a/research/comp-linguist/tools/formalize_node_lf.py
+++ b/research/comp-linguist/tools/formalize_node_lf.py
@@ -64,9 +64,23 @@ def parse_lf(text):
 PARTICULAR_SORTS = frozenset({"agentive-physical-object", "non-agentive-functional-artifact",
                               "perdurant", "normative-description", "non-agentive-social-object"})
 # Canonical EntityMatchLevel enum (logical-form-schema.md; PS $script:LogicalFormMatchLevels).
-# `universal` is a valid args[].sort (t/3251) but NEVER a match_level — the t/3379 leak. about[] keeps
-# BOTH ent-* and term: refs (Option A, SO-ratified e/145) but its match_level is enum-clamped here.
+# `universal` is a valid args[].sort (t/3251) but NEVER a match_level — the t/3379 leak. match_level
+# is enum-clamped here for both about[] and topical_candidates.
 VALID_MATCH_LEVELS = frozenset({"exact", "instance_of", "subclass", "superclass", "related"})
+
+# Option C (t/3389; SO+TL signed off e/145#13-#16). The mixed-convention about[] MISSED the
+# pre-committed concept-anchored floor (0.636 < 0.80, t/3381), so about[] reverts to ent-only and
+# the term: concept refs move to `topical_candidates` — a quality-marked layer whose provenance
+# block makes the unvalidated status legible FROM THE DATA (a consumer sees validated:false + the
+# 0.54 blind-golden precision without reading the register). Stamped by THIS generator; a repaired
+# generator (t/3390) must UPDATE this block or revalidate-and-move the refs to about[] — never
+# fresh refs under stale metadata (e/145#14(c) lifecycle rule).
+TOPICAL_CANDIDATES_PROVENANCE = {
+    "validated": False,
+    "generator": "formalize_node_lf.py",
+    "golden_ref": "t/3381",
+    "blind_golden_precision": 0.54,
+}
 
 
 def _repair_bare(ref, allowed):
@@ -102,14 +116,14 @@ def validate(lf, allowed, camp, cat):
         return a
 
     lf["args"] = [x for x in (fix(a) for a in (lf.get("args") or [])) if x]
-    kept_about = []
+    # Option C split (t/3389): about[] = ent-* only; term: concept refs -> topical_candidates.
+    # Only grounded refs survive (R6 / t/2294 — a ref not in the node's own entity_refs/concept_refs
+    # is dropped, never minted); the `in allowed` gate enforces the {ent-*|term:*} vocabulary.
+    kept_about, candidate_refs = [], []
     for ab in (lf.get("about") or []):
         if not isinstance(ab, dict):
             continue
         ref = _repair_bare(ab.get("ref", ""), allowed)
-        # about[] is a mixed topical index: keep BOTH ent-* and term: refs (Option A, SO e/145).
-        # Only grounded refs survive (R6 / t/2294 — a ref not in the node's own entity_refs/concept_refs
-        # is dropped, never minted); the `in allowed` gate also enforces the {ent-*|term:*} vocabulary.
         if ref not in allowed:
             continue
         ab["ref"] = ref
@@ -117,8 +131,14 @@ def validate(lf, allowed, camp, cat):
         # guess; enum-clamp so a concept's sort=`universal` can never leak into match_level (t/3379).
         ml = allowed[ref][1]
         ab["match_level"] = ml if ml in VALID_MATCH_LEVELS else "exact"
-        kept_about.append(ab)
+        (kept_about if ref.startswith("ent-") else candidate_refs).append(ab)
     lf["about"] = kept_about
+    # topical_candidates present only when concept refs exist (absent, not null, otherwise —
+    # absent≠null contract, t/2943). Provenance stamped fresh by this generator (lifecycle rule).
+    if candidate_refs:
+        lf["topical_candidates"] = {**TOPICAL_CANDIDATES_PROVENANCE, "refs": candidate_refs}
+    else:
+        lf.pop("topical_candidates", None)
     lf["modality"] = {"holder": f"camp:{POV.get(camp, camp)}", "attitude": CAT_ATT.get(cat, "belief")}
     lf.setdefault("status", "proposed")
     return lf

--- a/research/comp-linguist/tools/test_formalize_node_lf.py
+++ b/research/comp-linguist/tools/test_formalize_node_lf.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
-"""Regression tests for formalize_node_lf.validate() about[] handling (t/3379).
+"""Regression tests for formalize_node_lf.validate() about[] / topical_candidates handling.
 
-Option A (SO-ratified, e/145): about[] is a mixed topical index that keeps BOTH ent-* and term:
-refs; its match_level is enum-clamped to EntityMatchLevel so a concept's sort=`universal` can
-never leak into about[].match_level (the t/3379 recurrence). The module loads entities.json at
-import, so we skip cleanly when the data repo is absent (mirrors validation.data.test.ts)."""
+Option C (t/3389, SO+TL signed off e/145#13-#16): the mixed-convention about[] MISSED the
+pre-committed concept-anchored floor (0.636 < 0.80, t/3381), so about[] reverts to **ent-* only**
+and term: concept refs move to `topical_candidates` — a quality-marked layer (provenance block
+carries validated:false + the 0.54 blind-golden precision so the unvalidated status is legible
+from the data alone). match_level is enum-clamped on both so a concept's sort=`universal` can never
+leak in (the t/3379 leak). The module loads entities.json at import, so we skip cleanly when the
+data repo is absent (mirrors validation.data.test.ts)."""
 import importlib.util
 import os
 import pytest
@@ -35,29 +38,48 @@ ALLOWED = {
 def _run(about):
     lf = {"predicate": "x", "args": [], "about": about, "polarity": "positive",
           "temporal": {"type": "unspecified", "value": None}, "formalization_confidence": 0.9}
-    return flf.validate(lf, ALLOWED, "acc", "Beliefs")["about"]
+    return flf.validate(lf, ALLOWED, "acc", "Beliefs")
 
 
-def test_concept_ref_kept_and_universal_clamped():
-    """t/3379: a term: concept about-ref survives (Option A), and match_level='universal'
-    (the concept's sort leaking in) is clamped to the authoritative 'exact'."""
-    out = _run([{"ref": "term:regulation_precautionary", "match_level": "universal"}])
-    assert out == [{"ref": "term:regulation_precautionary", "match_level": "exact"}]
+def test_concept_ref_routed_to_topical_candidates():
+    """Option C: a term: concept ref leaves about[] and lands in topical_candidates.refs, with
+    match_level='universal' (the concept's sort leaking in) clamped to the authoritative 'exact'."""
+    lf = _run([{"ref": "term:regulation_precautionary", "match_level": "universal"}])
+    assert lf["about"] == []  # ent-only
+    assert lf["topical_candidates"]["refs"] == [{"ref": "term:regulation_precautionary", "match_level": "exact"}]
 
 
-def test_entity_ref_kept_with_authoritative_match_level():
-    out = _run([{"ref": "ent-x", "match_level": "exact"}])  # model says exact; register says instance_of
-    assert out == [{"ref": "ent-x", "match_level": "instance_of"}]  # authoritative wins
+def test_topical_candidates_carries_the_quality_provenance():
+    """The marking gate (e/145#13-#16): the layer's unvalidated status is legible FROM THE DATA."""
+    tc = _run([{"ref": "term:regulation_precautionary", "match_level": "exact"}])["topical_candidates"]
+    assert tc["validated"] is False
+    assert tc["generator"] == "formalize_node_lf.py"
+    assert tc["golden_ref"] == "t/3381"
+    assert tc["blind_golden_precision"] == 0.54
+
+
+def test_entity_ref_stays_in_about_ent_only():
+    """ent-* refs stay in about[] with the authoritative register match_level; no topical_candidates."""
+    lf = _run([{"ref": "ent-x", "match_level": "exact"}])  # model says exact; register says instance_of
+    assert lf["about"] == [{"ref": "ent-x", "match_level": "instance_of"}]  # authoritative wins
+    assert "topical_candidates" not in lf  # absent, not null (t/2943), when no concept refs
 
 
 def test_ungrounded_ref_dropped():
-    out = _run([{"ref": "ent-hallucinated", "match_level": "exact"}])
-    assert out == []  # R6 / t/2294 — never mint a ref not in the node's own refs
+    lf = _run([{"ref": "ent-hallucinated", "match_level": "exact"}])
+    assert lf["about"] == []  # R6 / t/2294 — never mint a ref not in the node's own refs
+    assert "topical_candidates" not in lf
 
 
-def test_mixed_index_preserved():
-    out = _run([{"ref": "ent-034", "match_level": "exact"},
-                {"ref": "term:regulation_precautionary", "match_level": "universal"}])
-    refs = [a["ref"] for a in out]
-    assert refs == ["ent-034", "term:regulation_precautionary"]
-    assert all(a["match_level"] in flf.VALID_MATCH_LEVELS for a in out)
+def test_split_mixed_ent_to_about_term_to_candidates():
+    lf = _run([{"ref": "ent-034", "match_level": "exact"},
+               {"ref": "term:regulation_precautionary", "match_level": "universal"}])
+    assert [a["ref"] for a in lf["about"]] == ["ent-034"]
+    assert [a["ref"] for a in lf["topical_candidates"]["refs"]] == ["term:regulation_precautionary"]
+    assert all(a["match_level"] in flf.VALID_MATCH_LEVELS for a in lf["about"] + lf["topical_candidates"]["refs"])
+
+
+def test_empty_about_no_topical_candidates_key():
+    lf = _run([])
+    assert lf["about"] == []
+    assert "topical_candidates" not in lf


### PR DESCRIPTION
Phase-1c of the signed-off Option C (e/145#13–#16; design `analyses/t3389-option-c/c-design.md`). **Additive phase-1 only** — no `--apply`, corpus unchanged; Zod (Rosetta) + PS (PowerShell) additive ports land in parallel, migration is phase-2.

- `formalize_node_lf.validate()`: `ent-*` → `about[]` (ent-only), `term:` → `topical_candidates.refs`.
- `topical_candidates` object carries the marking gate **in the data**: `{validated:false, generator, golden_ref:"t/3381", blind_golden_precision:0.54, refs:[...]}`. Absent (not null) when no concept refs.
- Provenance stamped by this generator; §109 doc records the shape, the fallback-in-effect rule (repaired t/3390 ≥0.80 reopens A), the lifecycle rule (update-or-move, never stale metadata), and the land order.
- Tests: 6/6 (ent→about, term→candidates, provenance stamped, ungrounded dropped, mixed split, absent-when-empty).

**Review routing:** playbook-covered impl of a signed-off design → **Quality (TL)** per `docs/review-routing.md`; no further Main/SO pass unless it deviates (it doesn't). Ref t/3389, e/145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)