### PR TITLE
feat(cl): FOL first consumer (B1) — cross-camp modality analytics (t/3398)

### DIFF
--- a/research/comp-linguist/analyses/fol-modality-analytics/REPORT.md
+++ b/research/comp-linguist/analyses/fol-modality-analytics/REPORT.md
@@ -1,0 +1,53 @@
+# FOL cross-camp modality analytics (B1, t/3398)
+
+> **Maturity marking (read this first).** This artifact reports distributional
+> patterns over the **mechanical axes only** of `node.logical_form`. It **gates
+> nothing**, writes nothing, and derives no argument structure. Axes consumed &
+> their measured reliability: modality (holder/attitude) & polarity ~1.00 (copied from POV/category, not judged); temporal.type ~0.94. NOT consumed: predicate ~0.50-0.68, args ~0.30, about[]/match_level/formalization_confidence (B5 not-safe list).
+>
+> Provenance: descriptive / indicative (single-draw over one corpus snapshot). Reporting-treatment:
+> `single-draw`. Data snapshot (ai-triad-data):
+> `f19d160e`. Regenerate with `tools/fol_modality_analytics.py`.
+
+## Coverage
+
+| Camp | Nodes | With `logical_form` | Coverage | BDI frames | Factual |
+|---|---:|---:|---:|---:|---:|
+| acc | 201 | 133 | 66.2% | 133 | 0 |
+| saf | 351 | 274 | 78.1% | 274 | 0 |
+| skp | 357 | 234 | 65.5% | 234 | 0 |
+
+## Attitude mix per camp (`modality.attitude`)
+
+| Camp | belief | desire | intention | dominant |
+|---|---:|---:|---:|---|
+| acc | 58 (43.6%) | 15 (11.3%) | 60 (45.1%) | intention |
+| saf | 126 (46.0%) | 24 (8.8%) | 124 (45.3%) | belief |
+| skp | 156 (66.7%) | 22 (9.4%) | 56 (23.9%) | belief |
+
+## Polarity balance (`polarity`)
+
+| Camp | positive | negative | negative % |
+|---|---:|---:|---:|
+| acc | 132 | 1 | 0.8% |
+| saf | 260 | 14 | 5.1% |
+| skp | 221 | 13 | 5.6% |
+
+## Temporal-type spread (`temporal.type`)
+
+| Camp | temporal.type distribution |
+|---|---|
+| acc | unspecified: 133 |
+| saf | unspecified: 269, before: 2, during: 2, at: 1 |
+| skp | unspecified: 232, before: 1, during: 1 |
+
+## Reading (descriptive — patterns, not verdicts)
+
+- **Attitude signature differs by camp** — see the dominant column above; this is
+  the cross-camp modality contrast the reification (`holds(camp, attitude, p)`) was
+  built to make queryable, and it rests only on the ~1.00 mechanical axes.
+- **Polarity** is overwhelmingly positive across camps; negation is a small minority.
+- **Temporal** is near-degenerate (`unspecified` dominates): the BDI corpus is
+  atemporal by construction — a finding in itself, not a gap in this tool.
+
+_Provenance sanity: `modality.holder` matched the file camp on all frames (0 mismatches)._

