### PR TITLE
analysis(t/3390): prompt-tuning can't reopen A — P/R frontier peaks ~0.68 F1 < 0.80

### DIFF
--- a/research/comp-linguist/analyses/t3390-precision/FINDINGS.md
+++ b/research/comp-linguist/analyses/t3390-precision/FINDINGS.md
@@ -47,6 +47,10 @@ A/B isolates the prompt effect from model/re-run variance. Topical selection = `
   A): v2 is the recommended prompt (**P = 0.85** at R = 0.61). But that is a *metric change* (F1 → precision@k)
   and a separate pre-committed decision — it does NOT reopen A under the current F1 rule.
 
+## Layer-owner decision (e/145#18–#19): KEEP v1 recall-first; do NOT regenerate with v2
+
+TL surfaced that v2's P=0.849 could upgrade the `topical_candidates` layer today under C. **Decision (CL, as layer owner): keep the v1 recall-first layer (0.54); no data change.** `topical_candidates` is a *candidate* layer — recall-oriented by name and intended role (topical retrieval/grounding candidates); a downstream filter prunes false positives, but v2's 40% recall loss drops genuine subjects (`documented_present_harm`, `capabilities_hazard`, `accountability_market`) that are unrecoverable downstream. v2 is not more *validated* (same unvalidated status, different P/R point), there are no consumers today (dark layer, t/3353), and the in-data marking already makes the 0.54 noise legible. **Revisit trigger:** a future consumer that genuinely needs a precision-first topical index — at which point the mechanism-change path (select-then-verify) could give both axes rather than forcing the trade. v2 is the recorded precision-first operating point until then.
+
 ## Do not land
 
 The v2/v3 prompts are **measured artifacts, not for production**: (a) neither clears the floor; (b) the

--- a/research/comp-linguist/analyses/t3390-precision/FINDINGS.md
+++ b/research/comp-linguist/analyses/t3390-precision/FINDINGS.md
@@ -1,0 +1,54 @@
+# t/3390 — generator concept-selection precision: prompt-tuning frontier (the "path back to A")
+
+**Verdict: prompt-tuning trades precision against recall along a frontier that peaks ~0.68 F1 — the locked ≥0.80 concept-anchored floor is NOT reachable by prompt-tuning. Option A does not reopen via a prompt fix; C stands.**
+
+## Method
+
+Same 61 frozen t/3381 nodes (`sample-manifest.json`), same blind `REFERENCE_ABOUT` gold, same
+ref-level per-row about-F1 over the 55 concept-anchored rows (identical to `score_about_golden.py`).
+Three prompt framings run **same-session** (`remeasure.py` runs v1+v2, `run_v3.py` runs v3) so the
+A/B isolates the prompt effect from model/re-run variance. Topical selection = `about[]` ∪
+`topical_candidates.refs` (version-agnostic). Model: `gemini-3.5-flash-lite`, temp 0.2.
+
+## Result
+
+| Prompt | mean per-row F1 | micro P | micro R | FP | FN | behavior |
+|---|---|---|---|---|---|---|
+| **v1** production (control) | 0.665 | 0.561 | 0.946 | 68 | 5 | over-includes |
+| **v2** precision-first (aggressive "prefer omit / 0–2 items") | 0.676 | **0.849** | 0.609 | 10 | 36 | over-excludes |
+| **v3** balanced (targeted exclusions, recall-preserving) | 0.654 | 0.534 | 0.935 | 75 | 6 | over-includes |
+
+(v1 here = 0.665 reproduces the frozen t/3381 baseline 0.636 within re-run variance — same over-inclusion signature.)
+
+## Finding
+
+1. **The over-inclusion IS prompt-controllable.** v2's three targeted exclusions (excluded-foil,
+   thematic-halo, lexical-coincidence) cut micro FP **68 → 10**, lifting precision **0.56 → 0.85**.
+   The failure taxonomy from t/3381 was correct and the fixes bite.
+2. **But the LLM's concept-selection is near-binary**, not smoothly tunable: it sits either permissive
+   (P ≈ 0.53–0.56, R ≈ 0.94) or strict (P ≈ 0.85, R ≈ 0.61). v3's recall-preserving language collapsed
+   straight back to v1's over-inclusion; no framing found a balanced middle.
+3. **The F1 envelope tops out ~0.68** across all three framings. The extra refs a permissive prompt adds
+   and the genuine refs a strict prompt drops are the **same ambiguous marginal concepts** (v2's 36 FN
+   are real gold subjects like `documented_present_harm`, `capabilities_hazard`, `accountability_market`
+   — not junk). The classes overlap irreducibly, the same pattern the register records for
+   `crux_undecided_rate` (dialectical/topical marginal cases not separable by the available instrument).
+4. **≥0.80 F1 needs BOTH P and R high (~0.80/0.80); the frontier does not offer that point.** So the
+   pre-committed floor is not reachable by prompt-tuning. **Per the locked e/145 rule, A does not reopen.**
+
+## Implications (for the group — not decided here)
+
+- **C stands** as the convention (the F1 floor is unmet by the only lever in scope here).
+- **Reopening A would need a MECHANISM change, not a prompt** — e.g. a two-stage *select-then-verify*
+  (generate candidate topical refs, then a second pass adjudicates each against the proposition), better
+  upstream concept-ref grounding, or a different instrument for the marginal class. That is a new design +
+  a fresh pre-committed re-measure, not a tweak.
+- **If a precision-first operating point is ever wanted for `topical_candidates` quality** (independent of
+  A): v2 is the recommended prompt (**P = 0.85** at R = 0.61). But that is a *metric change* (F1 → precision@k)
+  and a separate pre-committed decision — it does NOT reopen A under the current F1 rule.
+
+## Do not land
+
+The v2/v3 prompts are **measured artifacts, not for production**: (a) neither clears the floor; (b) the
+prompt is shared with PS `LogicalFormPass.ps1` (any change needs the t/3389 condition-3 PS↔TS parity);
+(c) changing selection behavior is out of scope while "C stands." Kept here as the evidence trail.

--- a/research/comp-linguist/analyses/t3390-precision/logical-form-formalization.v2.prompt
+++ b/research/comp-linguist/analyses/t3390-precision/logical-form-formalization.v2.prompt
@@ -1,0 +1,46 @@
+You are a formal-semantics analyst. Convert one claim into a neo-Davidsonian event frame. The output is a first-order logical form. Report only the structure the claim's own words assert. Do not add participants, events, or modality the claim does not state, and do not resolve or invent entity identifiers.
+
+Read the CLAIM and its RESOLVED ENTITIES, then emit the logical form.
+
+CLAIM CATEGORY: {{CLAIM_CATEGORY}}
+  (Beliefs | Desires | Intentions = an attributed BDI claim held by a camp; factual = an unattributed factual_claim.)
+
+ATTRIBUTING CAMP: {{CAMP}}
+  (acc | saf | skp for a BDI claim; empty for a factual claim.)
+
+PROPOSITION (the claim's proposition to formalize; for a BDI claim this is the register-normalized canonical_proposition, for a factual claim it is the point/verbatim text since canonical_proposition is empty):
+{{PROPOSITION}}
+
+RESOLVED ENTITIES (the ONLY entity ids you may put in args[].ref, each with the sort and match_level you MUST copy verbatim):
+{{ENTITY_REFS}}
+
+Return ONLY a JSON object with these fields:
+- "predicate": the lemma of the single core event or relation the proposition asserts (lowercase verb/relation lemma). It MUST be a CONTENT action the proposition asserts happens in the world, NEVER a stance/attitude/reporting verb (enforced by the predicate self-check rule).
+- "event_ref": a variable naming that event, "e1" (use "e2", "e3" only if the proposition genuinely asserts more than one event).
+- "args": array of participants in the event. Each: {"role", "ref", "sort", "match_level"}.
+    - "role": one of agent | patient | theme | recipient | instrument | location | source | goal | beneficiary | cause | manner.
+    - "ref": the id of the participant. If the participant is one of the RESOLVED ENTITIES, use its exact "ref" id; NEVER invent or alter an id. If it is not a resolved entity, use lit:"<the surface phrase>". If it is the event itself, use its event var.
+    - "sort": for a resolved-entity ref, copy that entity's sort verbatim. For a lit:/event arg, choose EXACTLY ONE of these five values — the closed DOLCE-lite set, no others (do NOT emit full-DOLCE terms such as "abstract", "process", "state", "social-object", "agentive-social-object", "social-group", "achievement"): agentive-physical-object (an agent — person, organization, or agentive body) | non-agentive-functional-artifact (a made physical or technical thing — a system, model, chip, dataset) | perdurant (an event, process, or state) | normative-description (a norm, law, policy, or regulation) | non-agentive-social-object (any other non-physical or abstract thing — a concept, quality, value, or claim).
+    - "match_level": for a resolved-entity ref, copy that entity's match_level verbatim (exact | instance_of | subclass | superclass | related). For a lit:/event arg, use "exact".
+- "polarity": "positive" or "negative", marking whether the proposition asserts the predication or its negation. This is negation of the event, not of any attitude.
+- "modality": for a BDI claim, {"holder": "camp:<CAMP>", "attitude": "belief"|"desire"|"intention"} where the attitude is the lowercased singular of CLAIM CATEGORY. For a factual claim, null.
+- "temporal": {"type": "at"|"before"|"after"|"during"|"unspecified", "value": "<ISO-8601 date or interval>" or null}. Use "unspecified" with null value when the proposition states no time. Never omit the field.
+- "formalization_confidence": 0.0–1.0, your confidence that this frame faithfully renders the proposition (low when the proposition is vague, compound, or hard to reduce to one event).
+- "status": "proposed". Use "rejected" only per the meta-descriptive rule below.
+- "about": array of {"ref", "match_level"} for the RESOLVED ENTITIES/CONCEPTS the claim is TOPICALLY about — its GENUINE subject matter, typically its 1–3 core topics, NOT every ref in the list. This is a PRECISION-FIRST index: include a ref ONLY if the claim actually makes a point ABOUT it. Distinct from args (predicate-argument roles): a resolved ref the claim genuinely concerns but that fills no arg role still belongs here. Apply these three exclusions BEFORE listing any ref:
+    (1) EXCLUDED-FOIL — if a concept/entity appears only in the claim's CONTRAST or EXCLUSION clause ("Excludes …", "not …", "rather than …", "as opposed to …", "unlike …"), the claim is NOT about it; omit it.
+    (2) THEMATIC-HALO — omit a broad ambient concept merely associated with the domain (e.g. generic "existential safety" on a claim really about liability, or "AI governance" on a claim about one specific mechanism) UNLESS the claim is specifically about that concept.
+    (3) LEXICAL COINCIDENCE — include a named entity only if the PROPOSITION is genuinely about that entity, judged from its meaning, not because a surface word matches the entity's name (e.g. do NOT include the company "Scale AI" when "scale" is a verb).
+  Prefer omitting a doubtful ref over including it. An empty "about", or one with a single ref, is common and correct.
+
+Rules:
+- Base args[].ref ONLY on the RESOLVED ENTITIES list. A participant the claim mentions but that is not in that list becomes lit:"…". Do not guess an ent- id for it.
+- Copy sort and match_level from the resolved entity; do not re-judge an entity's DOLCE sort.
+- Choose the single predicate that carries the proposition's main assertion; push secondary detail into args or omit it rather than inventing extra events.
+- attitude follows CLAIM CATEGORY and holder follows ATTRIBUTING CAMP mechanically; do not re-read them from the proposition text.
+- If the PROPOSITION is meta-descriptive ("The document discusses / highlights / argues ..."), formalize the EMBEDDED assertion (what the document actually claims), never the reporting frame. Do not emit predicate "discuss" / "report" / "highlight" with a "document" argument. Treat stance-framing wrappers the same way — "A Belief within accelerationist discourse that …", "safetyist discourse holds / aims to …", "the skeptic view is that …" are meta-descriptive framing: formalize the embedded content, not the wrapper. NEVER use "<camp> discourse", "the discourse", "the document", "the view", or any meta-descriptive collective as an args[] AGENT — the camp is already carried in modality, so the real agent is the content actor, or (if none) the frame is meta-descriptive. If no substantive embedded assertion is recoverable, set "status" to "rejected" and "formalization_confidence" at or below 0.2.
+- Strip the ATTITUDE-ATTRIBUTION clause too, not just the reporting frame. BDI propositions often wrap the real content in a stance frame such as "Skeptics support X", "reflects the belief that X", "aligns with the accelerationist view that X", or "the administration aims / seeks / intends to X". That stance is ALREADY carried in "modality" (holder + attitude), so the predicate must be the CONTENT proposition X, never the stance verb itself (support / oppose / reject / advocate / endorse / favor / call for / believe / think / hold / want / desire / aim / seek / intend / "view ... as"). Distinguish a stance verb, which duplicates modality, from a CONTENT action verb (remove / lower / encourage / protect / prevent / consolidate), which IS the predicate. Example: for "The document highlights GDPR Article 22 as a mechanism to protect individual autonomy; skeptics support these rights", emit predicate "protect" (agent GDPR, patient "individual autonomy"), not "support" (agent "skeptics"); the desire is already in modality.attitude.
+- MANDATORY PREDICATE SELF-CHECK (run before emitting): if the chosen "predicate" is any of {support, oppose, reject, advocate, endorse, favor, call, believe, think, hold, want, desire, aim, seek, intend, view, prioritize, value, prefer, promote, champion, emphasize, stress, recognize, acknowledge, address, discuss, highlight, report, note, argue, claim, assert, maintain, contend, reflect, align, frame, position, consider}, then the stance/reporting frame was NOT stripped — re-derive the CONTENT action (remove / lower / protect / prevent / require / ban / mandate / consolidate / automate / …) as the predicate; the attitude is already carried in modality.
+- Fill "about" PRECISION-FIRST from the RESOLVED ENTITIES/CONCEPTS the claim is genuinely about, applying the three exclusions above (excluded-foil, thematic-halo, lexical coincidence). "about" and "args" may overlap. NEVER dump every candidate; never list a ref just because it is available. A doubtful ref is omitted, not included. A 0–2-item "about" is common and correct.
+
+Do not include any commentary outside the JSON.

--- a/research/comp-linguist/analyses/t3390-precision/logical-form-formalization.v3.prompt
+++ b/research/comp-linguist/analyses/t3390-precision/logical-form-formalization.v3.prompt
@@ -1,0 +1,46 @@
+You are a formal-semantics analyst. Convert one claim into a neo-Davidsonian event frame. The output is a first-order logical form. Report only the structure the claim's own words assert. Do not add participants, events, or modality the claim does not state, and do not resolve or invent entity identifiers.
+
+Read the CLAIM and its RESOLVED ENTITIES, then emit the logical form.
+
+CLAIM CATEGORY: {{CLAIM_CATEGORY}}
+  (Beliefs | Desires | Intentions = an attributed BDI claim held by a camp; factual = an unattributed factual_claim.)
+
+ATTRIBUTING CAMP: {{CAMP}}
+  (acc | saf | skp for a BDI claim; empty for a factual claim.)
+
+PROPOSITION (the claim's proposition to formalize; for a BDI claim this is the register-normalized canonical_proposition, for a factual claim it is the point/verbatim text since canonical_proposition is empty):
+{{PROPOSITION}}
+
+RESOLVED ENTITIES (the ONLY entity ids you may put in args[].ref, each with the sort and match_level you MUST copy verbatim):
+{{ENTITY_REFS}}
+
+Return ONLY a JSON object with these fields:
+- "predicate": the lemma of the single core event or relation the proposition asserts (lowercase verb/relation lemma). It MUST be a CONTENT action the proposition asserts happens in the world, NEVER a stance/attitude/reporting verb (enforced by the predicate self-check rule).
+- "event_ref": a variable naming that event, "e1" (use "e2", "e3" only if the proposition genuinely asserts more than one event).
+- "args": array of participants in the event. Each: {"role", "ref", "sort", "match_level"}.
+    - "role": one of agent | patient | theme | recipient | instrument | location | source | goal | beneficiary | cause | manner.
+    - "ref": the id of the participant. If the participant is one of the RESOLVED ENTITIES, use its exact "ref" id; NEVER invent or alter an id. If it is not a resolved entity, use lit:"<the surface phrase>". If it is the event itself, use its event var.
+    - "sort": for a resolved-entity ref, copy that entity's sort verbatim. For a lit:/event arg, choose EXACTLY ONE of these five values — the closed DOLCE-lite set, no others (do NOT emit full-DOLCE terms such as "abstract", "process", "state", "social-object", "agentive-social-object", "social-group", "achievement"): agentive-physical-object (an agent — person, organization, or agentive body) | non-agentive-functional-artifact (a made physical or technical thing — a system, model, chip, dataset) | perdurant (an event, process, or state) | normative-description (a norm, law, policy, or regulation) | non-agentive-social-object (any other non-physical or abstract thing — a concept, quality, value, or claim).
+    - "match_level": for a resolved-entity ref, copy that entity's match_level verbatim (exact | instance_of | subclass | superclass | related). For a lit:/event arg, use "exact".
+- "polarity": "positive" or "negative", marking whether the proposition asserts the predication or its negation. This is negation of the event, not of any attitude.
+- "modality": for a BDI claim, {"holder": "camp:<CAMP>", "attitude": "belief"|"desire"|"intention"} where the attitude is the lowercased singular of CLAIM CATEGORY. For a factual claim, null.
+- "temporal": {"type": "at"|"before"|"after"|"during"|"unspecified", "value": "<ISO-8601 date or interval>" or null}. Use "unspecified" with null value when the proposition states no time. Never omit the field.
+- "formalization_confidence": 0.0–1.0, your confidence that this frame faithfully renders the proposition (low when the proposition is vague, compound, or hard to reduce to one event).
+- "status": "proposed". Use "rejected" only per the meta-descriptive rule below.
+- "about": array of {"ref", "match_level"} for the RESOLVED ENTITIES/CONCEPTS the claim is TOPICALLY about — its subject matter: its core topic(s) AND the specific concepts it makes a substantive point about. Include EVERY resolved ref the claim genuinely engages as a topic; the three exclusions below are the ONLY grounds for omitting a ref. Distinct from args (predicate-argument roles): a resolved ref the claim genuinely concerns but that fills no arg role still belongs here. Omit a ref ONLY if it meets one of:
+    (1) EXCLUDED-FOIL — it appears only in the claim's CONTRAST or EXCLUSION clause ("Excludes …", "not …", "rather than …", "as opposed to …", "unlike …"): the claim defines itself AGAINST it, so it is not about it.
+    (2) AMBIENT-ONLY — it is broad domain vocabulary the claim makes no specific point about (e.g. generic "existential safety" on a claim really about liability). If the claim substantively discusses the concept, KEEP it.
+    (3) LEXICAL COINCIDENCE — a named entity whose name surface-matches a word in the proposition but which the proposition is not actually about (e.g. the company "Scale AI" when "scale" is a verb).
+  Do not omit a genuinely-topical ref for any other reason; when the claim makes a point about a concept, include it even if the claim also lists several others.
+
+Rules:
+- Base args[].ref ONLY on the RESOLVED ENTITIES list. A participant the claim mentions but that is not in that list becomes lit:"…". Do not guess an ent- id for it.
+- Copy sort and match_level from the resolved entity; do not re-judge an entity's DOLCE sort.
+- Choose the single predicate that carries the proposition's main assertion; push secondary detail into args or omit it rather than inventing extra events.
+- attitude follows CLAIM CATEGORY and holder follows ATTRIBUTING CAMP mechanically; do not re-read them from the proposition text.
+- If the PROPOSITION is meta-descriptive ("The document discusses / highlights / argues ..."), formalize the EMBEDDED assertion (what the document actually claims), never the reporting frame. Do not emit predicate "discuss" / "report" / "highlight" with a "document" argument. Treat stance-framing wrappers the same way — "A Belief within accelerationist discourse that …", "safetyist discourse holds / aims to …", "the skeptic view is that …" are meta-descriptive framing: formalize the embedded content, not the wrapper. NEVER use "<camp> discourse", "the discourse", "the document", "the view", or any meta-descriptive collective as an args[] AGENT — the camp is already carried in modality, so the real agent is the content actor, or (if none) the frame is meta-descriptive. If no substantive embedded assertion is recoverable, set "status" to "rejected" and "formalization_confidence" at or below 0.2.
+- Strip the ATTITUDE-ATTRIBUTION clause too, not just the reporting frame. BDI propositions often wrap the real content in a stance frame such as "Skeptics support X", "reflects the belief that X", "aligns with the accelerationist view that X", or "the administration aims / seeks / intends to X". That stance is ALREADY carried in "modality" (holder + attitude), so the predicate must be the CONTENT proposition X, never the stance verb itself (support / oppose / reject / advocate / endorse / favor / call for / believe / think / hold / want / desire / aim / seek / intend / "view ... as"). Distinguish a stance verb, which duplicates modality, from a CONTENT action verb (remove / lower / encourage / protect / prevent / consolidate), which IS the predicate. Example: for "The document highlights GDPR Article 22 as a mechanism to protect individual autonomy; skeptics support these rights", emit predicate "protect" (agent GDPR, patient "individual autonomy"), not "support" (agent "skeptics"); the desire is already in modality.attitude.
+- MANDATORY PREDICATE SELF-CHECK (run before emitting): if the chosen "predicate" is any of {support, oppose, reject, advocate, endorse, favor, call, believe, think, hold, want, desire, aim, seek, intend, view, prioritize, value, prefer, promote, champion, emphasize, stress, recognize, acknowledge, address, discuss, highlight, report, note, argue, claim, assert, maintain, contend, reflect, align, frame, position, consider}, then the stance/reporting frame was NOT stripped — re-derive the CONTENT action (remove / lower / protect / prevent / require / ban / mandate / consolidate / automate / …) as the predicate; the attitude is already carried in modality.
+- Fill "about" from the RESOLVED ENTITIES/CONCEPTS the claim is genuinely about — its core subjects and the concepts it makes a point about — omitting a ref ONLY under the three exclusions (excluded-foil, ambient-only, lexical coincidence). "about" and "args" may overlap. Include every genuinely-topical ref; do not drop one merely to keep the list short, but never list a ref the claim only mentions in passing or excludes.
+
+Do not include any commentary outside the JSON.

--- a/research/comp-linguist/analyses/t3390-precision/remeasure-results.json
+++ b/research/comp-linguist/analyses/t3390-precision/remeasure-results.json
@@ -1,0 +1,1430 @@
+{
+ "floor": 0.8,
+ "v1_concept_anchored_f1": 0.664726788363152,
+ "v2_concept_anchored_f1": 0.6756709956709956,
+ "verdict_v2": "C stands",
+ "v1_rows": [
+  {
+   "id": "acc-beliefs-003",
+   "profile": "concept-only",
+   "f1": 0.6666666666666666,
+   "tp": 1,
+   "fp": [
+    "term:deployment_gated"
+   ],
+   "fn": [],
+   "prec": 0.5,
+   "rec": 1.0
+  },
+  {
+   "id": "acc-beliefs-028",
+   "profile": "mixed",
+   "f1": 1.0,
+   "tp": 3,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "acc-beliefs-048",
+   "profile": "concept-only",
+   "f1": 0.5,
+   "tp": 1,
+   "fp": [
+    "term:safety_existential",
+    "term:speculative_future_harm"
+   ],
+   "fn": [],
+   "prec": 0.3333333333333333,
+   "rec": 1.0
+  },
+  {
+   "id": "acc-beliefs-074",
+   "profile": "concept-only",
+   "f1": 0.6666666666666666,
+   "tp": 2,
+   "fp": [
+    "term:liability_strict",
+    "term:regulation_precautionary"
+   ],
+   "fn": [],
+   "prec": 0.5,
+   "rec": 1.0
+  },
+  {
+   "id": "acc-beliefs-088",
+   "profile": "concept-only",
+   "f1": 0.5,
+   "tp": 1,
+   "fp": [
+    "term:deployment_gated",
+    "term:safety_existential"
+   ],
+   "fn": [],
+   "prec": 0.3333333333333333,
+   "rec": 1.0
+  },
+  {
+   "id": "acc-beliefs-109",
+   "profile": "entity-only",
+   "f1": 0.0,
+   "tp": 0,
+   "fp": [
+    "ent-147",
+    "ent-148"
+   ],
+   "fn": [],
+   "prec": 0.0,
+   "rec": 0.0
+  },
+  {
+   "id": "acc-beliefs-111",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 2,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "acc-desires-001",
+   "profile": "concept-only",
+   "f1": 0.6666666666666666,
+   "tp": 1,
+   "fp": [],
+   "fn": [
+    "term:safety_existential"
+   ],
+   "prec": 1.0,
+   "rec": 0.5
+  },
+  {
+   "id": "acc-desires-010",
+   "profile": "concept-only",
+   "f1": 0.0,
+   "tp": 0,
+   "fp": [
+    "term:governance_oversight"
+   ],
+   "fn": [],
+   "prec": 0.0,
+   "rec": 0.0
+  },
+  {
+   "id": "acc-desires-026",
+   "profile": "concept-only",
+   "f1": 0.6666666666666666,
+   "tp": 2,
+   "fp": [
+    "term:capabilities_scaling",
+    "term:governance_adaptive"
+   ],
+   "fn": [],
+   "prec": 0.5,
+   "rec": 1.0
+  },
+  {
+   "id": "acc-desires-033",
+   "profile": "concept-only",
+   "f1": 0.0,
+   "tp": 0,
+   "fp": [
+    "term:safety_existential",
+    "term:speculative_future_harm"
+   ],
+   "fn": [],
+   "prec": 0.0,
+   "rec": 0.0
+  },
+  {
+   "id": "acc-desires-039",
+   "profile": "concept-only",
+   "f1": 0.8,
+   "tp": 2,
+   "fp": [
+    "term:capabilities_scaling"
+   ],
+   "fn": [],
+   "prec": 0.6666666666666666,
+   "rec": 1.0
+  },
+  {
+   "id": "acc-intentions-001",
+   "profile": "concept-only",
+   "f1": 0.6666666666666666,
+   "tp": 1,
+   "fp": [
+    "term:deployment_gated"
+   ],
+   "fn": [],
+   "prec": 0.5,
+   "rec": 1.0
+  },
+  {
+   "id": "acc-intentions-022",
+   "profile": "concept-only",
+   "f1": 0.6666666666666666,
+   "tp": 1,
+   "fp": [
+    "term:alignment_compliance"
+   ],
+   "fn": [],
+   "prec": 0.5,
+   "rec": 1.0
+  },
+  {
+   "id": "acc-intentions-060",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 1,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "acc-intentions-088",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 2,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "acc-intentions-093",
+   "profile": "entity-only",
+   "f1": 0.0,
+   "tp": 0,
+   "fp": [
+    "ent-224"
+   ],
+   "fn": [],
+   "prec": 0.0,
+   "rec": 0.0
+  },
+  {
+   "id": "acc-intentions-107",
+   "profile": "concept-only",
+   "f1": 0.8,
+   "tp": 2,
+   "fp": [
+    "term:governance_oversight"
+   ],
+   "fn": [],
+   "prec": 0.6666666666666666,
+   "rec": 1.0
+  },
+  {
+   "id": "saf-beliefs-001",
+   "profile": "mixed",
+   "f1": 1.0,
+   "tp": 3,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "saf-beliefs-004",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 1,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "saf-beliefs-039",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 4,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "saf-beliefs-101",
+   "profile": "concept-only",
+   "f1": 0.8571428571428571,
+   "tp": 3,
+   "fp": [
+    "term:capabilities_hazard"
+   ],
+   "fn": [],
+   "prec": 0.75,
+   "rec": 1.0
+  },
+  {
+   "id": "saf-beliefs-141",
+   "profile": "concept-only",
+   "f1": 0.8,
+   "tp": 2,
+   "fp": [
+    "term:regulation_precautionary"
+   ],
+   "fn": [],
+   "prec": 0.6666666666666666,
+   "rec": 1.0
+  },
+  {
+   "id": "saf-beliefs-214",
+   "profile": "mixed",
+   "f1": 0.8,
+   "tp": 2,
+   "fp": [
+    "term:regulation_precautionary"
+   ],
+   "fn": [],
+   "prec": 0.6666666666666666,
+   "rec": 1.0
+  },
+  {
+   "id": "saf-beliefs-216",
+   "profile": "entity-only",
+   "f1": 1.0,
+   "tp": 1,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "saf-beliefs-225",
+   "profile": "concept-only",
+   "f1": 0.0,
+   "tp": 0,
+   "fp": [
+    "term:safety_existential"
+   ],
+   "fn": [],
+   "prec": 0.0,
+   "rec": 0.0
+  },
+  {
+   "id": "saf-desires-001",
+   "profile": "concept-only",
+   "f1": 0.888888888888889,
+   "tp": 4,
+   "fp": [],
+   "fn": [
+    "term:capabilities_hazard"
+   ],
+   "prec": 1.0,
+   "rec": 0.8
+  },
+  {
+   "id": "saf-desires-005",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 2,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "saf-desires-011",
+   "profile": "concept-only",
+   "f1": 0.4,
+   "tp": 1,
+   "fp": [
+    "term:capabilities_hazard",
+    "term:safety_existential",
+    "term:speculative_future_harm"
+   ],
+   "fn": [],
+   "prec": 0.25,
+   "rec": 1.0
+  },
+  {
+   "id": "saf-desires-023",
+   "profile": "concept-only",
+   "f1": 0.0,
+   "tp": 0,
+   "fp": [
+    "term:safety_existential",
+    "term:speculative_risk_critique"
+   ],
+   "fn": [],
+   "prec": 0.0,
+   "rec": 0.0
+  },
+  {
+   "id": "saf-desires-028",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 1,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "saf-intentions-001",
+   "profile": "concept-only",
+   "f1": 0.8,
+   "tp": 2,
+   "fp": [
+    "term:safe_harbor_regulatory"
+   ],
+   "fn": [],
+   "prec": 0.6666666666666666,
+   "rec": 1.0
+  },
+  {
+   "id": "saf-intentions-047",
+   "profile": "concept-only",
+   "f1": 0.3636363636363636,
+   "tp": 2,
+   "fp": [
+    "term:behavioral_guardrails",
+    "term:capabilities_hazard",
+    "term:deployment_gated",
+    "term:regulation_precautionary",
+    "term:safety_empirical",
+    "term:safety_existential",
+    "term:transparency_verification"
+   ],
+   "fn": [],
+   "prec": 0.2222222222222222,
+   "rec": 1.0
+  },
+  {
+   "id": "saf-intentions-086",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 0,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "saf-intentions-141",
+   "profile": "concept-only",
+   "f1": 0.6153846153846153,
+   "tp": 4,
+   "fp": [
+    "term:capabilities_hazard",
+    "term:deployment_gated",
+    "term:regulation_precautionary",
+    "term:safety_existential",
+    "term:transparency_verification"
+   ],
+   "fn": [],
+   "prec": 0.4444444444444444,
+   "rec": 1.0
+  },
+  {
+   "id": "saf-intentions-202",
+   "profile": "mixed",
+   "f1": 0.4444444444444445,
+   "tp": 2,
+   "fp": [
+    "ent-360",
+    "term:alignment_compliance",
+    "term:behavioral_guardrails",
+    "term:deployment_gated",
+    "term:regulation_precautionary"
+   ],
+   "fn": [],
+   "prec": 0.2857142857142857,
+   "rec": 1.0
+  },
+  {
+   "id": "saf-intentions-203",
+   "profile": "concept-only",
+   "f1": 0.6666666666666666,
+   "tp": 1,
+   "fp": [
+    "term:capabilities_hazard"
+   ],
+   "fn": [],
+   "prec": 0.5,
+   "rec": 1.0
+  },
+  {
+   "id": "saf-intentions-204",
+   "profile": "mixed",
+   "f1": 0.4,
+   "tp": 2,
+   "fp": [
+    "ent-139",
+    "term:alignment_compliance",
+    "term:behavioral_guardrails",
+    "term:capabilities_hazard",
+    "term:regulation_precautionary",
+    "term:safety_existential"
+   ],
+   "fn": [],
+   "prec": 0.25,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-beliefs-001",
+   "profile": "concept-only",
+   "f1": 0.8571428571428571,
+   "tp": 3,
+   "fp": [],
+   "fn": [
+    "term:documented_present_harm"
+   ],
+   "prec": 1.0,
+   "rec": 0.75
+  },
+  {
+   "id": "skp-beliefs-047",
+   "profile": "mixed",
+   "f1": 1.0,
+   "tp": 3,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-beliefs-053",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 2,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-beliefs-054",
+   "profile": "mixed",
+   "f1": 0.6666666666666666,
+   "tp": 1,
+   "fp": [
+    "ent-360"
+   ],
+   "fn": [],
+   "prec": 0.5,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-beliefs-115",
+   "profile": "mixed",
+   "f1": 0.6666666666666666,
+   "tp": 1,
+   "fp": [
+    "ent-124"
+   ],
+   "fn": [],
+   "prec": 0.5,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-beliefs-136",
+   "profile": "concept-only",
+   "f1": 0.0,
+   "tp": 0,
+   "fp": [
+    "term:risk_innovation"
+   ],
+   "fn": [],
+   "prec": 0.0,
+   "rec": 0.0
+  },
+  {
+   "id": "skp-beliefs-170",
+   "profile": "concept-only",
+   "f1": 0.8,
+   "tp": 2,
+   "fp": [],
+   "fn": [
+    "term:capture_institutional"
+   ],
+   "prec": 1.0,
+   "rec": 0.6666666666666666
+  },
+  {
+   "id": "skp-beliefs-175",
+   "profile": "entity-only",
+   "f1": 1.0,
+   "tp": 1,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-beliefs-178",
+   "profile": "concept-only",
+   "f1": 0.6666666666666666,
+   "tp": 1,
+   "fp": [
+    "term:speculative_risk_critique"
+   ],
+   "fn": [],
+   "prec": 0.5,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-beliefs-230",
+   "profile": "entity-only",
+   "f1": 0.0,
+   "tp": 0,
+   "fp": [
+    "ent-139"
+   ],
+   "fn": [],
+   "prec": 0.0,
+   "rec": 0.0
+  },
+  {
+   "id": "skp-beliefs-237",
+   "profile": "entity-only",
+   "f1": 1.0,
+   "tp": 1,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-beliefs-244",
+   "profile": "concept-only",
+   "f1": 0.6666666666666666,
+   "tp": 1,
+   "fp": [
+    "term:documented_present_harm"
+   ],
+   "fn": [],
+   "prec": 0.5,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-desires-003",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 1,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-desires-014",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 2,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-desires-070",
+   "profile": "concept-only",
+   "f1": 0.0,
+   "tp": 0,
+   "fp": [
+    "term:accountability_market",
+    "term:risk_innovation",
+    "term:safety_existential",
+    "term:speculative_risk_critique"
+   ],
+   "fn": [],
+   "prec": 0.0,
+   "rec": 0.0
+  },
+  {
+   "id": "skp-desires-077",
+   "profile": "concept-only",
+   "f1": 0.0,
+   "tp": 0,
+   "fp": [
+    "term:risk_existential",
+    "term:safety_existential"
+   ],
+   "fn": [],
+   "prec": 0.0,
+   "rec": 0.0
+  },
+  {
+   "id": "skp-desires-083",
+   "profile": "concept-only",
+   "f1": 0.6666666666666666,
+   "tp": 1,
+   "fp": [
+    "term:capabilities_scaling"
+   ],
+   "fn": [],
+   "prec": 0.5,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-intentions-007",
+   "profile": "concept-only",
+   "f1": 0.6666666666666666,
+   "tp": 2,
+   "fp": [
+    "term:alignment_compliance",
+    "term:bias_systemic"
+   ],
+   "fn": [],
+   "prec": 0.5,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-intentions-044",
+   "profile": "concept-only",
+   "f1": 0.6666666666666666,
+   "tp": 1,
+   "fp": [
+    "term:accountability_market"
+   ],
+   "fn": [],
+   "prec": 0.5,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-intentions-102",
+   "profile": "concept-only",
+   "f1": 0.8,
+   "tp": 2,
+   "fp": [],
+   "fn": [
+    "term:regulation_adaptive"
+   ],
+   "prec": 1.0,
+   "rec": 0.6666666666666666
+  },
+  {
+   "id": "skp-intentions-127",
+   "profile": "mixed",
+   "f1": 1.0,
+   "tp": 2,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-intentions-135",
+   "profile": "concept-only",
+   "f1": 0.0,
+   "tp": 0,
+   "fp": [
+    "term:deployment_gated"
+   ],
+   "fn": [],
+   "prec": 0.0,
+   "rec": 0.0
+  },
+  {
+   "id": "skp-intentions-146",
+   "profile": "concept-only",
+   "f1": 0.8,
+   "tp": 4,
+   "fp": [
+    "term:accountability_institutional",
+    "term:regulation_precautionary"
+   ],
+   "fn": [],
+   "prec": 0.6666666666666666,
+   "rec": 1.0
+  }
+ ],
+ "v2_rows": [
+  {
+   "id": "acc-beliefs-003",
+   "profile": "concept-only",
+   "f1": 0.6666666666666666,
+   "tp": 1,
+   "fp": [
+    "term:deployment_gated"
+   ],
+   "fn": [],
+   "prec": 0.5,
+   "rec": 1.0
+  },
+  {
+   "id": "acc-beliefs-028",
+   "profile": "mixed",
+   "f1": 0.0,
+   "tp": 0,
+   "fp": [],
+   "fn": [
+    "ent-071",
+    "term:accountability_market",
+    "term:deployment_gated"
+   ],
+   "prec": 0.0,
+   "rec": 0.0
+  },
+  {
+   "id": "acc-beliefs-048",
+   "profile": "concept-only",
+   "f1": 0.6666666666666666,
+   "tp": 1,
+   "fp": [
+    "term:speculative_future_harm"
+   ],
+   "fn": [],
+   "prec": 0.5,
+   "rec": 1.0
+  },
+  {
+   "id": "acc-beliefs-074",
+   "profile": "concept-only",
+   "f1": 0.0,
+   "tp": 0,
+   "fp": [
+    "term:liability_strict"
+   ],
+   "fn": [
+    "term:accountability_institutional",
+    "term:documented_present_harm"
+   ],
+   "prec": 0.0,
+   "rec": 0.0
+  },
+  {
+   "id": "acc-beliefs-088",
+   "profile": "concept-only",
+   "f1": 0.0,
+   "tp": 0,
+   "fp": [],
+   "fn": [
+    "term:capabilities_hazard"
+   ],
+   "prec": 0.0,
+   "rec": 0.0
+  },
+  {
+   "id": "acc-beliefs-109",
+   "profile": "entity-only",
+   "f1": 1.0,
+   "tp": 0,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "acc-beliefs-111",
+   "profile": "concept-only",
+   "f1": 0.6666666666666666,
+   "tp": 1,
+   "fp": [],
+   "fn": [
+    "term:transparency_verification"
+   ],
+   "prec": 1.0,
+   "rec": 0.5
+  },
+  {
+   "id": "acc-desires-001",
+   "profile": "concept-only",
+   "f1": 0.6666666666666666,
+   "tp": 1,
+   "fp": [],
+   "fn": [
+    "term:safety_existential"
+   ],
+   "prec": 1.0,
+   "rec": 0.5
+  },
+  {
+   "id": "acc-desires-010",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 0,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "acc-desires-026",
+   "profile": "concept-only",
+   "f1": 0.5,
+   "tp": 1,
+   "fp": [
+    "term:governance_adaptive"
+   ],
+   "fn": [
+    "term:control_optimization"
+   ],
+   "prec": 0.5,
+   "rec": 0.5
+  },
+  {
+   "id": "acc-desires-033",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 0,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "acc-desires-039",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 2,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "acc-intentions-001",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 1,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "acc-intentions-022",
+   "profile": "concept-only",
+   "f1": 0.0,
+   "tp": 0,
+   "fp": [],
+   "fn": [
+    "term:governance_oversight"
+   ],
+   "prec": 0.0,
+   "rec": 0.0
+  },
+  {
+   "id": "acc-intentions-060",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 1,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "acc-intentions-088",
+   "profile": "concept-only",
+   "f1": 0.0,
+   "tp": 0,
+   "fp": [],
+   "fn": [
+    "term:accountability_market",
+    "term:governance_adaptive"
+   ],
+   "prec": 0.0,
+   "rec": 0.0
+  },
+  {
+   "id": "acc-intentions-093",
+   "profile": "entity-only",
+   "f1": 1.0,
+   "tp": 0,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "acc-intentions-107",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 2,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "saf-beliefs-001",
+   "profile": "mixed",
+   "f1": 1.0,
+   "tp": 3,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "saf-beliefs-004",
+   "profile": "concept-only",
+   "f1": 0.0,
+   "tp": 0,
+   "fp": [],
+   "fn": [
+    "term:safety_alignment"
+   ],
+   "prec": 0.0,
+   "rec": 0.0
+  },
+  {
+   "id": "saf-beliefs-039",
+   "profile": "concept-only",
+   "f1": 0.6666666666666666,
+   "tp": 2,
+   "fp": [],
+   "fn": [
+    "term:capabilities_hazard",
+    "term:speculative_future_harm"
+   ],
+   "prec": 1.0,
+   "rec": 0.5
+  },
+  {
+   "id": "saf-beliefs-101",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 3,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "saf-beliefs-141",
+   "profile": "concept-only",
+   "f1": 0.6666666666666666,
+   "tp": 1,
+   "fp": [],
+   "fn": [
+    "term:asymmetry_power"
+   ],
+   "prec": 1.0,
+   "rec": 0.5
+  },
+  {
+   "id": "saf-beliefs-214",
+   "profile": "mixed",
+   "f1": 1.0,
+   "tp": 2,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "saf-beliefs-216",
+   "profile": "entity-only",
+   "f1": 1.0,
+   "tp": 1,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "saf-beliefs-225",
+   "profile": "concept-only",
+   "f1": 0.0,
+   "tp": 0,
+   "fp": [
+    "term:safety_existential"
+   ],
+   "fn": [],
+   "prec": 0.0,
+   "rec": 0.0
+  },
+  {
+   "id": "saf-desires-001",
+   "profile": "concept-only",
+   "f1": 0.5714285714285715,
+   "tp": 2,
+   "fp": [],
+   "fn": [
+    "term:autonomy_human",
+    "term:capabilities_hazard",
+    "term:safety_existential"
+   ],
+   "prec": 1.0,
+   "rec": 0.4
+  },
+  {
+   "id": "saf-desires-005",
+   "profile": "concept-only",
+   "f1": 0.6666666666666666,
+   "tp": 1,
+   "fp": [],
+   "fn": [
+    "term:oversight_audit"
+   ],
+   "prec": 1.0,
+   "rec": 0.5
+  },
+  {
+   "id": "saf-desires-011",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 1,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "saf-desires-023",
+   "profile": "concept-only",
+   "f1": 0.0,
+   "tp": 0,
+   "fp": [
+    "term:safety_existential"
+   ],
+   "fn": [],
+   "prec": 0.0,
+   "rec": 0.0
+  },
+  {
+   "id": "saf-desires-028",
+   "profile": "concept-only",
+   "f1": 0.0,
+   "tp": 0,
+   "fp": [],
+   "fn": [
+    "term:liability_strict"
+   ],
+   "prec": 0.0,
+   "rec": 0.0
+  },
+  {
+   "id": "saf-intentions-001",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 2,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "saf-intentions-047",
+   "profile": "concept-only",
+   "f1": 0.6666666666666666,
+   "tp": 1,
+   "fp": [],
+   "fn": [
+    "term:oversight_audit"
+   ],
+   "prec": 1.0,
+   "rec": 0.5
+  },
+  {
+   "id": "saf-intentions-086",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 0,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "saf-intentions-141",
+   "profile": "concept-only",
+   "f1": 0.4,
+   "tp": 1,
+   "fp": [],
+   "fn": [
+    "term:autonomy_human",
+    "term:behavioral_guardrails",
+    "term:control_human_agency"
+   ],
+   "prec": 1.0,
+   "rec": 0.25
+  },
+  {
+   "id": "saf-intentions-202",
+   "profile": "mixed",
+   "f1": 0.5,
+   "tp": 1,
+   "fp": [
+    "term:alignment_compliance"
+   ],
+   "fn": [
+    "term:risk_innovation"
+   ],
+   "prec": 0.5,
+   "rec": 0.5
+  },
+  {
+   "id": "saf-intentions-203",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 1,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "saf-intentions-204",
+   "profile": "mixed",
+   "f1": 0.6666666666666666,
+   "tp": 1,
+   "fp": [],
+   "fn": [
+    "ent-416"
+   ],
+   "prec": 1.0,
+   "rec": 0.5
+  },
+  {
+   "id": "skp-beliefs-001",
+   "profile": "concept-only",
+   "f1": 0.8571428571428571,
+   "tp": 3,
+   "fp": [],
+   "fn": [
+    "term:documented_present_harm"
+   ],
+   "prec": 1.0,
+   "rec": 0.75
+  },
+  {
+   "id": "skp-beliefs-047",
+   "profile": "mixed",
+   "f1": 1.0,
+   "tp": 3,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-beliefs-053",
+   "profile": "concept-only",
+   "f1": 0.6666666666666666,
+   "tp": 1,
+   "fp": [],
+   "fn": [
+    "term:documented_present_harm"
+   ],
+   "prec": 1.0,
+   "rec": 0.5
+  },
+  {
+   "id": "skp-beliefs-054",
+   "profile": "mixed",
+   "f1": 1.0,
+   "tp": 1,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-beliefs-115",
+   "profile": "mixed",
+   "f1": 1.0,
+   "tp": 1,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-beliefs-136",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 0,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-beliefs-170",
+   "profile": "concept-only",
+   "f1": 0.5,
+   "tp": 1,
+   "fp": [],
+   "fn": [
+    "term:capture_institutional",
+    "term:oversight_democratic"
+   ],
+   "prec": 1.0,
+   "rec": 0.3333333333333333
+  },
+  {
+   "id": "skp-beliefs-175",
+   "profile": "entity-only",
+   "f1": 1.0,
+   "tp": 1,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-beliefs-178",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 1,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-beliefs-230",
+   "profile": "entity-only",
+   "f1": 1.0,
+   "tp": 0,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-beliefs-237",
+   "profile": "entity-only",
+   "f1": 1.0,
+   "tp": 1,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-beliefs-244",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 1,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-desires-003",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 1,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-desires-014",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 2,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-desires-070",
+   "profile": "concept-only",
+   "f1": 0.0,
+   "tp": 0,
+   "fp": [
+    "term:risk_innovation"
+   ],
+   "fn": [],
+   "prec": 0.0,
+   "rec": 0.0
+  },
+  {
+   "id": "skp-desires-077",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 0,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-desires-083",
+   "profile": "concept-only",
+   "f1": 0.6666666666666666,
+   "tp": 1,
+   "fp": [
+    "term:capabilities_scaling"
+   ],
+   "fn": [],
+   "prec": 0.5,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-intentions-007",
+   "profile": "concept-only",
+   "f1": 0.6666666666666666,
+   "tp": 1,
+   "fp": [],
+   "fn": [
+    "term:regulation_precautionary"
+   ],
+   "prec": 1.0,
+   "rec": 0.5
+  },
+  {
+   "id": "skp-intentions-044",
+   "profile": "concept-only",
+   "f1": 0.6666666666666666,
+   "tp": 1,
+   "fp": [
+    "term:governance_oversight"
+   ],
+   "fn": [],
+   "prec": 0.5,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-intentions-102",
+   "profile": "concept-only",
+   "f1": 0.5,
+   "tp": 1,
+   "fp": [],
+   "fn": [
+    "term:fairness_individual",
+    "term:regulation_adaptive"
+   ],
+   "prec": 1.0,
+   "rec": 0.3333333333333333
+  },
+  {
+   "id": "skp-intentions-127",
+   "profile": "mixed",
+   "f1": 1.0,
+   "tp": 2,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-intentions-135",
+   "profile": "concept-only",
+   "f1": 1.0,
+   "tp": 0,
+   "fp": [],
+   "fn": [],
+   "prec": 1.0,
+   "rec": 1.0
+  },
+  {
+   "id": "skp-intentions-146",
+   "profile": "concept-only",
+   "f1": 0.6666666666666666,
+   "tp": 2,
+   "fp": [],
+   "fn": [
+    "term:fairness_individual",
+    "term:transparency_accountability"
+   ],
+   "prec": 1.0,
+   "rec": 0.5
+  }
+ ]
+}

--- a/research/comp-linguist/analyses/t3390-precision/remeasure.py
+++ b/research/comp-linguist/analyses/t3390-precision/remeasure.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""t/3390 re-measure — does a precision-first about/topical prompt clear the locked 0.80 floor
+(which would reopen Option A, per e/145)? Runs the production prompt (v1 control) AND the v2
+variant over the SAME 61 frozen t/3381 nodes, scores each generator's topical selection
+(about[] ∪ topical_candidates.refs) against the blind REFERENCE_ABOUT with the identical
+ref-level per-row F1 over concept-anchored rows. Same-run A/B isolates the prompt effect from
+re-run/model variance. Needs GEMINI_API_KEY."""
+import json, os, re, sys, importlib.util, statistics
+from concurrent.futures import ThreadPoolExecutor
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = r"C:\Users\jsnov\repos\ai-triad-research"
+T3381 = os.path.join(REPO, "research", "comp-linguist", "analyses", "t3381-about-golden")
+V1_PROMPT = os.path.join(REPO, "scripts", "AITriad", "Prompts", "logical-form-formalization.prompt")
+V2_PROMPT = os.path.join(HERE, "logical-form-formalization.v2.prompt")
+FLOOR = 0.80
+
+# import the generator to reuse load_nodes/build_prompt/parse_lf/validate (identity-preserving)
+spec = importlib.util.spec_from_file_location(
+    "flf", os.path.join(REPO, "research", "comp-linguist", "tools", "formalize_node_lf.py"))
+flf = importlib.util.module_from_spec(spec); spec.loader.exec_module(flf)
+
+def f1(ref, cand):
+    if not ref and not cand: return 1.0
+    if not ref or not cand: return 0.0
+    tp = len(ref & cand); p = tp/len(cand); r = tp/len(ref)
+    return 0.0 if (p+r)==0 else 2*p*r/(p+r)
+
+def parse_reference(path):
+    out, cur = {}, None
+    hdr = re.compile(r"^##\s+\[\d+\]\s+(\S+)")
+    for ln in open(path, encoding="utf-8"):
+        m = hdr.match(ln)
+        if m: cur = m.group(1); continue
+        if cur and ln.startswith("**REFERENCE_ABOUT:**"):
+            body = ln.split("**REFERENCE_ABOUT:**", 1)[1].strip()
+            out[cur] = set() if body.lower() in ("", "none") else {t.strip() for t in body.split(",") if t.strip()}
+            cur = None
+    return out
+
+man = json.load(open(os.path.join(T3381, "sample-manifest.json"), encoding="utf-8"))
+prof = {e["id"]: e["profile"] for e in man["ids"]}
+ids = [e["id"] for e in man["ids"]]
+gold = parse_reference(os.path.join(T3381, "about-golden-worksheet.md"))
+
+# node objects for the 61 sample ids
+all_nodes = {n["id"]: (fn, data, n) for fn, data, n in flf.load_nodes()}
+missing = [i for i in ids if i not in all_nodes]
+if missing: print(f"WARN {len(missing)} sample ids not found as grounded nodes: {missing[:5]}...")
+sample = [all_nodes[i] for i in ids if i in all_nodes]
+
+import google.generativeai as genai
+genai.configure(api_key=os.environ.get("GEMINI_API_KEY", ""))
+model = genai.GenerativeModel("gemini-3.5-flash-lite",
+                              generation_config={"temperature": 0.2, "response_mime_type": "application/json"})
+
+def topical_refs(lf):
+    """all refs the generator marked topical, version-agnostic (about[] +/or topical_candidates)."""
+    out = set()
+    for a in (lf.get("about") or []): out.add(a.get("ref"))
+    tc = lf.get("topical_candidates")
+    if isinstance(tc, dict):
+        for a in (tc.get("refs") or []): out.add(a.get("ref"))
+    return out - {None}
+
+def run_variant(tmpl):
+    def one(item):
+        fn, data, n = item
+        prompt, allowed, camp, cat = flf.build_prompt(tmpl, n)
+        import time
+        for a in range(3):
+            try:
+                r = model.generate_content(prompt)
+                lf = flf.validate(flf.parse_lf(r.text or ""), allowed, camp, cat)
+                if lf and lf.get("predicate"):
+                    return (n["id"], topical_refs(lf))
+            except Exception as ex:
+                sys.stderr.write(f"  [warn] {n['id']} a{a}: {type(ex).__name__}\n")
+            time.sleep(0.8 * (a + 1))
+        return (n["id"], set())
+    with ThreadPoolExecutor(max_workers=6) as ex:
+        return dict(ex.map(one, sample))
+
+def score(pred_by_id, label):
+    rows = []
+    for nid in ids:
+        if nid not in gold: continue
+        g = gold[nid]; p = pred_by_id.get(nid, set())
+        tp = len(g & p)
+        rows.append({"id": nid, "profile": prof[nid], "f1": f1(g, p),
+                     "tp": tp, "fp": sorted(p - g), "fn": sorted(g - p),
+                     "prec": tp/len(p) if p else (1.0 if not g else 0.0),
+                     "rec": tp/len(g) if g else (1.0 if not p else 0.0)})
+    ca = [r for r in rows if r["profile"] in ("concept-only", "mixed")]
+    floor_val = statistics.mean(r["f1"] for r in ca)
+    tp = sum(r["tp"] for r in ca); fp = sum(len(r["fp"]) for r in ca); fn = sum(len(r["fn"]) for r in ca)
+    P = tp/(tp+fp) if tp+fp else float("nan"); R = tp/(tp+fn) if tp+fn else float("nan")
+    print(f"\n=== {label} — concept-anchored (n={len(ca)}) ===")
+    print(f"  mean per-row about-F1 = {floor_val:.4f}   floor {FLOOR} -> {'PASS (reopens A)' if floor_val>=FLOOR else 'FAIL (C stands)'}")
+    print(f"  micro P={P:.4f} R={R:.4f}  (TP={tp} FP={fp} FN={fn})")
+    return floor_val, rows
+
+if __name__ == "__main__":
+    print(f"nodes: {len(sample)}/{len(ids)}")
+    v1 = run_variant(open(V1_PROMPT, encoding="utf-8").read())
+    v1f, v1rows = score(v1, "v1 (production prompt, control)")
+    v2 = run_variant(open(V2_PROMPT, encoding="utf-8").read())
+    v2f, v2rows = score(v2, "v2 (precision-first variant)")
+    print(f"\nDELTA v2-v1 = {v2f - v1f:+.4f}")
+    json.dump({"floor": FLOOR, "v1_concept_anchored_f1": v1f, "v2_concept_anchored_f1": v2f,
+               "verdict_v2": "reopens A" if v2f >= FLOOR else "C stands",
+               "v1_rows": v1rows, "v2_rows": v2rows},
+              open(os.path.join(HERE, "remeasure-results.json"), "w", encoding="utf-8"), indent=1)
+    print("\nwrote remeasure-results.json")

--- a/research/comp-linguist/analyses/t3390-precision/run_v3.py
+++ b/research/comp-linguist/analyses/t3390-precision/run_v3.py
@@ -1,0 +1,6 @@
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import remeasure as rm  # safe: __main__-guarded; top-level loads data + configures genai, no LLM calls
+HERE = os.path.dirname(os.path.abspath(__file__))
+v3 = rm.run_variant(open(os.path.join(HERE, "logical-form-formalization.v3.prompt"), encoding="utf-8").read())
+rm.score(v3, "v3 (balanced: targeted exclusions + recall-preserving)")


### PR DESCRIPTION
Empirical re-measure (t/3390, the "path back to A") over the 61 frozen t/3381 nodes vs the blind REFERENCE_ABOUT, same ref-level per-row F1. Three prompt framings, same-session A/B:

| prompt | F1 | micro P | micro R |
|---|---|---|---|
| v1 production (control) | 0.665 | 0.561 | 0.946 |
| v2 precision-first | 0.676 | **0.849** | 0.609 |
| v3 recall-preserving | 0.654 | 0.534 | 0.935 |

Over-inclusion IS prompt-controllable (v2 cut FP 68→10, P 0.56→0.85) but the LLM is near-binary and the F1 envelope tops out ~0.68 — the marginal refs it adds/drops are the same ambiguous class. **≥0.80 F1 is not reachable by prompt-tuning → A does not reopen via a prompt fix; C stands.** Reopening needs a mechanism change (select-then-verify / better grounding) + a fresh pre-committed decision.

Analysis only — variant prompts are measured artifacts, NOT for production (shared with PS, parity-gated). Ref t/3390, t/3381, e/145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)