### PR TITLE
refactor(debate-workspace): consume shared useLongPressSelectionMenu hook (t/3382 follow-up)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
@@ -4,6 +4,7 @@
 import { useState, useRef, useEffect, useCallback, useMemo, Fragment } from 'react';
 import { api } from '@bridge';
 import { useDebateStore } from '../../hooks/useDebateStore';
+import { useLongPressSelectionMenu } from '../../hooks/useLongPressSelectionMenu';
 import { useShallow } from 'zustand/react/shallow';
 import { useTaxonomyStore } from '../../hooks/useTaxonomyStore';
 import type { SpeakerId } from '../../types/debate';
@@ -1205,33 +1206,11 @@ function useDebateSelectionMenu(activeDebate: DWStore['activeDebate'], defaultTi
     return { x, y, selectedText, entryId, isPoverStatement, tier, startOffset, endOffset };
   }, [activeDebate?.transcript, defaultTier]);
 
-  // Phase 7: Context menu handler (desktop right-click)
-  const handleContextMenu = useCallback((e: React.MouseEvent) => {
-    const menu = buildMenuState(e.currentTarget, e.clientX, e.clientY);
-    if (!menu) return; // No selection → use default browser menu
-    e.preventDefault();
-    setContextMenu(menu);
-  }, [buildMenuState]);
-
-  // Touch devices don't fire `contextmenu` on long-press-to-select (t/3382) — iOS/Android
-  // intercept the gesture with their native selection callout instead. Watch for a selection
-  // that survives touchend and show the same menu at the release point.
-  const touchMenuTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  useEffect(() => () => { if (touchMenuTimerRef.current) clearTimeout(touchMenuTimerRef.current); }, []);
-
-  const handleTouchEnd = useCallback((e: React.TouchEvent) => {
-    const container = e.currentTarget;
-    const touch = e.changedTouches[0];
-    if (!touch) return;
-    const x = touch.clientX;
-    const y = touch.clientY;
-    if (touchMenuTimerRef.current) clearTimeout(touchMenuTimerRef.current);
-    // The selection finalizes slightly after touchend on mobile Safari/Chrome; wait one tick.
-    touchMenuTimerRef.current = setTimeout(() => {
-      const menu = buildMenuState(container, x, y);
-      if (menu) setContextMenu(menu);
-    }, 50);
-  }, [buildMenuState]);
+  // Phase 7 (desktop right-click) + t/3382 (touch long-press-to-select, which never
+  // fires `contextmenu` — iOS/Android intercept it with the native selection callout)
+  // share one trigger model via the shared hook: show the menu once a selection is final.
+  const { onContextMenu: handleContextMenu, onTouchEnd: handleTouchEnd } =
+    useLongPressSelectionMenu(buildMenuState, setContextMenu);
 
   return { contextMenu, setContextMenu, commentPopover, setCommentPopover, handleContextMenu, handleTouchEnd };
 }


### PR DESCRIPTION
## Summary
- Fast-follow to t/3382: #2062 (my hand-rolled touch-menu timer) and #2065 (Rosetta's shared `useLongPressSelectionMenu` hook) both merged to main at the same moment — the TL's sequencing ruling (t/3382#3: #2061/#2065 lands first, then #2062 rebases to consume) got raced by a human merge-on-green before the rebase step happened
- This PR does the deferred rebase: replaces the local `handleContextMenu`/`handleTouchEnd`/`touchMenuTimerRef` in `DebateWorkspace.tsx` with `useLongPressSelectionMenu(buildMenuState, setContextMenu)`, closing the divergent-implementation gap
- No behavior change — `buildMenuState` (selection lookup, entry/tier/offset computation) is untouched; only the touchend/settle/timer plumbing moves into the shared hook

## Test plan
- [x] `npx vitest run src/renderer/components/debate-workspace/DebateWorkspace.test.tsx` — 71/71 pass unchanged (confirms the hook is behaviorally identical to the code it replaces)
- [x] `npx tsc --noEmit` — no new errors
- [x] `npx eslint` — 0 errors, same pre-existing warnings only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
