### PR TITLE
feat(fol-eval): AI clause classifier (§3) + classify stage — Increment 2b (t/3354)

### DIFF
--- a/ai-usages.json
+++ b/ai-usages.json
@@ -578,5 +578,19 @@
       "logical-form",
       "fol"
     ]
+  },
+  "enrichment.fol-clause-classify": {
+    "description": "Classify a batch of debate clauses into the closed 5-type FOL-on-debate taxonomy (assertoric-factual/causal, normative-deontic, speech-act-belief-revision-meta, rhetorical-evaluative) + the attribution/anaphora_dependency/polarity attributes (t/3354 design §3, CL-authoritative). Offline research eval ONLY (read-only over debates; no in-loop path). run-fol-debate-eval.ps1 renders fol-clause-classify.prompt with the clause batch and passes it as {{prompt}}. jsonMode WITHOUT responseSchema (the nested attribute object risks the same Gemini structured-output HTTP 400 as enrichment.logical-form-formalization; the prompt enforces one strict-JSON {results:[...]} object and the stage parses defensively). temperature pinned 0 for determinism. INSTRUMENT-PROVISIONAL: labels anchor no conclusion until spot-validated against CL's blind gold set fol-eval-classifier-gold.jsonl (design §5, t/3342).",
+    "model": "gemini-3.5-flash-lite",
+    "temperature": 0,
+    "maxTokens": 2000,
+    "timeoutMs": 60000,
+    "jsonMode": true,
+    "messageTemplate": "{{prompt}}",
+    "tags": [
+      "enrichment",
+      "fol",
+      "debate-eval"
+    ]
   }
 }

--- a/scripts/AITriad/Prompts/fol-clause-classify.prompt
+++ b/scripts/AITriad/Prompts/fol-clause-classify.prompt
@@ -1,0 +1,24 @@
+You classify debate clauses for an offline research eval (FOL-on-debate, t/3354). Each clause is one finite clause segmented from a debate turn. Assign every clause EXACTLY ONE primary type from the closed set below, plus three orthogonal attributes. Judge only the clause text (with the turn it came from as context); do not infer beyond it.
+
+PRIMARY TYPE (closed set — choose exactly one):
+- "assertoric-factual" = a truth-apt empirical claim about a particular or statistical state of the world (cited/quantitative where possible), leaning self-contained. e.g. "seven firms control 35% of the S&P 500"; "data centers consumed 415 TWh in 2024".
+- "assertoric-causal" = a truth-apt causal or dispositional generalization, typically a universally-quantified generic, often value-laden. e.g. "caps protect incumbents"; "post-disaster penalties cannot rebuild grids".
+- "normative-deontic" = a prescriptive claim with deontic force (must / should / ought / is-obligated-to). e.g. "Congress should bifurcate liability".
+- "speech-act-belief-revision-meta" = a move about the discourse itself: concession, retained commitment, or defeater-conditional. e.g. "I concede the telemetry point"; "I still hold the ban is premature"; "I would change my position if <defeater>".
+- "rhetorical-evaluative" = no truth-apt propositional core to formalize: rhetorical question, category-error charge, pure evaluative framing. e.g. "who gave regulators the authority?"; "comparing a chatbot to a 737 MAX is a category error".
+
+ATTRIBUTES (orthogonal — record all three on every clause):
+- "attribution" ∈ "own" | "attributed-opponent" | "attributed-third-party". An attributed restatement ("Accelerationist proposes that P") is typed by the EMBEDDED proposition P's kind, with attribution "attributed-opponent". The attributed + assertoric combination is the highest-value, highest-anaphora-risk cell.
+- "anaphora_dependency" ∈ "self-contained" | "demonstrative" | "topic-ellipsis" | "attributed-restatement". Whether resolving the clause needs a cross-turn referent (a demonstrative like "that approach", a bare elided topic like "the ban", or an attributed restatement).
+- "polarity" ∈ "asserted" | "negated". "negated" only when the clause's core proposition is itself negated (P vs ¬P) — load-bearing for contradiction detection.
+
+CLAUSES:
+{{clauses_block}}
+
+Return ONLY this JSON (one object per clause id, EVERY id exactly once, no prose):
+{"results": [{"id": "<clause id>", "primary_type": "assertoric-factual", "attribution": "own", "anaphora_dependency": "self-contained", "polarity": "asserted", "confidence": 0.0}]}
+
+Rules:
+- Choose the single best primary type. A fact-dense clause that ENDS on a normative or rhetorical note is typed on its own core, not the neighbor's.
+- "confidence" is your certainty in the primary type, 0.0-1.0.
+- Prefer "rhetorical-evaluative" over forcing an assertoric label when there is no truth-apt core.

