### PR TITLE
feat(fol-eval): clause segmenter (§4) + segment stage — Increment 2a (t/3354)

### DIFF
--- a/scripts/fol-eval-segment.ps1
+++ b/scripts/fol-eval-segment.ps1
@@ -1,0 +1,170 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    FOL-on-debate eval — clause segmenter (design §4, CL-authoritative rules). PURE, no AI, no I/O.
+.DESCRIPTION
+    Increment 2a of the offline FOL-on-debate eval harness (t/3354). Implements the rule-based
+    clause segmenter from the co-signed design
+    (research/comp-linguist/analyses/fol-debate-eval/fol-eval-design.md §4): the unit below the
+    turn and below the orthographic sentence is the FINITE CLAUSE — one classification + one
+    formalization unit.
+
+    This file defines ONLY pure functions (no top-level side effects), so it is dot-sourced by both
+    the runner (run-fol-debate-eval.ps1) and the Pester tests without an execution guard.
+
+    Segmentation is deterministic and offset-preserving: every emitted clause carries stable
+    char offsets into the ORIGINAL turn text so the artifacts are double-annotation-ready
+    (design §11 — a second annotator upgrades without a re-run).
+
+    §4 rules realized here (heuristic, English surface cues — the AI clause classifier §3 does the
+    semantic typing; this stage only cuts):
+      2. Split coordinated finite clauses at ", and/but/or/yet ...".
+      3. Split at discourse connectives (however / therefore / thus / hence / so / because) and ';'.
+      4. The load-bearing rule — a trailing normative/rhetorical CLOSER never inherits the factual
+         body it follows: because rule 3 cuts before "so/therefore/…", the closer becomes its own
+         clause, typed on its own by the classifier.
+      5. Attributed-restatement matrix vs content: "X claims that P" -> the wrapper "X claims that"
+         is its own clause (is_attribution_wrapper=$true); the embedded P starts a new clause and is
+         the formalization target.
+      7. Enumerations: comma+coordinator splitting gives each full-proposition list item its own clause.
+      8. Sub-clausal fragments (bare tokens / punctuation-only) attach to nothing and are DROPPED
+         (word-count / alphanumeric heuristic; documented limitation — rule-8 NP-attachment is coarse
+         here and left to CL's gold-set audit).
+
+    KNOWN LIMITATIONS (honest, for the CL pairing pass): finiteness (rules 1/2/6) and NP-fragment
+    detection (rule 8) are approximated by surface cues, not a parser. Boundaries are conservative
+    (prefer over-segmentation to lost content); the classifier + blind gold set (§5) are the
+    validation instrument that certifies whether these cuts are good enough.
+.LINK
+    run-fol-debate-eval.ps1
+#>
+
+Set-StrictMode -Version Latest
+
+function Split-DebateTurnClauses {
+    <#
+    .SYNOPSIS
+        Segment one debate statement turn into finite clauses (design §4). Pure; deterministic; offset-preserving.
+    .PARAMETER Text
+        The raw turn content (transcript[].content).
+    .PARAMETER DebateId
+        Stable debate id (used in the clause id).
+    .PARAMETER TurnIndex
+        Index of this turn within transcript[] (used in the clause id + source span).
+    .OUTPUTS
+        A List[object] of clause records, each:
+          id                    - "<DebateId>:t<TurnIndex>:c<clause_index>" (stable, double-annotation-ready)
+          debate_id, turn_index
+          clause_index          - 0-based ordinal within the turn
+          text                  - trimmed clause text
+          char_start, char_end  - offsets into the ORIGINAL Text (char_end exclusive)
+          segmentation_rule     - the §4 rule that opened this clause
+          is_attribution_wrapper- $true for the "X claims that" matrix wrapper (design §4 rule 5 / §3.2)
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Collections.Generic.List[object]])]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$Text,
+
+        [Parameter(Mandatory)]
+        [string]$DebateId,
+
+        [Parameter(Mandatory)]
+        [int]$TurnIndex
+    )
+    Set-StrictMode -Version Latest
+
+    $clauses = [System.Collections.Generic.List[object]]::new()
+    if ([string]::IsNullOrWhiteSpace($Text)) { return $clauses }
+
+    $len = $Text.Length
+
+    # cut index (start of a new segment) -> §4 rule tag. First rule to claim an index wins.
+    # Index 0 is intentionally NOT pre-seeded: the rule-5 attribution wrapper can legitimately
+    # OPEN the turn (index 0), and must be allowed to tag clause 0 as the wrapper. Index 0 is
+    # defaulted to 'sentence-initial' at the end only if no higher-precedence rule claimed it.
+    $cuts = @{}
+    $addCut = {
+        param([int]$Index, [string]$Rule)
+        if ($Index -ge 0 -and $Index -lt $len -and -not $cuts.ContainsKey($Index)) { $cuts[$Index] = $Rule }
+    }
+
+    # Rule 5 FIRST (attribution wrapper) — the highest-precedence, most specific cut. The wrapper span
+    # [start, afterThat) is isolated so the embedded proposition P starts its own clause.
+    # Attribution verbs seen in the real debate corpus (t/3354 §3.2 highest-value cell); the trailing
+    # "that" complementizer marks where the wrapper ends and the embedded proposition P begins.
+    $attrRe = '(?:\b(?:Accelerationist|Safetyist|Skeptic|Coordinator)\b|\b[Tt]he\s+opponent\b|\b(?:[Tt]hey|[Hh]e|[Ss]he)\b)\s+(?:claims?|argues?|proposes?|posits?|contends?|asserts?|maintains?|insists?|says?|states?|holds?|notes?|warns?|observes?|suggests?|emphasi[sz]es?|acknowledges?)\s+that\s+'
+    foreach ($m in [regex]::Matches($Text, $attrRe)) {
+        & $addCut $m.Index 'attribution-wrapper-start'
+        & $addCut ($m.Index + $m.Length) 'attributed-content'
+    }
+
+    # Rule 1/implicit — sentence boundary: terminal punctuation + optional closing quote/paren + whitespace.
+    foreach ($m in [regex]::Matches($Text, '[.!?]+["'')\]]?\s+')) {
+        & $addCut ($m.Index + $m.Length) 'sentence'
+    }
+
+    # Rule 3 — semicolon.
+    foreach ($m in [regex]::Matches($Text, ';\s+')) {
+        & $addCut ($m.Index + $m.Length) 'semicolon-split'
+    }
+
+    # Rule 3/4 — discourse connectives; cut BEFORE the connective so a trailing closer stands alone.
+    foreach ($m in [regex]::Matches($Text, '(?:,\s+|\s+)(however|therefore|thus|hence|because|so)\s+')) {
+        & $addCut $m.Groups[1].Index 'connective-split'
+    }
+
+    # Rule 2/7 — coordinated finite clauses / enumerated propositions: cut at the coordinator.
+    foreach ($m in [regex]::Matches($Text, ',\s+(and|but|or|yet)\s+')) {
+        & $addCut $m.Groups[1].Index 'coordinator-split'
+    }
+
+    # Default the turn opening to 'sentence-initial' unless a higher-precedence rule (rule 5) claimed it.
+    if (-not $cuts.ContainsKey(0)) { $cuts[0] = 'sentence-initial' }
+
+    $boundaries = @($cuts.Keys | Sort-Object)
+    $clauseIndex = 0
+    for ($i = 0; $i -lt $boundaries.Count; $i++) {
+        $segStart = [int]$boundaries[$i]
+        $segEnd = if ($i + 1 -lt $boundaries.Count) { [int]$boundaries[$i + 1] } else { $len }
+        $rawLen = $segEnd - $segStart
+        if ($rawLen -le 0) { continue }
+        $raw = $Text.Substring($segStart, $rawLen)
+
+        # Trim to non-whitespace and carry the adjusted offsets (double-annotation-ready spans).
+        $leadWs = $raw.Length - $raw.TrimStart().Length
+        $trimmed = $raw.Trim()
+        if ([string]::IsNullOrWhiteSpace($trimmed)) { continue }
+
+        # Rule 8 — drop sub-clausal fragments: punctuation-only, or a single short token with no
+        # internal whitespace (a bare NP / stray connective remnant). Conservative: keep anything
+        # that has >=2 tokens or a reasonably long single token.
+        $hasAlnum = $trimmed -match '[A-Za-z0-9]'
+        $tokenCount = @($trimmed -split '\s+' | Where-Object { $_ -ne '' }).Count
+        if (-not $hasAlnum) { continue }
+        if ($tokenCount -lt 2 -and $trimmed.Length -lt 4) { continue }
+
+        $charStart = $segStart + $leadWs
+        $charEnd = $charStart + $trimmed.Length
+        $rule = [string]$cuts[$segStart]
+
+        $clauses.Add([PSCustomObject]@{
+                id                     = "${DebateId}:t${TurnIndex}:c${clauseIndex}"
+                debate_id              = $DebateId
+                turn_index             = $TurnIndex
+                clause_index           = $clauseIndex
+                text                   = $trimmed
+                char_start             = $charStart
+                char_end               = $charEnd
+                segmentation_rule      = $rule
+                is_attribution_wrapper = ($rule -eq 'attribution-wrapper-start')
+            })
+        $clauseIndex++
+    }
+
+    return $clauses
+}

