### PR TITLE
feat(analysis): Formalization section in BdiGroundingPanel — surface logical_form (t/3397, A1)

### DIFF
--- a/taxonomy-editor/src/renderer/components/analysis/BdiGroundingPanel.css
+++ b/taxonomy-editor/src/renderer/components/analysis/BdiGroundingPanel.css
@@ -175,3 +175,212 @@
   background: rgba(234, 179, 8, 0.12);
   color: #ca8a04;
 }
+
+/* ─── Formalization (FOL) section (t/3397) ───────────────
+   Experimental, collapsed-by-default layer over node.logical_form. Weak-axis marking must be
+   visible INSIDE the expanded body, not only the header badge (TL §8 binding condition). */
+
+.bdi-gr-fol-toggle {
+  width: 100%;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--border-subtle);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.bdi-gr-fol-caret {
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  width: 10px;
+}
+
+.bdi-gr-fol-badge {
+  font-size: var(--text-2xs);
+  font-weight: 700;
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: rgba(234, 179, 8, 0.15);
+  color: #ca8a04;
+  border: 1px solid rgba(234, 179, 8, 0.3);
+  margin-left: auto;
+}
+
+.bdi-gr-fol-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 6px 2px 2px;
+}
+
+.bdi-gr-fol-weak-note {
+  font-size: var(--text-2xs);
+  color: #ca8a04;
+  background: rgba(234, 179, 8, 0.08);
+  border: 1px solid rgba(234, 179, 8, 0.2);
+  border-radius: var(--radius-sm);
+  padding: 5px 8px;
+  margin: 0;
+  line-height: 1.5;
+}
+
+.bdi-gr-fol-header-row {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: var(--text-xs);
+}
+
+.bdi-gr-fol-predicate {
+  font-weight: 700;
+  font-family: var(--font-mono);
+  color: var(--text-primary);
+}
+
+.bdi-gr-fol-polarity {
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  padding: 1px 4px;
+  border-radius: var(--radius-sm);
+}
+
+.bdi-gr-fol-polarity--positive {
+  background: rgba(34, 197, 94, 0.1);
+  color: #16a34a;
+}
+
+.bdi-gr-fol-polarity--negative {
+  background: rgba(239, 68, 68, 0.1);
+  color: #dc2626;
+}
+
+.bdi-gr-fol-modality,
+.bdi-gr-fol-temporal {
+  font-size: var(--text-2xs);
+  color: var(--text-secondary);
+}
+
+.bdi-gr-fol-participants {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border: 1px dashed rgba(234, 179, 8, 0.3);
+  border-radius: var(--radius-sm);
+  padding: 6px;
+}
+
+.bdi-gr-fol-participants-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.bdi-gr-fol-participants-title {
+  font-size: var(--text-2xs);
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.bdi-gr-fol-low-reliability {
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  color: #ca8a04;
+}
+
+.bdi-gr-fol-arg-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--text-2xs);
+  padding: 2px 0;
+}
+
+.bdi-gr-fol-arg-role {
+  font-weight: 600;
+  color: var(--text-primary);
+  min-width: 72px;
+}
+
+.bdi-gr-fol-arg-sort,
+.bdi-gr-fol-arg-match {
+  color: var(--text-muted);
+}
+
+.bdi-gr-fol-about {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+  font-size: var(--text-2xs);
+}
+
+.bdi-gr-fol-about-label {
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin-right: 2px;
+}
+
+.bdi-gr-fol-footer-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--text-2xs);
+}
+
+.bdi-gr-fol-status {
+  font-weight: 600;
+  padding: 1px 4px;
+  border-radius: var(--radius-sm);
+}
+
+.bdi-gr-fol-status--accepted {
+  background: rgba(34, 197, 94, 0.12);
+  color: #16a34a;
+}
+
+.bdi-gr-fol-status--proposed {
+  background: rgba(148, 163, 184, 0.15);
+  color: var(--text-secondary);
+}
+
+.bdi-gr-fol-status--rejected {
+  background: rgba(239, 68, 68, 0.1);
+  color: #dc2626;
+}
+
+.bdi-gr-fol-confidence {
+  color: var(--text-muted);
+}
+
+.bdi-gr-fol-debug-toggle {
+  align-self: flex-start;
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  padding: 2px 6px;
+  cursor: pointer;
+}
+
+.bdi-gr-fol-debug-toggle:hover {
+  color: var(--text-primary);
+  border-color: var(--focus-ring);
+}
+
+.bdi-gr-fol-raw {
+  font-size: var(--text-2xs);
+  font-family: var(--font-mono);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  padding: 8px;
+  overflow-x: auto;
+  white-space: pre;
+  max-height: 240px;
+  overflow-y: auto;
+}