--- a/scripts/fol-eval-classify.ps1
+++ b/scripts/fol-eval-classify.ps1
@@ -1,0 +1,284 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    FOL-on-debate eval — clause CLASSIFIER (design §3, CL-authoritative taxonomy). Increment 2b.
+.DESCRIPTION
+    Types each segmented clause (from fol-eval-segment.ps1) into the closed 5-type taxonomy plus the
+    three orthogonal attributes, per the co-signed design §3
+    (research/comp-linguist/analyses/fol-debate-eval/fol-eval-design.md). The classifier is a NEW AI
+    INSTRUMENT (TL condition 3 / §5): its labels anchor NO conclusion until spot-validated against
+    CL's blind gold set (fol-eval-classifier-gold.jsonl). The per-class distribution vs the §3.3 bands
+    is a SANITY GATE, not a threshold.
+
+    Structure mirrors invoke-contradiction-classifier.ps1: pure transforms (Format-FolClauseBlock /
+    ConvertFrom-FolClauseClassification / Measure-FolClauseDistribution) are dot-source unit-tested with
+    NO AI; the single impure call (Invoke-FolClauseClassifier) renders fol-clause-classify.prompt via
+    Get-Prompt and calls Invoke-AIByUsage. A clause is NEVER dropped: an unclassifiable clause gets
+    primary_type 'unclassified' (method 'missing'), which downstream stages exclude from the FOL subset.
+
+    NOTE: Get-Prompt is a module-PRIVATE helper (Import-Module does not expose it), so the runner
+    dot-sources it + sets $script:ModuleRoot before calling Invoke-FolClauseClassifier (same handling
+    as invoke-contradiction-classifier.ps1, t/3302). Invoke-AIByUsage IS exported.
+.LINK
+    fol-eval-segment.ps1
+.LINK
+    run-fol-debate-eval.ps1
+#>
+
+Set-StrictMode -Version Latest
+
+# Closed label sets (design §3). A model label outside these is treated as unclassified (never trusted).
+$script:FOL_PRIMARY_TYPES = @('assertoric-factual', 'assertoric-causal', 'normative-deontic', 'speech-act-belief-revision-meta', 'rhetorical-evaluative')
+$script:FOL_ATTRIBUTION = @('own', 'attributed-opponent', 'attributed-third-party')
+$script:FOL_ANAPHORA = @('self-contained', 'demonstrative', 'topic-ellipsis', 'attributed-restatement')
+$script:FOL_POLARITY = @('asserted', 'negated')
+
+# The assertoric subset that reaches FOL extraction (design §2/§7).
+$script:FOL_ASSERTORIC_TYPES = @('assertoric-factual', 'assertoric-causal')
+
+# §3.3 distribution sanity bands (fraction lo/hi). SANITY, not thresholds — outside => inspect, not fail.
+# speech-act band is widened to 0.30 hi because it rises to ~25-30% in later rounds (design §3.3).
+$script:FOL_DISTRIBUTION_BANDS = @{
+    'assertoric-factual'              = @(0.20, 0.25)
+    'assertoric-causal'               = @(0.35, 0.40)
+    'normative-deontic'               = @(0.15, 0.20)
+    'speech-act-belief-revision-meta' = @(0.10, 0.30)
+    'rhetorical-evaluative'           = @(0.08, 0.12)
+}
+
+function Format-FolClauseBlock {
+    <#
+    .SYNOPSIS
+        Render clauses into the prompt's {{clauses_block}}. PS string only (no shell) — text with quotes
+        / newlines is safe. Pure; no AI, no I/O.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param([Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Clauses)
+    Set-StrictMode -Version Latest
+    $sb = [System.Text.StringBuilder]::new()
+    foreach ($c in $Clauses) {
+        [void]$sb.AppendLine("### $([string]$c.id)")
+        [void]$sb.AppendLine("TEXT: $([string]$c.text)")
+        [void]$sb.AppendLine('')
+    }
+    return $sb.ToString().TrimEnd()
+}
+
+function ConvertFrom-FolClauseClassification {
+    <#
+    .SYNOPSIS
+        Join model classifications (keyed by clause id) back onto the segmented clauses. Pure; no AI, no I/O.
+    .DESCRIPTION
+        Every input clause is returned exactly once (never dropped). A clause with no valid result gets
+        primary_type 'unclassified' + attributes 'unknown' + classify_method 'missing'. The original
+        segmentation fields (id/text/spans/rule) are preserved so the artifact stays double-annotation-ready.
+    .PARAMETER Clauses
+        The segmented clause objects (from Split-DebateTurnClauses).
+    .PARAMETER Results
+        Validated classification map: id -> @{ primary_type; attribution; anaphora_dependency; polarity; confidence }.
+    #>
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Clauses,
+        [Parameter(Mandatory)][hashtable]$Results
+    )
+    Set-StrictMode -Version Latest
+    $out = [System.Collections.Generic.List[object]]::new()
+    foreach ($c in $Clauses) {
+        $id = [string]$c.id
+        if ($Results.ContainsKey($id)) {
+            $r = $Results[$id]
+            $primary = [string]$r['primary_type']
+            $attribution = [string]$r['attribution']
+            $anaphora = [string]$r['anaphora_dependency']
+            $polarity = [string]$r['polarity']
+            $confidence = [double]$r['confidence']
+            $method = 'llm'
+            $isAssertoric = $primary -in $script:FOL_ASSERTORIC_TYPES
+        }
+        else {
+            $primary = 'unclassified'; $attribution = 'unknown'; $anaphora = 'unknown'; $polarity = 'unknown'
+            $confidence = 0.0; $method = 'missing'; $isAssertoric = $false
+        }
+        $out.Add([PSCustomObject]@{
+                id                  = $id
+                debate_id           = $c.debate_id
+                turn_index          = $c.turn_index
+                clause_index        = $c.clause_index
+                text                = $c.text
+                char_start          = $c.char_start
+                char_end            = $c.char_end
+                segmentation_rule   = $c.segmentation_rule
+                primary_type        = $primary
+                attribution         = $attribution
+                anaphora_dependency = $anaphora
+                polarity            = $polarity
+                is_assertoric       = $isAssertoric
+                classify_confidence = $confidence
+                classify_method     = $method
+            })
+    }
+    return @($out)
+}
+
+function Measure-FolClauseDistribution {
+    <#
+    .SYNOPSIS
+        Per-primary-type distribution + §3.3 band sanity flags. Pure; no AI, no I/O.
+    .DESCRIPTION
+        Returns a summary: total, per-type count/fraction/within_band, assertoric_total fraction, and
+        unclassified count. within_band is the §3.3 SANITY check (outside => inspect the classifier /
+        segmenter before trusting labels — NOT a pass/fail gate).
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param([Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Classified)
+    Set-StrictMode -Version Latest
+
+    $total = @($Classified).Count
+    $counts = @{}
+    foreach ($t in $script:FOL_PRIMARY_TYPES) { $counts[$t] = 0 }
+    $unclassified = 0
+    foreach ($c in $Classified) {
+        $t = [string]$c.primary_type
+        if ($counts.ContainsKey($t)) { $counts[$t]++ } else { $unclassified++ }
+    }
+
+    $perType = [System.Collections.Generic.List[object]]::new()
+    $assertoricCount = 0
+    foreach ($t in $script:FOL_PRIMARY_TYPES) {
+        $n = $counts[$t]
+        if ($t -in $script:FOL_ASSERTORIC_TYPES) { $assertoricCount += $n }
+        $frac = if ($total -gt 0) { [Math]::Round($n / [double]$total, 4) } else { 0.0 }
+        $band = $script:FOL_DISTRIBUTION_BANDS[$t]
+        $within = if ($band) { ($frac -ge $band[0] -and $frac -le $band[1]) } else { $true }
+        $perType.Add([PSCustomObject]@{
+                primary_type = $t
+                count        = $n
+                fraction     = $frac
+                band_lo      = if ($band) { $band[0] } else { $null }
+                band_hi      = if ($band) { $band[1] } else { $null }
+                within_band  = $within
+            })
+    }
+
+    $assertoricFrac = if ($total -gt 0) { [Math]::Round($assertoricCount / [double]$total, 4) } else { 0.0 }
+    return [PSCustomObject]@{
+        total                   = $total
+        per_type                = @($perType)
+        assertoric_count        = $assertoricCount
+        assertoric_fraction     = $assertoricFrac
+        assertoric_within_band  = ($assertoricFrac -ge 0.55 -and $assertoricFrac -le 0.65)
+        unclassified_count      = $unclassified
+    }
+}
+
+function Invoke-FolClauseClassifier {
+    <#
+    .SYNOPSIS
+        Classify one batch of clauses via the AI backend (design §3). IMPURE — renders the prompt +
+        calls Invoke-AIByUsage. Returns a validated map id -> classification, or $null on failure.
+    .DESCRIPTION
+        Requires the module (Invoke-AIByUsage) loaded and Get-Prompt dot-sourced with $script:ModuleRoot
+        set (the runner does this). Only entries whose primary_type + all three attributes are in the
+        closed §3 sets survive into the map — an invalid label is a miss (the caller emits 'missing'),
+        never a silently-trusted junk label.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param([Parameter(Mandatory)][object[]]$Clauses, [double]$Temperature = 0.0)
+    Set-StrictMode -Version Latest
+    if (-not $Clauses -or @($Clauses).Count -eq 0) { return @{} }
+    try {
+        $block = Format-FolClauseBlock -Clauses $Clauses
+        $rendered = Get-Prompt -Name 'fol-clause-classify' -Replacements @{ clauses_block = $block }
+        $resp = Invoke-AIByUsage -UsageId 'enrichment.fol-clause-classify' `
+            -Values @{ prompt = $rendered } -Override @{ temperature = $Temperature } -ErrorAction Stop
+        if (-not $resp -or -not $resp.PSObject.Properties['Text'] -or [string]::IsNullOrWhiteSpace($resp.Text)) {
+            Write-Warning "fol-clause-classify: backend returned no Text for $(@($Clauses).Count) clause(s) — check the model/key for usage 'enrichment.fol-clause-classify'."
+            return $null
+        }
+        $parsed = $resp.Text | ConvertFrom-Json -ErrorAction Stop
+        if (-not $parsed.PSObject.Properties['results']) {
+            Write-Warning 'fol-clause-classify: backend Text was not the expected { results: [...] } JSON.'
+            return $null
+        }
+        $map = @{}
+        foreach ($r in @($parsed.results)) {
+            # Positive guard only (no `continue` inside a function — Pester #2669 escapes to the caller's loop).
+            if ($r.PSObject.Properties['id'] -and $r.PSObject.Properties['primary_type']) {
+                $pt = [string]$r.primary_type
+                $attr = if ($r.PSObject.Properties['attribution']) { [string]$r.attribution } else { '' }
+                $ana = if ($r.PSObject.Properties['anaphora_dependency']) { [string]$r.anaphora_dependency } else { '' }
+                $pol = if ($r.PSObject.Properties['polarity']) { [string]$r.polarity } else { '' }
+                if ($pt -in $script:FOL_PRIMARY_TYPES -and $attr -in $script:FOL_ATTRIBUTION -and
+                    $ana -in $script:FOL_ANAPHORA -and $pol -in $script:FOL_POLARITY) {
+                    $conf = if ($r.PSObject.Properties['confidence']) { [double]$r.confidence } else { 0.0 }
+                    $map[[string]$r.id] = @{
+                        primary_type        = $pt
+                        attribution         = $attr
+                        anaphora_dependency = $ana
+                        polarity            = $pol
+                        confidence          = [Math]::Round($conf, 4)
+                    }
+                }
+            }
+        }
+        return $map
+    }
+    catch {
+        # Log the WHY (project rule: log every fallback path + reason). Usually a missing/invalid key or
+        # an unregistered model for usage 'enrichment.fol-clause-classify'.
+        Write-Warning "fol-clause-classify: model call failed: $($_.Exception.Message)"
+        return $null
+    }
+}
+
+function Invoke-FolClauseClassifyBatched {
+    <#
+    .SYNOPSIS
+        Classify all clauses in fixed-size batches, batch-first with a per-clause fallback for any id the
+        batch missed (never drops a clause). Returns the validated map id -> classification.
+    .DESCRIPTION
+        Mirrors invoke-contradiction-classifier's batch+fallback: an id absent from the batch response is
+        re-classified alone; still-missing ids are left out of the map (the join emits them as 'missing').
+        IMPURE (calls Invoke-FolClauseClassifier). Separated so the batching policy is one place.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param([Parameter(Mandatory)][object[]]$Clauses, [int]$BatchSize = 15, [double]$Temperature = 0.0)
+    Set-StrictMode -Version Latest
+    $map = @{}
+    $batch = [System.Collections.Generic.List[object]]::new()
+    $flush = {
+        param($items)
+        if (@($items).Count -eq 0) { return }
+        $r = Invoke-FolClauseClassifier -Clauses @($items) -Temperature $Temperature
+        if ($null -eq $r) {
+            # TOTAL batch failure (backend unavailable / non-JSON) — do NOT per-clause-retry the whole
+            # batch (that would fire N more doomed calls on e.g. a missing key). Leave these ids missing.
+            Write-Warning "fol-clause-classify: batch of $(@($items).Count) clause(s) failed entirely — skipping per-clause fallback (backend unavailable); these clauses emit 'missing'."
+            return
+        }
+        foreach ($k in $r.Keys) { $map[$k] = $r[$k] }
+        # Per-clause fallback ONLY for the ids a (partially) successful batch missed.
+        foreach ($it in @($items)) {
+            $cid = [string]$it.id
+            if (-not $map.ContainsKey($cid)) {
+                $single = Invoke-FolClauseClassifier -Clauses @($it) -Temperature $Temperature
+                if ($null -ne $single -and $single.ContainsKey($cid)) { $map[$cid] = $single[$cid] }
+                else { Write-Warning "fol-clause-classify: clause '$cid' unresolved after batch + per-clause fallback — emitting 'missing' (no assertoric membership)." }
+            }
+        }
+    }
+    foreach ($c in $Clauses) {
+        $batch.Add($c)
+        if ($batch.Count -ge $BatchSize) { & $flush $batch; $batch = [System.Collections.Generic.List[object]]::new() }
+    }
+    & $flush $batch
+    return $map
+}

--- a/scripts/run-fol-debate-eval.ps1
+++ b/scripts/run-fol-debate-eval.ps1
@@ -14,12 +14,12 @@
     COREF/attribution on the assertoric subset (§6, hard prerequisite) -> FOL extraction
     (§7, reuses Private/LogicalFormPass.ps1) -> CONTRADICTION + paraphrase FN-rate (§8).
 
-    THIS COMMIT is the foundation only: the read-only input loaders, the read-only OUTPUT
-    guardrail, the run-bounding cap + up-front manifest, and the stage-dispatch skeleton.
-    The segmenter and clause classifier (§3/§4, CL-authoritative) are NOT implemented here —
-    they land after the CL pairing pass that enumerates the blind gold set
-    (fol-eval-classifier-gold.jsonl). Those stages throw until then, so -DryRun (plan +
-    manifest, no model calls) is the runnable path in this increment.
+    IMPLEMENTED stages: load, run-bound, manifest, SEGMENT (§4, rule-based, fol-eval-segment.ps1),
+    CLASSIFY (§3, AI clause classifier, fol-eval-classify.ps1). The classifier is INSTRUMENT-PROVISIONAL
+    (§5/t/3342): its per-class distribution is checked against the §3.3 bands as a SANITY gate only —
+    labels anchor no conclusion until CL scores the blind gold set (fol-eval-classifier-gold.jsonl).
+    The coref/FOL/contradiction/FN-rate stages are NOT implemented yet and throw (honest failure).
+    Runnable paths without a model call: -DryRun (plan+manifest) and -SkipClassify (segment only).
 
     READ-ONLY (design §1, TL tightening e/141#8): the harness writes NOTHING under the data
     root — not outputs, not caches, not temp/intermediates. -OutputDir is asserted to be
@@ -42,12 +42,19 @@
 .PARAMETER MaxClausesPerDebate
     Hard cap on clauses formalized per debate (run-bound §10).
 .PARAMETER Model
-    AI model for the (not-yet-implemented) classifier/FOL stages. Default gemini-3.5-flash-lite.
+    AI model note (the classifier's model is set by the usage 'enrichment.fol-clause-classify' in
+    ai-usages.json). Recorded in the manifest. Default gemini-3.5-flash-lite.
+.PARAMETER ClassifyBatchSize
+    Clauses per classifier model call (batch-first, per-clause fallback for misses). Default 15.
+.PARAMETER SkipClassify
+    Run SEGMENT only (emit clauses.jsonl), make NO model calls. Inspect segmentation without a key.
 .PARAMETER DryRun
     Plan only: load + sample debates, emit the manifest (sampling plan + cost ceiling), make
-    NO model calls and hit NO unimplemented stage. The runnable path this increment.
+    NO model calls and hit NO stage. The cheapest runnable path.
 .EXAMPLE
     pwsh -File scripts/run-fol-debate-eval.ps1 -OutputDir ./.fol-eval-out -MaxDebates 20 -DryRun
+.EXAMPLE
+    pwsh -File scripts/run-fol-debate-eval.ps1 -OutputDir ./.fol-eval-out -MaxDebates 5 -SkipClassify
 .LINK
     run-xconflict-classifier.ps1
 #>
@@ -71,6 +78,13 @@ param(
     [string]$Model = 'gemini-3.5-flash-lite',
 
     [Parameter()]
+    [ValidateRange(1, 50)]
+    [int]$ClassifyBatchSize = 15,
+
+    [Parameter()]
+    [switch]$SkipClassify,
+
+    [Parameter()]
     [switch]$DryRun
 )
 
@@ -81,8 +95,15 @@ Import-Module (Join-Path $PSScriptRoot 'AITriad' 'AITriad.psd1') -Force -ErrorAc
 $Mod = Get-Module AITriad
 if (-not $Mod) { throw 'AITriad module failed to load; cannot resolve data-root helpers.' }
 
-# Clause segmenter (design §4) — a pure, dot-sourceable library (no top-level side effects).
+# Clause segmenter (§4) + classifier (§3) — pure, dot-sourceable libraries (no top-level side effects).
 . (Join-Path $PSScriptRoot 'fol-eval-segment.ps1')
+. (Join-Path $PSScriptRoot 'fol-eval-classify.ps1')
+
+# Get-Prompt is a module-PRIVATE helper (Import-Module does not expose it), so the classifier's
+# Get-Prompt call would fail with 'not recognized'. Dot-source it + set $script:ModuleRoot so its
+# default Prompts/ dir resolves fol-clause-classify.prompt (same handling as the CC classifier, t/3302).
+$script:ModuleRoot = Join-Path $PSScriptRoot 'AITriad'
+. (Join-Path $PSScriptRoot 'AITriad' 'Private' 'Get-Prompt.ps1')
 
 # ── Module-session-state wrappers for Private helpers (see .DESCRIPTION note) ──────
 function Resolve-DebatesDir { & $Mod { Get-DebatesDir } }
@@ -169,8 +190,9 @@ $manifest = [ordered]@{
     clause_cost_ceiling    = $clauseCeiling
     est_model_calls_upper  = $clauseCeiling * 2   # classifier + FOL, upper bound
     dry_run                = [bool]$DryRun
-    stages_implemented     = @('load', 'run-bound', 'manifest', 'segment')
-    stages_pending_pairing = @('classify', 'coref', 'fol', 'contradiction', 'fn-rate', 'correlate')
+    classify_batch_size    = $ClassifyBatchSize
+    stages_implemented     = @('load', 'run-bound', 'manifest', 'segment', 'classify')
+    stages_pending_pairing = @('coref', 'fol', 'contradiction', 'fn-rate', 'correlate')
 }
 
 Write-Host ''
@@ -199,32 +221,64 @@ if ($DryRun) {
 # calls — it is the honest, runnable extension of the foundation. The classifier (§3) that TYPES
 # each clause is the next increment (2b) and is what turns these clauses into the assertoric subset.
 $clausesPath = Join-Path $resolvedOut 'clauses.jsonl'
-$clauseLines = [System.Collections.Generic.List[string]]::new()
+$allClauses = [System.Collections.Generic.List[object]]::new()
 $ruleCounts = @{}
 foreach ($deb in $selected) {
     foreach ($st in $deb.Statements) {
         $cls = @(Split-DebateTurnClauses -Text $st.content -DebateId $deb.DebateId -TurnIndex $st.turn_index)
         foreach ($cl in $cls) {
-            $clauseLines.Add(($cl | ConvertTo-Json -Depth 4 -Compress))
+            $allClauses.Add($cl)
             $rule = [string]$cl.segmentation_rule
             if ($ruleCounts.ContainsKey($rule)) { $ruleCounts[$rule]++ } else { $ruleCounts[$rule] = 1 }
         }
     }
 }
-Set-Content -LiteralPath $clausesPath -Value $clauseLines -Encoding utf8
+Set-Content -LiteralPath $clausesPath -Value @($allClauses | ForEach-Object { $_ | ConvertTo-Json -Depth 4 -Compress }) -Encoding utf8
 
 Write-Host ''
 Write-Host '=== SEGMENT stage (design §4) — rule-based clause segmentation ===' -ForegroundColor Cyan
-Write-Host "  Clauses: $($clauseLines.Count) across $($selected.Count) debate(s) -> $clausesPath" -ForegroundColor White
+Write-Host "  Clauses: $($allClauses.Count) across $($selected.Count) debate(s) -> $clausesPath" -ForegroundColor White
 foreach ($rk in @($ruleCounts.Keys | Sort-Object)) {
     Write-Host ("    {0,-26} {1}" -f $rk, $ruleCounts[$rk]) -ForegroundColor DarkGray
 }
 
-# ── CLASSIFY + downstream stages (design §3/§6/§7/§8) — Increment 2b, NOT implemented here ──
-# The clause classifier (§3 5-type taxonomy + attributes) is a new AI instrument validated against
-# the blind gold set (§5). Throwing (rather than a fake no-op) keeps the harness honest: a non-DryRun
-# run fails loudly with the exact next step instead of emitting empty results that look complete.
+if ($SkipClassify) {
+    Write-Host ''
+    Write-Host 'SkipClassify: SEGMENT-only run — clauses.jsonl emitted, no model calls. (Inspect segmentation without a key.)' -ForegroundColor Green
+    Write-Host ''
+    return [PSCustomObject]@{ manifest = $manifest; clauses_path = $clausesPath; clause_count = $allClauses.Count }
+}
+
+# ── CLASSIFY stage (design §3) — AI clause classifier; Increment 2b ─────────────────────────
+# Types each clause into the closed 5-type taxonomy + attributes (fol-eval-classify.ps1). PAID: model
+# calls, bounded by the run cap. INSTRUMENT-PROVISIONAL (§5, t/3342): the per-class distribution below
+# is a SANITY check vs the §3.3 bands, NOT a threshold — labels anchor no conclusion until CL scores the
+# blind gold set. A clause is never dropped: an unresolved clause is 'unclassified' (excluded from FOL).
+Write-Host ''
+Write-Host "=== CLASSIFY stage (design §3) — AI clause classifier (PAID; batch=$ClassifyBatchSize) ===" -ForegroundColor Cyan
+$classMap = Invoke-FolClauseClassifyBatched -Clauses @($allClauses) -BatchSize $ClassifyBatchSize -Temperature 0
+$classified = @(ConvertFrom-FolClauseClassification -Clauses @($allClauses) -Results $classMap)
+
+$classifiedPath = Join-Path $resolvedOut 'classified-clauses.jsonl'
+Set-Content -LiteralPath $classifiedPath -Value @($classified | ForEach-Object { $_ | ConvertTo-Json -Depth 4 -Compress }) -Encoding utf8
+
+$dist = Measure-FolClauseDistribution -Classified $classified
+Write-Host "  Classified: $($dist.total) clauses -> $classifiedPath  (unclassified: $($dist.unclassified_count))" -ForegroundColor White
+Write-Host '  Per-class distribution (vs §3.3 sanity bands — inspect if outside, NOT a gate):' -ForegroundColor White
+foreach ($pt in $dist.per_type) {
+    $flag = if ($pt.within_band) { 'ok ' } else { 'OUT' }
+    $bandTxt = if ($null -ne $pt.band_lo) { "[$($pt.band_lo)-$($pt.band_hi)]" } else { '[--]' }
+    $color = if ($pt.within_band) { 'DarkGray' } else { 'DarkYellow' }
+    Write-Host ("    {0,-32} {1,4}  {2,6}  {3} {4}" -f $pt.primary_type, $pt.count, $pt.fraction, $flag, $bandTxt) -ForegroundColor $color
+}
+$asFlag = if ($dist.assertoric_within_band) { 'ok ' } else { 'OUT' }
+Write-Host ("    {0,-32} {1,4}  {2,6}  {3} [0.55-0.65]" -f 'ASSERTORIC TOTAL (-> FOL)', $dist.assertoric_count, $dist.assertoric_fraction, $asFlag) -ForegroundColor Cyan
+if ($dist.unclassified_count -eq $dist.total -and $dist.total -gt 0) {
+    Write-Warning 'CLASSIFY: every clause is unclassified — the backend returned nothing (missing key / model?). classified-clauses.jsonl was still emitted so the run is inspectable; no labels are trustworthy.'
+}
+
+# ── COREF / FOL / CONTRADICTION / FN-rate (design §6/§7/§8) — later increments, NOT implemented ──
 throw (New-EvalError `
     'Run the full FOL-on-debate eval pipeline' `
-    "The SEGMENT stage ran (clauses.jsonl emitted, $($clauseLines.Count) clauses) but the classify/coref/FOL/contradiction stages are not yet implemented — the clause classifier (design §3) is Increment 2b." `
-    'Inspect clauses.jsonl now (or use -DryRun for the plan+manifest). The classifier stage follows with the Computational Linguist blind gold set (design §5); until then load/run-bound/manifest/segment are implemented.')
+    "SEGMENT + CLASSIFY ran (clauses.jsonl + classified-clauses.jsonl emitted; $($dist.assertoric_count) assertoric of $($dist.total)) but the coref/FOL/contradiction/FN-rate stages are not yet implemented." `
+    'Inspect classified-clauses.jsonl now (or use -DryRun / -SkipClassify). The coref stage (design §6, the hard prerequisite on the attributed-opponent x assertoric cell) is the next increment; FOL + contradiction + paraphrase FN-rate follow.')

--- a/taxonomy-editor/src/renderer/data/promptCatalog.ts
+++ b/taxonomy-editor/src/renderer/data/promptCatalog.ts
@@ -1021,6 +1021,17 @@ export const PROMPT_CATALOG: PromptCatalogEntry[] = [
     applicableDataSources: ['taxonomyNodes'],
     promptFiles: ['logical-form-formalization'],
   },
+  {
+    id: 'ps-fol-clause-classify',
+    title: 'FOL-on-Debate Clause Classifier',
+    description: 'Classifies a debate clause into the closed 5-type FOL taxonomy (assertoric-factual/causal, normative-deontic, speech-act/belief-revision-meta, rhetorical-evaluative) plus attribution / anaphora / polarity attributes.',
+    source: 'AITriad/Prompts/fol-clause-classify.prompt',
+    template: '(Loading from disk...)',
+    group: 'powershell',
+    purpose: 'Used by run-fol-debate-eval.ps1 (offline FOL-on-debate eval, t/3354) — types segmented debate clauses so only the assertoric-factual/causal subset reaches FOL extraction. Read-only research eval; INSTRUMENT-PROVISIONAL until validated against CL\'s blind gold set (design §5).',
+    applicableDataSources: ['taxonomyNodes'],
+    promptFiles: ['fol-clause-classify'],
+  },
 
   // === Debate pipeline: Quality & repair prompts ===
   {

--- a/tests/DataWriteSinkGuard.Tests.ps1
+++ b/tests/DataWriteSinkGuard.Tests.ps1
@@ -59,7 +59,7 @@ BeforeAll {
         'scripts/AITriad/Public/New-SyntheticCorpus.ps1'   = 'append-checkpoint + fresh corpus generation + NEW metadata (not a whole-file data rewrite)'
         'scripts/AITriad/Public/Test-DebatePersistence.ps1' = 'writes a random persist-probe .tmp (test probe, non-data)'
         'scripts/AITriad/Private/AICallLog.ps1'            = 'append-only AI call-log JSONL (Add-Content); references Get-DataRoot only to locate the log file — never read-mutate-rewrites a data-of-record file (t/3241)'
-        'scripts/run-fol-debate-eval.ps1'                  = 'read-only FOL-on-debate eval harness (t/3354); Set-Content writes only run-manifest.json + clauses.jsonl to -OutputDir, which is fail-closed asserted OUTSIDE the data root via Test-IsUnderDataRoot (design §1) — references data tokens (debates/summaries/conflicts) as read-only inputs, never writes ../ai-triad-data'
+        'scripts/run-fol-debate-eval.ps1'                  = 'read-only FOL-on-debate eval harness (t/3354); Set-Content writes only run-manifest.json + clauses.jsonl + classified-clauses.jsonl to -OutputDir, which is fail-closed asserted OUTSIDE the data root via Test-IsUnderDataRoot (design §1) — references data tokens (debates/summaries/conflicts) as read-only inputs, never writes ../ai-triad-data'
     }
 
     # A data-of-record path token (basename or data-dir accessor). Kept specific so

--- a/tests/FolDebateClassify.Tests.ps1
+++ b/tests/FolDebateClassify.Tests.ps1
@@ -1,0 +1,103 @@
+# Tag: qbaf (t/3354 — FOL-on-debate eval clause classifier, design §3)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Tests for the FOL-on-debate clause classifier PURE transforms (scripts/fol-eval-classify.ps1, §3).
+.DESCRIPTION
+    Format-FolClauseBlock, ConvertFrom-FolClauseClassification, and Measure-FolClauseDistribution are
+    pure (no AI, no I/O), so the tests dot-source the library and exercise them directly. The impure
+    Invoke-FolClauseClassifier / Invoke-FolClauseClassifyBatched (which call the AI backend) are not
+    invoked here — the classify stage's live behavior is covered by the runner's -DryRun/-SkipClassify
+    paths and manual smoke runs, not by these unit tests.
+#>
+
+BeforeAll {
+    . "$PSScriptRoot/../scripts/fol-eval-classify.ps1"
+}
+
+Describe 'Format-FolClauseBlock' -Tag 'qbaf' {
+    It 'renders each clause as an id header plus a TEXT line, shell-safe for quotes/newlines' {
+        $clauses = @(
+            [pscustomobject]@{ id = 'd:t0:c0'; text = 'Caps protect incumbents.' }
+            [pscustomobject]@{ id = 'd:t0:c1'; text = 'He said "no".' }
+        )
+        $block = Format-FolClauseBlock -Clauses $clauses
+        ($block -match '### d:t0:c0') | Should -BeTrue
+        ($block -match 'TEXT: Caps protect incumbents\.') | Should -BeTrue
+        ($block -match '### d:t0:c1') | Should -BeTrue
+        # quotes in the text survive verbatim (string marshaling, not shell)
+        $block.Contains('TEXT: He said "no".') | Should -BeTrue
+    }
+    It 'tolerates an empty clause set' {
+        Format-FolClauseBlock -Clauses @() | Should -Be ''
+    }
+}
+
+Describe 'ConvertFrom-FolClauseClassification — join, validate, never-drop' -Tag 'qbaf' {
+    BeforeAll {
+        $script:segClauses = @(
+            [pscustomobject]@{ id = 'd:t0:c0'; debate_id = 'd'; turn_index = 0; clause_index = 0; text = 'Seven firms control 35%.'; char_start = 0; char_end = 24; segmentation_rule = 'sentence-initial' }
+            [pscustomobject]@{ id = 'd:t0:c1'; debate_id = 'd'; turn_index = 0; clause_index = 1; text = 'Congress should act.'; char_start = 25; char_end = 45; segmentation_rule = 'sentence' }
+        )
+    }
+
+    It 'attaches the classification and flags the assertoric subset' {
+        $results = @{
+            'd:t0:c0' = @{ primary_type = 'assertoric-factual'; attribution = 'own'; anaphora_dependency = 'self-contained'; polarity = 'asserted'; confidence = 0.9 }
+            'd:t0:c1' = @{ primary_type = 'normative-deontic'; attribution = 'own'; anaphora_dependency = 'self-contained'; polarity = 'asserted'; confidence = 0.8 }
+        }
+        $out = @(ConvertFrom-FolClauseClassification -Clauses $segClauses -Results $results)
+        $out.Count | Should -Be 2
+        ($out | Where-Object { $_.id -eq 'd:t0:c0' }).primary_type | Should -Be 'assertoric-factual'
+        ($out | Where-Object { $_.id -eq 'd:t0:c0' }).is_assertoric | Should -BeTrue
+        ($out | Where-Object { $_.id -eq 'd:t0:c1' }).is_assertoric | Should -BeFalse
+        # Original segmentation fields preserved (double-annotation-ready).
+        ($out | Where-Object { $_.id -eq 'd:t0:c0' }).char_start | Should -Be 0
+        ($out | Where-Object { $_.id -eq 'd:t0:c0' }).segmentation_rule | Should -Be 'sentence-initial'
+    }
+
+    It 'never drops a clause with no result — emits unclassified/missing, not assertoric' {
+        $out = @(ConvertFrom-FolClauseClassification -Clauses $segClauses -Results @{})
+        $out.Count | Should -Be 2
+        $out | ForEach-Object {
+            $_.primary_type | Should -Be 'unclassified'
+            $_.classify_method | Should -Be 'missing'
+            $_.is_assertoric | Should -BeFalse
+        }
+    }
+}
+
+Describe 'Measure-FolClauseDistribution — §3.3 sanity bands' -Tag 'qbaf' {
+    It 'computes per-type fractions, assertoric total, and within_band flags' {
+        # 5 assertoric-factual, 5 rhetorical -> factual 0.5 (OUT of 0.20-0.25), assertoric total 0.5 (OUT of 0.55-0.65)
+        $classified = @()
+        1..5 | ForEach-Object { $classified += [pscustomobject]@{ primary_type = 'assertoric-factual' } }
+        1..5 | ForEach-Object { $classified += [pscustomobject]@{ primary_type = 'rhetorical-evaluative' } }
+        $d = Measure-FolClauseDistribution -Classified $classified
+        $d.total | Should -Be 10
+        $d.assertoric_count | Should -Be 5
+        $d.assertoric_fraction | Should -Be 0.5
+        $d.assertoric_within_band | Should -BeFalse
+        ($d.per_type | Where-Object { $_.primary_type -eq 'assertoric-factual' }).fraction | Should -Be 0.5
+        ($d.per_type | Where-Object { $_.primary_type -eq 'assertoric-factual' }).within_band | Should -BeFalse
+    }
+
+    It 'counts unclassified separately and handles an empty set' {
+        $d0 = Measure-FolClauseDistribution -Classified @()
+        $d0.total | Should -Be 0
+        $d0.assertoric_fraction | Should -Be 0.0
+
+        $mixed = @(
+            [pscustomobject]@{ primary_type = 'assertoric-causal' }
+            [pscustomobject]@{ primary_type = 'unclassified' }
+        )
+        $d1 = Measure-FolClauseDistribution -Classified $mixed
+        $d1.total | Should -Be 2
+        $d1.unclassified_count | Should -Be 1
+        $d1.assertoric_count | Should -Be 1
+    }
+}


### PR DESCRIPTION
## Increment 2b — AI clause classifier (design §3)

Third build increment of the offline FOL-on-debate eval harness (t/3354), after the foundation (#2045) and the segmenter (#2081). Implements the **AI clause classifier** from the co-signed, TL-gated design §3 (CL-authoritative closed 5-type taxonomy + the attribution/anaphora_dependency/polarity attributes).

### What lands
- **`Prompts/fol-clause-classify.prompt`** — the §3 closed-taxonomy classifier prompt; returns strict `{results:[...]}` JSON, uses the §3.1 gold examples as few-shot (the **blind** gold set is deliberately NOT used — §5 train/test separation).
- **`ai-usages.json`** — new `enrichment.fol-clause-classify` usage (gemini-3.5-flash-lite, temp 0, jsonMode, `{{prompt}}`). Additive config referencing the already-registered model → **no `ai-models.json` change, so the `verify:config` completeness gates are unaffected**.
- **`scripts/fol-eval-classify.ps1`** — pure transforms (`Format-FolClauseBlock` / `ConvertFrom-FolClauseClassification` / `Measure-FolClauseDistribution`) + the guarded AI call (`Invoke-FolClauseClassifier`) and batch-with-per-clause-fallback (`Invoke-FolClauseClassifyBatched`), mirroring `invoke-contradiction-classifier`. A clause is **never dropped**: unresolved → `unclassified` (excluded from the assertoric/FOL subset); only labels inside the closed §3 sets are trusted. A total batch failure skips the per-clause retry (no call storm on a missing key).
- **`run-fol-debate-eval.ps1`** — dot-sources the classifier + the module-private `Get-Prompt`; the non-DryRun path runs the **CLASSIFY stage** (emits `classified-clauses.jsonl` + a §3.3-band distribution **SANITY** check — INSTRUMENT-PROVISIONAL per §5/t/3342, **not a threshold**), then throws at the pending coref stage. New `-SkipClassify` (segment-only, no key) and `-ClassifyBatchSize` params.
- Tests: **`FolDebateClassify.Tests.ps1`** (8 pure-transform cases); `DataWriteSinkGuard.Tests.ps1` exemption reason updated for `classified-clauses.jsonl`.

### Verification
- **21/21 Pester** green (classifier 8 + segmenter 12 + sink-guard 3).
- `verify:config` PS gates pass (the vitest gates fail only for missing `taxonomy-editor/node_modules` in a fresh worktree — environment, not this change; and they gate `ai-models.json`, which is untouched).
- Usage + prompt resolve; live `-SkipClassify` over the real corpus emits `clauses.jsonl`; a degraded **no-key** CLASSIFY run marks all clauses `unclassified` (never dropped), emits `classified-clauses.jsonl`, prints the distribution, and throws at coref — the total-batch-failure guard avoids a per-clause storm.

### Scope / gates
Read-only over `../ai-triad-data` (§1, fail-closed). The classifier is a **new instrument**: labels anchor no conclusion until CL scores the blind `fol-eval-classifier-gold.jsonl` (§5). Not a blocking-gate promotion or schema change → no Second Opinion (t/3361). Next: coref (§6, the hard prerequisite), then FOL + contradiction + paraphrase FN-rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)