### PR TITLE
fix(taxonomy): show Debate Tested chip on all BDI categories (t/3393)

### DIFF
--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.test.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.test.tsx
@@ -95,7 +95,10 @@ vi.mock('../conflict', () => ({
 }));
 vi.mock('./GraphAttributesPanel', () => ({ GraphAttributesPanel: () => null }));
 vi.mock('./NodeEditHistory', () => ({ NodeEditHistory: () => null }));
-vi.mock('./DebateTestedChip', () => ({ DebateTestedChip: () => null }));
+// t/3393: spy (not a plain () => null) so tests can assert the chip was actually reached for a
+// given node category, not just that rendering didn't throw.
+const { mockDebateTestedChip } = vi.hoisted(() => ({ mockDebateTestedChip: vi.fn(() => null) }));
+vi.mock('./DebateTestedChip', () => ({ DebateTestedChip: mockDebateTestedChip }));
 vi.mock('./DebateTestedDrilldown', () => ({ DebateTestedDrilldown: () => null }));
 vi.mock('../shared/MentionField', () => ({
   useContainerMentionKit: () => ({ renderMentionField: () => null, descriptionMention: null }),
@@ -327,5 +330,31 @@ describe('NodeDetail — Simple-view last-edited line (t/3022)', () => {
   it('omits the last-edited line when the node has no edit metadata', () => {
     render(<NodeDetail pov="acc" node={mockNode} readOnly={false} onPin={vi.fn()} onSimilarSearch={vi.fn()} onRelated={vi.fn()} />);
     expect(screen.queryByText(/last edited by/i)).not.toBeInTheDocument();
+  });
+});
+
+// ── Debate Tested on all BDI categories (t/3393) ────────────────────────────
+// Previously gated to `node.category === 'Beliefs'` only; the underlying
+// debate_tested record is populated on Desires/Intentions nodes too (confirmed
+// against live taxonomy data), so the chip must render on every category.
+
+describe('NodeDetail — Debate Tested chip renders on every BDI category (t/3393)', () => {
+  beforeEach(() => {
+    mockPrefsState.viewMode = 'simple';
+    vi.clearAllMocks();
+  });
+
+  it.each(['Beliefs', 'Desires', 'Intentions'] as const)('renders the Debate Tested chip for a %s node', (category) => {
+    render(
+      <NodeDetail
+        pov="acc"
+        node={{ ...mockNode, category }}
+        readOnly={false}
+        onPin={vi.fn()}
+        onSimilarSearch={vi.fn()}
+        onRelated={vi.fn()}
+      />,
+    );
+    expect(mockDebateTestedChip).toHaveBeenCalled();
   });
 });

--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
@@ -711,19 +711,24 @@ function NodeDetailTabBar({ activeTab, setActiveTab, conflictCount, cruxCount, f
   );
 }
 
-// ── Content tab: Beliefs metrics row (extracted from NodeDetail for complexity) ──
+// ── Content tab: node metrics row (extracted from NodeDetail for complexity) ──
+// t/3393: Debate Tested must show on every BDI category, not only Beliefs — the underlying
+// debate_tested record is populated on Desires/Intentions nodes too (confirmed against live
+// data), so this row itself is no longer Beliefs-exclusive. Confidence stays Beliefs-gated: it's
+// a genuinely Beliefs-specific metric (empirical-claim confidence) that's only sparsely populated
+// elsewhere (legacy/cross-cutting data), and the ticket didn't ask to change its visibility.
 
-interface BeliefsMetricsRowProps {
+interface NodeMetricsRowProps {
   node: PovNode;
   showDtDrilldown: boolean;
   setShowDtDrilldown: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-function BeliefsMetricsRow({ node, showDtDrilldown, setShowDtDrilldown }: BeliefsMetricsRowProps) {
+function NodeMetricsRow({ node, showDtDrilldown, setShowDtDrilldown }: NodeMetricsRowProps) {
   return (
     <>
       <div className="nd-metrics-row">
-        {node.confidence != null && (
+        {node.category === 'Beliefs' && node.confidence != null && (
           <span className="nd-metric" title="Confidence score">
             Confidence: <strong>{node.confidence.toFixed(2)}</strong>
           </span>
@@ -940,9 +945,8 @@ interface NodeDetailContentTabProps {
 function NodeDetailContentTab({ pov, node, readOnly, err, descMode, setDescMode, update, updatePovNode, showDtDrilldown, setShowDtDrilldown, expandedLineage, setExpandedLineage, showAttributeInfo, hasGraphAttrs, descriptionMention, plainDescriptionMention }: NodeDetailContentTabProps) {
   return (
     <>
-      {node.category === 'Beliefs' && (
-        <BeliefsMetricsRow node={node} showDtDrilldown={showDtDrilldown} setShowDtDrilldown={setShowDtDrilldown} />
-      )}
+      {/* t/3393: Debate Tested must show on every BDI category, not only Beliefs. */}
+      <NodeMetricsRow node={node} showDtDrilldown={showDtDrilldown} setShowDtDrilldown={setShowDtDrilldown} />
 
       {!readOnly && err('label') && (
         <div className="error-text">{err('label')}</div>


### PR DESCRIPTION
## t/3393 — Debate Tested indicator was Beliefs-only

PM-filed, PI-reported with screenshot. The Debate Tested chip only rendered when `node.category === 'Beliefs'`.

### Root cause
Checked the live data before touching code: the `debate_tested` record is populated substantially on Desires/Intentions nodes too (e.g. accelerationist Desires 22/26, Intentions 69/86 carry a record) — the category gate was hiding real, existing data, not correctly reflecting an absence.

### Fix
- Renamed `BeliefsMetricsRow` → `NodeMetricsRow` (no longer Beliefs-exclusive) and dropped the category gate at the call site.
- `Confidence` stays Beliefs-gated (moved the check inside the row) — it's a genuinely Beliefs-specific metric, only sparsely populated elsewhere (2-5 legacy nodes per POV file), and the ticket only asked about Debate Tested. Kept its visibility unchanged to avoid unrequested scope creep.

### Tests
`DebateTestedChip` was mocked as a plain `() => null` stub with no way to assert it was reached — converted to a spy. Added coverage across all 3 BDI categories (Beliefs/Desires/Intentions). **RED arm proven**: temporarily restored the category gate and confirmed exactly the Desires/Intentions cases fail while Beliefs still passes.

### Verification
renderer tsc clean · eslint 1 pre-existing complexity warning unchanged (confirmed via git-stash baseline diff, not introduced by this change) · `NodeDetail.test.tsx` 17/17.

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>

🤖 Generated with [Claude Code](https://claude.com/claude-code)