--- a/taxonomy-editor/src/renderer/components/analysis/BdiGroundingPanel.test.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/BdiGroundingPanel.test.tsx
@@ -4,6 +4,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import type { ConceptLinkRef, EntityLinkRef } from '@lib/entities/types';
+import type { LogicalForm } from '@lib/entities/logicalForm';
 
 vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => null }));
 
@@ -61,6 +62,21 @@ function makeNode(overrides: Record<string, unknown> = {}) {
     ...overrides,
   };
 }
+
+const LOGICAL_FORM: LogicalForm = {
+  predicate: 'acquire',
+  event_ref: 'e1',
+  args: [
+    { role: 'agent', ref: 'ent-034', sort: 'agentive-physical-object', match_level: 'exact' },
+    { role: 'patient', ref: 'ent-055', sort: 'non-agentive-functional-artifact', match_level: 'exact' },
+  ],
+  polarity: 'positive',
+  modality: { holder: 'camp:acc', attitude: 'belief' },
+  temporal: { type: 'at', value: '2025-02' },
+  about: [{ ref: 'ent-034', match_level: 'exact' }],
+  formalization_confidence: 0.85,
+  status: 'accepted',
+};
 
 describe('BdiGroundingPanel (t/3292)', () => {
   beforeEach(() => { vi.clearAllMocks(); });
@@ -181,5 +197,99 @@ describe('BdiGroundingPanel (t/3292)', () => {
     }));
     render(<BdiGroundingPanel />);
     expect(screen.getByText('alignment')).toBeInTheDocument();
+  });
+
+  describe('Formalization section (t/3397)', () => {
+    it('renders nothing when the node has no logical_form', () => {
+      mockStore.mockReturnValue(makeStore({
+        selectedNodeId: 'acc-beliefs-001',
+        accelerationist: { nodes: [makeNode()] },
+      }));
+      render(<BdiGroundingPanel />);
+      expect(screen.queryByText('Formalization')).not.toBeInTheDocument();
+    });
+
+    it('renders the collapsed header with an experimental badge when logical_form is present', () => {
+      mockStore.mockReturnValue(makeStore({
+        selectedNodeId: 'acc-beliefs-001',
+        accelerationist: { nodes: [makeNode({ logical_form: LOGICAL_FORM })] },
+      }));
+      render(<BdiGroundingPanel />);
+      expect(screen.getByText('Formalization')).toBeInTheDocument();
+      expect(screen.getByText('experimental')).toBeInTheDocument();
+      // Collapsed by default — body content not yet in the DOM.
+      expect(screen.queryByText('acquire')).not.toBeInTheDocument();
+    });
+
+    it('expands on click and shows predicate/polarity/modality/temporal', () => {
+      mockStore.mockReturnValue(makeStore({
+        selectedNodeId: 'acc-beliefs-001',
+        accelerationist: { nodes: [makeNode({ logical_form: LOGICAL_FORM })] },
+      }));
+      render(<BdiGroundingPanel />);
+      fireEvent.click(screen.getByRole('button', { name: /Formalization/ }));
+      expect(screen.getByText('acquire')).toBeInTheDocument();
+      expect(screen.getByText('positive')).toBeInTheDocument();
+      expect(screen.getByText(/Accelerationist.*belief/)).toBeInTheDocument();
+      expect(screen.getByText(/at 2025-02/)).toBeInTheDocument();
+    });
+
+    it('shows the weak-axes note INSIDE the expanded section, not only on the header', () => {
+      mockStore.mockReturnValue(makeStore({
+        selectedNodeId: 'acc-beliefs-001',
+        accelerationist: { nodes: [makeNode({ logical_form: LOGICAL_FORM })] },
+      }));
+      render(<BdiGroundingPanel />);
+      expect(screen.queryByText(/predicate \(~0.68\)/)).not.toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button', { name: /Formalization/ }));
+      expect(screen.getByText(/predicate \(~0.68\) and args \(~0.30\)/)).toBeInTheDocument();
+      expect(screen.getByText(/low-reliability axis/)).toBeInTheDocument();
+    });
+
+    it('renders participant rows with role, ref, sort, and match_level', () => {
+      mockStore.mockReturnValue(makeStore({
+        selectedNodeId: 'acc-beliefs-001',
+        accelerationist: { nodes: [makeNode({ logical_form: LOGICAL_FORM })] },
+      }));
+      render(<BdiGroundingPanel />);
+      fireEvent.click(screen.getByRole('button', { name: /Formalization/ }));
+      expect(screen.getByText('agent')).toBeInTheDocument();
+      expect(screen.getAllByText('ent-034').length).toBeGreaterThan(0);
+      expect(screen.getByText('agentive-physical-object')).toBeInTheDocument();
+      expect(screen.getAllByText('exact').length).toBeGreaterThan(0);
+    });
+
+    it('renders about[] refs with the existing proposed-style treatment', () => {
+      mockStore.mockReturnValue(makeStore({
+        selectedNodeId: 'acc-beliefs-001',
+        accelerationist: { nodes: [makeNode({ logical_form: LOGICAL_FORM })] },
+      }));
+      render(<BdiGroundingPanel />);
+      fireEvent.click(screen.getByRole('button', { name: /Formalization/ }));
+      const aboutChip = screen.getAllByText('ent-034').find(el => el.className.includes('bdi-gr-status--proposed'));
+      expect(aboutChip).toBeTruthy();
+    });
+
+    it('renders formalization_confidence with a self-rated caveat', () => {
+      mockStore.mockReturnValue(makeStore({
+        selectedNodeId: 'acc-beliefs-001',
+        accelerationist: { nodes: [makeNode({ logical_form: LOGICAL_FORM })] },
+      }));
+      render(<BdiGroundingPanel />);
+      fireEvent.click(screen.getByRole('button', { name: /Formalization/ }));
+      expect(screen.getByText(/confidence 85% \(self-rated\)/)).toBeInTheDocument();
+    });
+
+    it('keeps raw JSON hidden until the debug toggle is clicked', () => {
+      mockStore.mockReturnValue(makeStore({
+        selectedNodeId: 'acc-beliefs-001',
+        accelerationist: { nodes: [makeNode({ logical_form: LOGICAL_FORM })] },
+      }));
+      render(<BdiGroundingPanel />);
+      fireEvent.click(screen.getByRole('button', { name: /Formalization/ }));
+      expect(screen.queryByText(/"event_ref"/)).not.toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button', { name: /View raw frame/ }));
+      expect(screen.getByText(/"event_ref"/)).toBeInTheDocument();
+    });
   });
 });