--- a/research/comp-linguist/analyses/fol-modality-analytics/summary.json
+++ b/research/comp-linguist/analyses/fol-modality-analytics/summary.json
@@ -1,0 +1,114 @@
+{
+  "metric": "fol_cross_camp_modality_analytics",
+  "provenance": "descriptive / indicative (single-draw over one corpus snapshot)",
+  "reporting_treatment": "single-draw",
+  "gates_nothing": true,
+  "consumed_axes": [
+    "modality.holder",
+    "modality.attitude",
+    "polarity",
+    "temporal.type"
+  ],
+  "excluded_axes": [
+    "predicate",
+    "args",
+    "about",
+    "match_level",
+    "formalization_confidence"
+  ],
+  "axis_maturity": "modality (holder/attitude) & polarity ~1.00 (copied from POV/category, not judged); temporal.type ~0.94. NOT consumed: predicate ~0.50-0.68, args ~0.30, about[]/match_level/formalization_confidence (B5 not-safe list).",
+  "data_snapshot_sha": "f19d160e",
+  "per_camp": {
+    "acc": {
+      "nodes_total": 201,
+      "nodes_with_logical_form": 133,
+      "coverage_pct": 66.2,
+      "bdi_frames": 133,
+      "factual_frames": 0,
+      "attitude": {
+        "belief": 58,
+        "desire": 15,
+        "intention": 60
+      },
+      "attitude_other": {},
+      "attitude_pct": {
+        "belief": 43.6,
+        "desire": 11.3,
+        "intention": 45.1
+      },
+      "polarity": {
+        "positive": 132,
+        "negative": 1
+      },
+      "polarity_negative_pct": 0.8,
+      "temporal_type": {
+        "unspecified": 133
+      },
+      "holder_mismatch": 0
+    },
+    "saf": {
+      "nodes_total": 351,
+      "nodes_with_logical_form": 274,
+      "coverage_pct": 78.1,
+      "bdi_frames": 274,
+      "factual_frames": 0,
+      "attitude": {
+        "belief": 126,
+        "desire": 24,
+        "intention": 124
+      },
+      "attitude_other": {},
+      "attitude_pct": {
+        "belief": 46.0,
+        "desire": 8.8,
+        "intention": 45.3
+      },
+      "polarity": {
+        "positive": 260,
+        "negative": 14
+      },
+      "polarity_negative_pct": 5.1,
+      "temporal_type": {
+        "unspecified": 269,
+        "before": 2,
+        "during": 2,
+        "at": 1
+      },
+      "holder_mismatch": 0
+    },
+    "skp": {
+      "nodes_total": 357,
+      "nodes_with_logical_form": 234,
+      "coverage_pct": 65.5,
+      "bdi_frames": 234,
+      "factual_frames": 0,
+      "attitude": {
+        "belief": 156,
+        "desire": 22,
+        "intention": 56
+      },
+      "attitude_other": {},
+      "attitude_pct": {
+        "belief": 66.7,
+        "desire": 9.4,
+        "intention": 23.9
+      },
+      "polarity": {
+        "positive": 221,
+        "negative": 13
+      },
+      "polarity_negative_pct": 5.6,
+      "temporal_type": {
+        "unspecified": 232,
+        "before": 1,
+        "during": 1
+      },
+      "holder_mismatch": 0
+    }
+  },
+  "corpus_bdi_attitude_totals": {
+    "belief": 340,
+    "desire": 61,
+    "intention": 240
+  }
+}