--- a/scripts/run-fol-debate-eval.ps1
+++ b/scripts/run-fol-debate-eval.ps1
@@ -81,6 +81,9 @@ Import-Module (Join-Path $PSScriptRoot 'AITriad' 'AITriad.psd1') -Force -ErrorAc
 $Mod = Get-Module AITriad
 if (-not $Mod) { throw 'AITriad module failed to load; cannot resolve data-root helpers.' }
 
+# Clause segmenter (design §4) — a pure, dot-sourceable library (no top-level side effects).
+. (Join-Path $PSScriptRoot 'fol-eval-segment.ps1')
+
 # ── Module-session-state wrappers for Private helpers (see .DESCRIPTION note) ──────
 function Resolve-DebatesDir { & $Mod { Get-DebatesDir } }
 function Test-OutputUnderDataRoot { param([string]$Path) & $Mod { param($p) Test-IsUnderDataRoot -Path $p } $Path }
@@ -115,13 +118,24 @@ $closed = [System.Collections.Generic.List[object]]::new()
 foreach ($f in $allFiles) {
     $d = Get-Content -Raw -LiteralPath $f.FullName | ConvertFrom-Json
     if (-not ($d.PSObject.Properties['phase'] -and $d.phase -eq 'closed')) { continue }
-    $statements = @(
-        if ($d.PSObject.Properties['transcript'] -and $null -ne $d.transcript) {
-            @($d.transcript) | Where-Object { $_.PSObject.Properties['type'] -and $_.type -eq 'statement' }
+
+    # Stable debate id for clause ids: the debate's own id if present, else the file stem.
+    $debateId = if ($d.PSObject.Properties['id'] -and $d.id) { [string]$d.id } else { [System.IO.Path]::GetFileNameWithoutExtension($f.Name) }
+
+    # Retain statement turns with their ACTUAL transcript index (span reproducibility, §11).
+    $statements = [System.Collections.Generic.List[object]]::new()
+    if ($d.PSObject.Properties['transcript'] -and $null -ne $d.transcript) {
+        $turnIndex = -1
+        foreach ($turn in @($d.transcript)) {
+            $turnIndex++
+            if ($turn.PSObject.Properties['type'] -and $turn.type -eq 'statement' -and
+                $turn.PSObject.Properties['content'] -and $turn.content) {
+                $statements.Add([PSCustomObject]@{ turn_index = $turnIndex; content = [string]$turn.content })
+            }
         }
-    )
+    }
     if ($statements.Count -eq 0) { continue }
-    $closed.Add([PSCustomObject]@{ File = $f.Name; StatementCount = $statements.Count })
+    $closed.Add([PSCustomObject]@{ File = $f.Name; DebateId = $debateId; StatementCount = $statements.Count; Statements = $statements })
 }
 
 # ── RUN-BOUNDING (design §10): deterministic sample + LOG, never silent truncation ──
@@ -155,8 +169,8 @@ $manifest = [ordered]@{
     clause_cost_ceiling    = $clauseCeiling
     est_model_calls_upper  = $clauseCeiling * 2   # classifier + FOL, upper bound
     dry_run                = [bool]$DryRun
-    stages_implemented     = @('load', 'run-bound', 'manifest')
-    stages_pending_pairing = @('segment', 'classify', 'coref', 'fol', 'contradiction', 'fn-rate', 'correlate')
+    stages_implemented     = @('load', 'run-bound', 'manifest', 'segment')
+    stages_pending_pairing = @('classify', 'coref', 'fol', 'contradiction', 'fn-rate', 'correlate')
 }
 
 Write-Host ''
@@ -179,11 +193,38 @@ if ($DryRun) {
     return [PSCustomObject]$manifest
 }
 
-# ── PIPELINE STAGES (design §2) — segmenter/classifier are CL-paired; NOT implemented here ──
-# These land after the CL pairing pass (§3/§4 against live turns + the ~60-item blind gold
-# set). Throwing (rather than a fake no-op) keeps the foundation honest: a non-DryRun run
-# fails loudly with the exact next step instead of emitting empty results that look complete.
+# ── SEGMENT stage (design §4) — rule-based, pure (fol-eval-segment.ps1); Increment 2a ──────
+# Segment every selected debate's statement turns into finite clauses and emit them as JSONL with
+# stable ids + char spans (double-annotation-ready, §11). This is deterministic and makes NO model
+# calls — it is the honest, runnable extension of the foundation. The classifier (§3) that TYPES
+# each clause is the next increment (2b) and is what turns these clauses into the assertoric subset.
+$clausesPath = Join-Path $resolvedOut 'clauses.jsonl'
+$clauseLines = [System.Collections.Generic.List[string]]::new()
+$ruleCounts = @{}
+foreach ($deb in $selected) {
+    foreach ($st in $deb.Statements) {
+        $cls = @(Split-DebateTurnClauses -Text $st.content -DebateId $deb.DebateId -TurnIndex $st.turn_index)
+        foreach ($cl in $cls) {
+            $clauseLines.Add(($cl | ConvertTo-Json -Depth 4 -Compress))
+            $rule = [string]$cl.segmentation_rule
+            if ($ruleCounts.ContainsKey($rule)) { $ruleCounts[$rule]++ } else { $ruleCounts[$rule] = 1 }
+        }
+    }
+}
+Set-Content -LiteralPath $clausesPath -Value $clauseLines -Encoding utf8
+
+Write-Host ''
+Write-Host '=== SEGMENT stage (design §4) — rule-based clause segmentation ===' -ForegroundColor Cyan
+Write-Host "  Clauses: $($clauseLines.Count) across $($selected.Count) debate(s) -> $clausesPath" -ForegroundColor White
+foreach ($rk in @($ruleCounts.Keys | Sort-Object)) {
+    Write-Host ("    {0,-26} {1}" -f $rk, $ruleCounts[$rk]) -ForegroundColor DarkGray
+}
+
+# ── CLASSIFY + downstream stages (design §3/§6/§7/§8) — Increment 2b, NOT implemented here ──
+# The clause classifier (§3 5-type taxonomy + attributes) is a new AI instrument validated against
+# the blind gold set (§5). Throwing (rather than a fake no-op) keeps the harness honest: a non-DryRun
+# run fails loudly with the exact next step instead of emitting empty results that look complete.
 throw (New-EvalError `
     'Run the full FOL-on-debate eval pipeline' `
-    'The segment/classify/coref/FOL/contradiction stages are not yet implemented — they are gated on the CL segmenter+classifier pairing pass (design §3/§4) that enumerates the blind gold set.' `
-    'Use -DryRun for the plan+manifest now. The stage build follows the pairing pass with the Computational Linguist (t/3354); until then only load/run-bound/manifest are implemented.')
+    "The SEGMENT stage ran (clauses.jsonl emitted, $($clauseLines.Count) clauses) but the classify/coref/FOL/contradiction stages are not yet implemented — the clause classifier (design §3) is Increment 2b." `
+    'Inspect clauses.jsonl now (or use -DryRun for the plan+manifest). The classifier stage follows with the Computational Linguist blind gold set (design §5); until then load/run-bound/manifest/segment are implemented.')

--- a/tests/DataWriteSinkGuard.Tests.ps1
+++ b/tests/DataWriteSinkGuard.Tests.ps1
@@ -59,7 +59,7 @@ BeforeAll {
         'scripts/AITriad/Public/New-SyntheticCorpus.ps1'   = 'append-checkpoint + fresh corpus generation + NEW metadata (not a whole-file data rewrite)'
         'scripts/AITriad/Public/Test-DebatePersistence.ps1' = 'writes a random persist-probe .tmp (test probe, non-data)'
         'scripts/AITriad/Private/AICallLog.ps1'            = 'append-only AI call-log JSONL (Add-Content); references Get-DataRoot only to locate the log file — never read-mutate-rewrites a data-of-record file (t/3241)'
-        'scripts/run-fol-debate-eval.ps1'                  = 'read-only FOL-on-debate eval harness (t/3354); Set-Content writes only a run-manifest to -OutputDir, which is fail-closed asserted OUTSIDE the data root via Test-IsUnderDataRoot (design §1) — references data tokens (debates/summaries/conflicts) as read-only inputs, never writes ../ai-triad-data'
+        'scripts/run-fol-debate-eval.ps1'                  = 'read-only FOL-on-debate eval harness (t/3354); Set-Content writes only run-manifest.json + clauses.jsonl to -OutputDir, which is fail-closed asserted OUTSIDE the data root via Test-IsUnderDataRoot (design §1) — references data tokens (debates/summaries/conflicts) as read-only inputs, never writes ../ai-triad-data'
     }
 
     # A data-of-record path token (basename or data-dir accessor). Kept specific so

--- a/tests/FolDebateSegment.Tests.ps1
+++ b/tests/FolDebateSegment.Tests.ps1
@@ -1,0 +1,123 @@
+# Tag: qbaf (t/3354 — FOL-on-debate eval clause segmenter, design §4)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Tests for the FOL-on-debate clause segmenter (scripts/fol-eval-segment.ps1, design §4).
+.DESCRIPTION
+    Split-DebateTurnClauses is a PURE, deterministic, offset-preserving transform (no AI, no I/O),
+    so the tests dot-source the library directly and assert on the §4 boundary rules, the
+    double-annotation-ready spans (§11), and the fragment-drop heuristic (rule 8).
+#>
+
+BeforeAll {
+    . "$PSScriptRoot/../scripts/fol-eval-segment.ps1"
+}
+
+Describe 'Split-DebateTurnClauses — §4 boundary rules' -Tag 'qbaf' {
+
+    It 'returns no clauses for empty / whitespace text' {
+        @(Split-DebateTurnClauses -Text '' -DebateId 'd1' -TurnIndex 0).Count | Should -Be 0
+        @(Split-DebateTurnClauses -Text "   `t " -DebateId 'd1' -TurnIndex 0).Count | Should -Be 0
+    }
+
+    It 'treats a single self-contained sentence as one clause' {
+        $c = @(Split-DebateTurnClauses -Text 'Seven firms control 35% of the S&P 500.' -DebateId 'd1' -TurnIndex 2)
+        $c.Count | Should -Be 1
+        $c[0].text | Should -Be 'Seven firms control 35% of the S&P 500.'
+        $c[0].id | Should -Be 'd1:t2:c0'
+        $c[0].segmentation_rule | Should -Be 'sentence-initial'
+    }
+
+    It 'splits multiple sentences (rule 1)' {
+        $c = @(Split-DebateTurnClauses -Text 'Caps protect incumbents. Congress should drop them.' -DebateId 'd1' -TurnIndex 0)
+        $c.Count | Should -Be 2
+        $c[0].text | Should -Be 'Caps protect incumbents.'
+        $c[1].text | Should -Be 'Congress should drop them.'
+        $c[1].segmentation_rule | Should -Be 'sentence'
+    }
+
+    It 'rule 4 — a trailing normative/rhetorical closer does NOT inherit the factual body (splits at "so")' {
+        $c = @(Split-DebateTurnClauses -Text 'Data centers consumed 415 TWh in 2024 so the ban is unjustified' -DebateId 'd1' -TurnIndex 1)
+        $c.Count | Should -Be 2
+        $c[0].text | Should -Be 'Data centers consumed 415 TWh in 2024'
+        $c[1].text | Should -Be 'so the ban is unjustified'
+        $c[1].segmentation_rule | Should -Be 'connective-split'
+    }
+
+    It 'rule 3 — splits at a discourse connective ("because") into antecedent + consequent' {
+        $c = @(Split-DebateTurnClauses -Text 'Congress should not impose caps because caps protect incumbents' -DebateId 'd1' -TurnIndex 0)
+        $c.Count | Should -Be 2
+        $c[0].text | Should -Be 'Congress should not impose caps'
+        $c[1].text | Should -Be 'because caps protect incumbents'
+    }
+
+    It 'rule 2 — splits coordinated finite clauses at ", and"' {
+        $c = @(Split-DebateTurnClauses -Text 'The caps entrench incumbents, and Congress should drop them' -DebateId 'd1' -TurnIndex 0)
+        $c.Count | Should -Be 2
+        $c[0].text | Should -Be 'The caps entrench incumbents,'
+        $c[1].text | Should -Be 'and Congress should drop them'
+        $c[1].segmentation_rule | Should -Be 'coordinator-split'
+    }
+
+    It 'rule 5 — attributed restatement: isolates the "X claims that" wrapper from the embedded proposition' {
+        $c = @(Split-DebateTurnClauses -Text 'Safetyist claims that the regime monitors clusters above 10^26 ops' -DebateId 'd1' -TurnIndex 3)
+        $c.Count | Should -Be 2
+        $c[0].is_attribution_wrapper | Should -BeTrue
+        $c[0].segmentation_rule | Should -Be 'attribution-wrapper-start'
+        $c[1].is_attribution_wrapper | Should -BeFalse
+        $c[1].text | Should -Be 'the regime monitors clusters above 10^26 ops'
+        $c[1].segmentation_rule | Should -Be 'attributed-content'
+    }
+
+    It 'rule 5 — recognizes the "posits that" attribution verb seen in the real corpus' {
+        $c = @(Split-DebateTurnClauses -Text 'Skeptic posits that pre-release audits are a prerequisite for progress' -DebateId 'd1' -TurnIndex 5)
+        $c.Count | Should -Be 2
+        $c[0].is_attribution_wrapper | Should -BeTrue
+        $c[1].text | Should -Be 'pre-release audits are a prerequisite for progress'
+    }
+
+    It 'rule 8 — drops sub-clausal / punctuation-only fragments' {
+        # A stray bare token after a split should not survive as a clause.
+        $c = @(Split-DebateTurnClauses -Text 'The ban is premature. No.' -DebateId 'd1' -TurnIndex 0)
+        # "No." is a single short token -> dropped; only the substantive clause remains.
+        @($c | Where-Object { $_.text -eq 'The ban is premature.' }).Count | Should -Be 1
+        @($c | Where-Object { $_.text -match '^No' }).Count | Should -Be 0
+    }
+}
+
+Describe 'Split-DebateTurnClauses — spans + ids (double-annotation-ready, §11)' -Tag 'qbaf' {
+
+    It 'char offsets round-trip to the original text for every clause' {
+        $text = 'Caps protect incumbents. Congress should drop them, and citizens should watch regulators.'
+        $c = @(Split-DebateTurnClauses -Text $text -DebateId 'deb-abc' -TurnIndex 4)
+        $c.Count | Should -BeGreaterThan 1
+        foreach ($cl in $c) {
+            # The recorded span must reproduce the recorded text exactly (offset integrity).
+            $text.Substring($cl.char_start, $cl.char_end - $cl.char_start) | Should -Be $cl.text
+            $cl.char_start | Should -BeGreaterOrEqual 0
+            $cl.char_end | Should -BeLessOrEqual $text.Length
+        }
+    }
+
+    It 'assigns stable, sequential, unique clause ids scoped to debate + turn' {
+        $text = 'A first claim here. A second claim here. A third claim here.'
+        $c = @(Split-DebateTurnClauses -Text $text -DebateId 'deb-xyz' -TurnIndex 7)
+        $c.Count | Should -Be 3
+        $c[0].id | Should -Be 'deb-xyz:t7:c0'
+        $c[1].id | Should -Be 'deb-xyz:t7:c1'
+        $c[2].id | Should -Be 'deb-xyz:t7:c2'
+        @($c.id | Sort-Object -Unique).Count | Should -Be 3
+        $c | ForEach-Object { $_.turn_index | Should -Be 7 }
+    }
+
+    It 'is deterministic — identical input yields identical output' {
+        $text = 'Seven firms control 35% of the S&P 500, and that concentration is the real risk.'
+        $a = @(Split-DebateTurnClauses -Text $text -DebateId 'd' -TurnIndex 0)
+        $b = @(Split-DebateTurnClauses -Text $text -DebateId 'd' -TurnIndex 0)
+        ($a | ConvertTo-Json -Depth 5) | Should -Be ($b | ConvertTo-Json -Depth 5)
+    }
+}


### PR DESCRIPTION
## Increment 2a — clause segmenter (design §4)

Second build increment of the offline FOL-on-debate eval harness (t/3354), after the foundation (#2045). Implements the **rule-based clause segmenter** from the co-signed, TL-gated design (`research/comp-linguist/analyses/fol-debate-eval/fol-eval-design.md` §4, CL-authoritative boundary rules).

### What lands
- **`scripts/fol-eval-segment.ps1`** — `Split-DebateTurnClauses`, a PURE, deterministic, offset-preserving transform (no AI, no I/O; dot-sourced by the runner + tests). Realizes §4 rules 2/3/4/5/7/8: split coordinated finite clauses, discourse connectives (`however/therefore/thus/hence/so/because`) + `;`, the load-bearing "trailing normative/rhetorical closer never inherits the factual body" cut, the attributed-restatement matrix-vs-content split (`X claims/posits that P` → wrapper isolated, embedded P is the formalization target), enumerations, and sub-clausal fragment drop. Every clause carries **stable ids + char spans** → double-annotation-ready (§11).
- **`run-fol-debate-eval.ps1`** — dot-sources the segmenter; the loader now retains statement turns with their actual `transcript[]` index; the non-DryRun path runs the **SEGMENT stage** (emits `clauses.jsonl` outside the data root + a per-rule distribution), then throws honestly at the still-pending **classify** stage (Increment 2b).
- Tests: **`FolDebateSegment.Tests.ps1`** (12 cases — §4 rules, span round-trip integrity, stable/unique ids, determinism); **`DataWriteSinkGuard.Tests.ps1`** exemption reason updated to note the `clauses.jsonl` write (still fail-closed OUTSIDE the data root, §1).

### Verification
- 15/15 Pester green (segmenter 12 + sink-guard 3); `Test-ModuleManifest` OK.
- Live non-DryRun over the real **185-closed-debate** corpus (keys unset, read-only): sampled 5 → segmented **816 clauses** to `clauses.jsonl` outside the data root, printed the per-rule distribution, threw at classify as designed.

### Scope / gates
Read-only over `../ai-triad-data` (design §1, fail-closed). No `ai-usages.json`/`ai-models.json` change → no `verify:config` impact, and neither a blocking-gate promotion nor a schema change → no Second Opinion (t/3361). The AI clause **classifier** (§3) + blind gold set (§5) are Increment 2b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)