--- a/taxonomy-editor/src/renderer/components/analysis/BdiGroundingPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/BdiGroundingPanel.tsx
@@ -1,12 +1,47 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useTaxonomyStore } from '../../hooks/useTaxonomyStore';
 import type { PovNode } from '../../types/taxonomy';
 import type { ConceptLinkRef, EntityLinkRef } from '@lib/entities/types';
+import type { LogicalForm } from '@lib/entities/logicalForm';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import './BdiGroundingPanel.css';
+
+// Measured maturity figures (t/3353 §2, docs/logical-form-surfacing-and-consumption-proposal.md).
+// Update alongside the register if these are re-measured — cited, never invented.
+const FOL_WEAK_AXES_NOTE =
+  'Experimental — predicate (~0.68) and args (~0.30) axes are unvalidated. ' +
+  'Do not treat participants below as authoritative.';
+
+const FOL_HOLDER_LABEL: Record<string, string> = {
+  'camp:acc': 'Accelerationist',
+  'camp:saf': 'Safetyist',
+  'camp:skp': 'Skeptic',
+};
+
+// logical_form is validated by lib/entities/logicalForm.ts but not yet declared on the PovNode
+// TS interface (t/3157 added entity_refs/concept_refs there; logical_form predates that and is
+// accessed via cast elsewhere in this codebase, e.g. taxonomyDataSlice.ts's reattach-on-save path).
+function getLogicalForm(node: PovNode): LogicalForm | undefined {
+  return (node as unknown as { logical_form?: LogicalForm }).logical_form;
+}
+
+interface TopicalCandidates {
+  refs: { ref: string; match_level: string }[];
+}
+
+// Option-C `topical_candidates` (t/3389, logical-form-schema.md §topical_candidates) is additive
+// phase-1 and Python-only so far — no TS Zod entry yet. Read defensively at runtime; render only
+// the documented shape, never assume a ref-kind beyond what's present (t/3397 spec point 6).
+function getTopicalCandidates(lf: LogicalForm): TopicalCandidates | undefined {
+  const tc = (lf as unknown as { topical_candidates?: unknown }).topical_candidates;
+  if (!tc || typeof tc !== 'object') return undefined;
+  const refs = (tc as Record<string, unknown>).refs;
+  if (!Array.isArray(refs)) return undefined;
+  return { refs: refs as { ref: string; match_level: string }[] };
+}
 
 function findNodeInFiles(
   id: string,
@@ -67,6 +102,102 @@ function EntityRow({ linkRef, onClick }: EntityRowProps) {
   );
 }
 