--- a/research/comp-linguist/tools/fol_modality_analytics.py
+++ b/research/comp-linguist/tools/fol_modality_analytics.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Cross-camp modality analytics over node `logical_form` (t/3398, FOL consumer B1).
+
+READ-ONLY. The first real consumer of the `logical_form` layer. It reports
+distributional patterns over the **reliable (mechanical) axes only** —
+`modality.holder`, `modality.attitude`, `polarity`, `temporal.type` — which are
+copied from the node's POV/category, not LLM-judged, and measure ~1.00
+(modality/polarity) / ~0.94 (temporal) on the golden set.
+
+It deliberately does NOT touch `predicate` (~0.50-0.68), `args[]` (~0.30),
+`about[]`, `match_level`, or `formalization_confidence`-as-threshold, and it does
+NOT attempt proposition-identity/equality joins. Those are the B5 "not safe to
+build on yet" axes in `docs/logical-form-surfacing-and-consumption-proposal.md`.
+
+Output is an analysis artifact (`REPORT.md` + `summary.json`), never a UI, never a
+gate, never a write to the corpus. Design of record: t/3353 / t/3398.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+CAMPS: dict[str, str] = {
+    "acc": "accelerationist.json",
+    "saf": "safetyist.json",
+    "skp": "skeptic.json",
+}
+ATTITUDES = ("belief", "desire", "intention")
+POLARITIES = ("positive", "negative")
+
+# Measured maturity of the consumed axes (metric-provenance-register.md; the D3b
+# golden). Stated in the artifact so every reader sees what the numbers rest on.
+AXIS_MATURITY = (
+    "modality (holder/attitude) & polarity ~1.00 (copied from POV/category, not judged); "
+    "temporal.type ~0.94. NOT consumed: predicate ~0.50-0.68, args ~0.30, "
+    "about[]/match_level/formalization_confidence (B5 not-safe list)."
+)
+
+
+def resolve_data_root(explicit: str | None) -> Path:
+    """Resolve the ai-triad-data root: explicit arg > env > .aitriad.json > sibling fallback."""
+    if explicit:
+        return Path(explicit).resolve()
+    env = os.environ.get("AI_TRIAD_DATA_ROOT")
+    if env:
+        return Path(env).resolve()
+    # .aitriad.json lives at the code-repo root; find it walking up from cwd.
+    here = Path.cwd()
+    for parent in (here, *here.parents):
+        cfg = parent / ".aitriad.json"
+        if cfg.is_file():
+            try:
+                data_root = json.loads(cfg.read_text(encoding="utf-8")).get("data_root")
+            except (json.JSONDecodeError, OSError):
+                data_root = None
+            if data_root:
+                return (parent / data_root).resolve()
+            break
+    # Monorepo/sibling fallback.
+    return (here / ".." / ".." / ".." / "ai-triad-data").resolve()
+
+
+def load_nodes(path: Path) -> list[dict[str, Any]]:
+    """Load a POV file's node list. Raises with an actionable message on failure."""
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"POV file not found: {path}\n"
+            f"  Next steps: confirm the data root (AI_TRIAD_DATA_ROOT / .aitriad.json 'data_root') "
+            f"points at the ai-triad-data checkout containing taxonomy/Origin/."
+        )
+    data = json.loads(path.read_text(encoding="utf-8"))
+    nodes = data.get("nodes") if isinstance(data, dict) else data
+    if not isinstance(nodes, list):
+        raise ValueError(f"Unexpected shape in {path}: expected a 'nodes' list.")
+    return nodes
+
+
+def analyze_camp(camp: str, nodes: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate the reliable modality axes for one camp. Read-only."""
+    with_lf = [n for n in nodes if isinstance(n, dict) and isinstance(n.get("logical_form"), dict)]
+    attitude = Counter()
+    polarity = Counter()
+    temporal = Counter()
+    holder_mismatch = 0  # provenance sanity: holder should match the file's camp
+    factual = 0          # modality == null (unattributed fact) — bucketed separately
+    expected_holder = f"camp:{camp}"
+
+    for node in with_lf:
+        lf = node["logical_form"]
+        modality = lf.get("modality")
+        if modality is None:
+            factual += 1
+            continue
+        att = modality.get("attitude")
+        attitude[att] += 1
+        if modality.get("holder") != expected_holder:
+            holder_mismatch += 1
+        polarity[lf.get("polarity")] += 1
+        temporal[(lf.get("temporal") or {}).get("type")] += 1
+
+    bdi_total = sum(attitude.values())
+    return {
+        "nodes_total": len(nodes),
+        "nodes_with_logical_form": len(with_lf),
+        "coverage_pct": round(100 * len(with_lf) / len(nodes), 1) if nodes else 0.0,
+        "bdi_frames": bdi_total,
+        "factual_frames": factual,
+        "attitude": {a: attitude.get(a, 0) for a in ATTITUDES},
+        "attitude_other": {k: v for k, v in attitude.items() if k not in ATTITUDES},
+        "attitude_pct": {
+            a: (round(100 * attitude.get(a, 0) / bdi_total, 1) if bdi_total else 0.0)
+            for a in ATTITUDES
+        },
+        "polarity": {p: polarity.get(p, 0) for p in POLARITIES},
+        "polarity_negative_pct": (
+            round(100 * polarity.get("negative", 0) / bdi_total, 1) if bdi_total else 0.0
+        ),
+        "temporal_type": dict(sorted(temporal.items(), key=lambda kv: -kv[1])),
+        "holder_mismatch": holder_mismatch,
+    }
+
+
+def build_summary(origin: Path, data_sha: str) -> dict[str, Any]:
+    per_camp = {camp: analyze_camp(camp, load_nodes(origin / fn)) for camp, fn in CAMPS.items()}
+    totals_att = Counter()
+    for camp in per_camp.values():
+        for a in ATTITUDES:
+            totals_att[a] += camp["attitude"][a]
+    return {
+        "metric": "fol_cross_camp_modality_analytics",
+        "provenance": "descriptive / indicative (single-draw over one corpus snapshot)",
+        "reporting_treatment": "single-draw",
+        "gates_nothing": True,
+        "consumed_axes": ["modality.holder", "modality.attitude", "polarity", "temporal.type"],
+        "excluded_axes": ["predicate", "args", "about", "match_level", "formalization_confidence"],
+        "axis_maturity": AXIS_MATURITY,
+        "data_snapshot_sha": data_sha,
+        "per_camp": per_camp,
+        "corpus_bdi_attitude_totals": dict(totals_att),
+    }
+
+
+def render_report(summary: dict[str, Any]) -> str:
+    L: list[str] = []
+    L.append("# FOL cross-camp modality analytics (B1, t/3398)")
+    L.append("")
+    L.append("> **Maturity marking (read this first).** This artifact reports distributional")
+    L.append("> patterns over the **mechanical axes only** of `node.logical_form`. It **gates")
+    L.append("> nothing**, writes nothing, and derives no argument structure. Axes consumed &")
+    L.append(f"> their measured reliability: {summary['axis_maturity']}")
+    L.append(">")
+    L.append(f"> Provenance: {summary['provenance']}. Reporting-treatment:")
+    L.append(f"> `{summary['reporting_treatment']}`. Data snapshot (ai-triad-data):")
+    L.append(f"> `{summary['data_snapshot_sha']}`. Regenerate with `tools/fol_modality_analytics.py`.")
+    L.append("")
+    L.append("## Coverage")
+    L.append("")
+    L.append("| Camp | Nodes | With `logical_form` | Coverage | BDI frames | Factual |")
+    L.append("|---|---:|---:|---:|---:|---:|")
+    for camp, c in summary["per_camp"].items():
+        L.append(
+            f"| {camp} | {c['nodes_total']} | {c['nodes_with_logical_form']} | "
+            f"{c['coverage_pct']}% | {c['bdi_frames']} | {c['factual_frames']} |"
+        )
+    L.append("")
+    L.append("## Attitude mix per camp (`modality.attitude`)")
+    L.append("")
+    L.append("| Camp | belief | desire | intention | dominant |")
+    L.append("|---|---:|---:|---:|---|")
+    for camp, c in summary["per_camp"].items():
+        pct = c["attitude_pct"]
+        dominant = max(ATTITUDES, key=lambda a: c["attitude"][a])
+        L.append(
+            f"| {camp} | {c['attitude']['belief']} ({pct['belief']}%) | "
+            f"{c['attitude']['desire']} ({pct['desire']}%) | "
+            f"{c['attitude']['intention']} ({pct['intention']}%) | {dominant} |"
+        )
+    L.append("")
+    L.append("## Polarity balance (`polarity`)")
+    L.append("")
+    L.append("| Camp | positive | negative | negative % |")
+    L.append("|---|---:|---:|---:|")
+    for camp, c in summary["per_camp"].items():
+        L.append(
+            f"| {camp} | {c['polarity']['positive']} | {c['polarity']['negative']} | "
+            f"{c['polarity_negative_pct']}% |"
+        )
+    L.append("")
+    L.append("## Temporal-type spread (`temporal.type`)")
+    L.append("")
+    L.append("| Camp | temporal.type distribution |")
+    L.append("|---|---|")
+    for camp, c in summary["per_camp"].items():
+        dist = ", ".join(f"{k}: {v}" for k, v in c["temporal_type"].items())
+        L.append(f"| {camp} | {dist} |")
+    L.append("")
+    L.append("## Reading (descriptive — patterns, not verdicts)")
+    L.append("")
+    L.append("- **Attitude signature differs by camp** — see the dominant column above; this is")
+    L.append("  the cross-camp modality contrast the reification (`holds(camp, attitude, p)`) was")
+    L.append("  built to make queryable, and it rests only on the ~1.00 mechanical axes.")
+    L.append("- **Polarity** is overwhelmingly positive across camps; negation is a small minority.")
+    L.append("- **Temporal** is near-degenerate (`unspecified` dominates): the BDI corpus is")
+    L.append("  atemporal by construction — a finding in itself, not a gap in this tool.")
+    L.append("")
+    mismatches = sum(c["holder_mismatch"] for c in summary["per_camp"].values())
+    L.append(
+        f"_Provenance sanity: `modality.holder` matched the file camp on all frames "
+        f"({mismatches} mismatches)._" if mismatches == 0 else
+        f"_⚠ Provenance: {mismatches} `modality.holder` values did not match their file camp — investigate._"
+    )
+    L.append("")
+    return "\n".join(L)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--data-root", default=None, help="ai-triad-data checkout (default: env/.aitriad.json/fallback)")
+    ap.add_argument("--out-dir", default=None, help="output dir (default: analyses/fol-modality-analytics next to this tool)")
+    ap.add_argument("--data-sha", default="unknown", help="ai-triad-data snapshot SHA to record in the artifact")
+    args = ap.parse_args(argv)
+
+    data_root = resolve_data_root(args.data_root)
+    origin = data_root / "taxonomy" / "Origin"
+    if not origin.is_dir():
+        print(f"ERROR: taxonomy/Origin not found under data root {data_root}", file=sys.stderr)
+        return 2
+
+    out_dir = Path(args.out_dir) if args.out_dir else (Path(__file__).resolve().parent.parent / "analyses" / "fol-modality-analytics")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    summary = build_summary(origin, args.data_sha)
+    (out_dir / "summary.json").write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    (out_dir / "REPORT.md").write_text(render_report(summary), encoding="utf-8")
+    print(f"Wrote {out_dir / 'REPORT.md'} and summary.json (data snapshot {args.data_sha}).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
First real consumer of the dark `logical_form` layer (t/3353 Part B / B1; PI GO, TL review e/149#2).

**What:** a read-only analytics tool (`research/comp-linguist/tools/fol_modality_analytics.py`) + generated artifact (`analyses/fol-modality-analytics/REPORT.md` + `summary.json`) over `node.logical_form`'s **reliable mechanical axes only** — `modality.holder × attitude` per camp, `polarity`, `temporal.type`.

**Binding conditions (TL §8) honored:**
- Reliable axes only — excludes predicate/args/about[]/match_level/formalization_confidence (B5 not-safe list); no proposition-equality joins.
- Reports patterns, **gates nothing**, writes nothing to the corpus.
- Output leads with a maturity-marking header stating what the numbers rest on.

**Findings (data snapshot f19d160e):** attitude signature differs by camp — acc intention-dominant (45%), skp belief-dominant (67%), saf balanced; polarity ~95%+ positive; corpus near-atemporal. Deterministic (no network/LLM) — regenerates byte-identical on a fixed snapshot.

Self-cert `/trivial-change` (read-only research tooling in own scope, no schema/data-model/gate change). Python self-review (pure stdlib) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)