+function FormalizationSection({ logicalForm }: { logicalForm: LogicalForm }) {
+  const [expanded, setExpanded] = useState(false);
+  const [showRaw, setShowRaw] = useState(false);
+  const topicalCandidates = getTopicalCandidates(logicalForm);
+  const aboutRefs = logicalForm.about ?? [];
+
+  return (
+    <section className="bdi-gr-section bdi-gr-fol">
+      <button
+        type="button"
+        className="bdi-gr-section-header bdi-gr-fol-toggle"
+        onClick={() => setExpanded(e => !e)}
+        aria-expanded={expanded}
+      >
+        <span className="bdi-gr-fol-caret">{expanded ? '▾' : '▸'}</span>
+        <span className="bdi-gr-section-title">Formalization</span>
+        <span className="bdi-gr-fol-badge" title="Derived, unconsumed layer — no downstream consumer relies on this yet">experimental</span>
+      </button>
+
+      {expanded && (
+        <div className="bdi-gr-fol-body">
+          <p className="bdi-gr-fol-weak-note">{FOL_WEAK_AXES_NOTE}</p>
+
+          <div className="bdi-gr-fol-header-row">
+            <span className="bdi-gr-fol-predicate">{logicalForm.predicate}</span>
+            <span className={`bdi-gr-fol-polarity bdi-gr-fol-polarity--${logicalForm.polarity}`}>{logicalForm.polarity}</span>
+            {logicalForm.modality && (
+              <span className="bdi-gr-fol-modality">
+                {FOL_HOLDER_LABEL[logicalForm.modality.holder] ?? logicalForm.modality.holder} · {logicalForm.modality.attitude}
+              </span>
+            )}
+            <span className="bdi-gr-fol-temporal">
+              {logicalForm.temporal.type}{logicalForm.temporal.value ? ` ${logicalForm.temporal.value}` : ''}
+            </span>
+          </div>
+
+          <div className="bdi-gr-fol-participants">
+            <div className="bdi-gr-fol-participants-header">
+              <span className="bdi-gr-fol-participants-title">Participants</span>
+              <span className="bdi-gr-fol-low-reliability" title="args ~0.30 — see the experimental note above">⚠ low-reliability axis</span>
+            </div>
+            {logicalForm.args.length === 0
+              ? <p className="bdi-gr-section-empty">No participants recorded.</p>
+              : logicalForm.args.map((arg, i) => (
+                <div key={i} className="bdi-gr-fol-arg-row">
+                  <span className="bdi-gr-fol-arg-role">{arg.role}</span>
+                  <span className="bdi-gr-ref">{arg.ref}</span>
+                  <span className="bdi-gr-fol-arg-sort">{arg.sort}</span>
+                  <span className="bdi-gr-fol-arg-match">{arg.match_level}</span>
+                </div>
+              ))}
+          </div>
+
+          {aboutRefs.length > 0 && (
+            <div className="bdi-gr-fol-about">
+              <span className="bdi-gr-fol-about-label">about</span>
+              {aboutRefs.map((a, i) => (
+                <span key={i} className="bdi-gr-status bdi-gr-status--proposed" title={`match_level: ${a.match_level}`}>
+                  {a.ref}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {topicalCandidates && topicalCandidates.refs.length > 0 && (
+            <div className="bdi-gr-fol-about">
+              <span className="bdi-gr-fol-about-label">topical candidates</span>
+              <span className="bdi-gr-status bdi-gr-status--proposed" title="validated: false — Option-C concept layer, t/3389">unvalidated</span>
+              {topicalCandidates.refs.map((r, i) => (
+                <span key={i} className="bdi-gr-status bdi-gr-status--proposed" title={`match_level: ${r.match_level}`}>
+                  {r.ref}
+                </span>
+              ))}
+            </div>
+          )}
+
+          <div className="bdi-gr-fol-footer-row">
+            <span className={`bdi-gr-fol-status bdi-gr-fol-status--${logicalForm.status}`}>{logicalForm.status}</span>
+            <span
+              className="bdi-gr-fol-confidence"
+              title="Self-rated by the formalization pass — stipulated, not correlated with measured correctness"
+            >
+              confidence {confidencePct(logicalForm.formalization_confidence)} (self-rated)*
+            </span>
+          </div>
+
+          <button type="button" className="bdi-gr-fol-debug-toggle" onClick={() => setShowRaw(s => !s)}>
+            {showRaw ? 'Hide raw frame' : 'View raw frame (debug)'}
+          </button>
+          {showRaw && <pre className="bdi-gr-fol-raw">{JSON.stringify(logicalForm, null, 2)}</pre>}
+        </div>
+      )}
+    </section>
+  );
+}
+
 export function BdiGroundingPanel() {
   const { selectedNodeId, accelerationist, safetyist, skeptic, setToolbarPanel } = useTaxonomyStore();
 
@@ -91,6 +222,7 @@ export function BdiGroundingPanel() {
 
   const conceptRefs = node.concept_refs ?? [];
   const entityRefs = node.entity_refs ?? [];
+  const logicalForm = getLogicalForm(node);
 
   return (
     <div className="bdi-gr-root">
@@ -119,6 +251,8 @@ export function BdiGroundingPanel() {
             <EntityRow key={r.ref} linkRef={r} onClick={() => setToolbarPanel('entities')} />
           ))}
       </section>
+
+      {logicalForm && <FormalizationSection logicalForm={logicalForm} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Implements t/3353 Part A / option A1 (TL architecture review PASSED e/149#2, PI GO p/548): a collapsible **Formalization** section inside the existing `BdiGroundingPanel`, sibling to the concept/entity grounding rows, surfacing the previously-dark `node.logical_form` layer.

- Collapsed by default, `experimental` badge on the header
- **BINDING (TL §8):** weak-axes note rendered INSIDE the expanded body — "predicate (~0.68) and args (~0.30) axes are unvalidated" — plus a standing "⚠ low-reliability axis" marker directly on the participants sub-table (a header badge alone does not satisfy this per the review)
- `formalization_confidence` renders with an explicit "(self-rated)*" caveat + tooltip (stipulated, not calibrated per the measured-maturity table — never presented as a reliability bar)
- `about[]` rows reuse the panel's existing `bdi-gr-status--proposed` styling (per the handoff note, for visual consistency with the concept/entity honesty conventions)
- Defensive-only forward-compat render of the not-yet-typed Option-C `topical_candidates` field (t/3389, Python-only so far) — read via runtime shape checks, never assumed
- Raw JSON behind a debug toggle, off by default; no NL gloss (A3 explicitly out of scope — opt-in-only if ever built)
- Renderer-only — `logical_form` already loaded on the POV node (post-t/3352), no transport change

Routes t/3397 + duplicate t/3399 (see t/3399#1/#2 for dedup note).

## Test plan

- [x] 20/20 tests pass (`BdiGroundingPanel.test.tsx`, 8 new for the Formalization section)
- [x] `/review-ts` clean — no CRITICAL/WARNING findings
- [x] No new `tsc` errors (3 pre-existing errors in `lib/brief`/`lib/sanitize`, unrelated)
- [ ] Quality (TL) review — routed per docs/review-routing.md (single-scope, UI-only, existing pattern, no schema change)

Closes t/3397, t/3399 (duplicate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AoWKVNhQCeYg5uZZoMUfx3