### PR TITLE
feat(fol-eval): coref/attribution stage (§6, hard prerequisite) — Increment 3 (t/3354)

### DIFF
--- a/ai-usages.json
+++ b/ai-usages.json
@@ -592,5 +592,19 @@
       "fol",
       "debate-eval"
     ]
+  },
+  "enrichment.fol-clause-coref": {
+    "description": "Resolve cross-turn referential dependencies (demonstratives / topic ellipsis / attributed restatements) in the assertoric debate-clause subset against the debate context, rewriting each clause into a self-contained proposition for FOL extraction (t/3354 design §6, the hard prerequisite). Offline research eval ONLY (read-only over debates; no in-loop path). run-fol-debate-eval.ps1 renders fol-clause-coref.prompt with the prior-turn context + clause batch and passes it as {{prompt}}. jsonMode WITHOUT responseSchema (prompt enforces one strict-JSON {results:[...]} object; the stage parses defensively). temperature pinned 0 for determinism. INSTRUMENT-PROVISIONAL: resolutions are measurement inputs, not ground truth — coverage loss is reported, and no number anchors a conclusion until double-annotated (design §11).",
+    "model": "gemini-3.5-flash-lite",
+    "temperature": 0,
+    "maxTokens": 2000,
+    "timeoutMs": 60000,
+    "jsonMode": true,
+    "messageTemplate": "{{prompt}}",
+    "tags": [
+      "enrichment",
+      "fol",
+      "debate-eval"
+    ]
   }
 }

--- a/scripts/AITriad/Prompts/fol-clause-coref.prompt
+++ b/scripts/AITriad/Prompts/fol-clause-coref.prompt
@@ -1,0 +1,22 @@
+You resolve cross-turn referential dependencies in debate clauses for an offline research eval (FOL-on-debate, t/3354). Each clause is an assertoric (factual or causal) clause segmented from ONE debater's turn. Isolated from its debate it may be unformalizable because it leans on the surrounding dialogue: a demonstrative ("that approach"), a bare elided topic ("the ban", "the threshold"), or an attributed restatement of another agent's claim. Your job: rewrite each clause into a SELF-CONTAINED proposition using the debate context, so it can be formalized on its own — WITHOUT adding any claim the debater did not make.
+
+DEBATE CONTEXT (prior turns, earliest first):
+{{context_block}}
+
+CLAUSES TO RESOLVE (each may depend on the context above):
+{{clauses_block}}
+
+For each clause, return the minimally-edited self-contained rewrite and a status:
+- "self_contained" = already needs no context; return the text unchanged.
+- "resolved" = you replaced every demonstrative / elided topic / attributed referent with its explicit referent from the context; the rewrite is fully self-contained.
+- "partial" = you resolved some references but at least one referent is not recoverable from the context; the rewrite is closer but still under-specified.
+- "unresolved" = the clause depends on a referent the context does not supply; return the original text.
+
+Return ONLY this JSON (one object per clause id, EVERY id exactly once, no prose):
+{"results": [{"id": "<clause id>", "resolved_text": "<self-contained rewrite or original>", "resolution_status": "resolved", "confidence": 0.0}]}
+
+Rules:
+- NEVER introduce a claim, entity, quantity, or polarity the clause did not already assert — resolve references only, do not elaborate or "improve" the argument.
+- For an attributed restatement ("X's claim that P"), the resolved_text is the embedded proposition P with its referents made explicit — attributed to X, not asserted in your own voice.
+- Preserve negation exactly (P vs not-P).
+- "confidence" is your certainty in the resolution, 0.0-1.0. Prefer "partial"/"unresolved" over inventing a referent.

--- a/scripts/fol-eval-coref.ps1
+++ b/scripts/fol-eval-coref.ps1
@@ -1,0 +1,305 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    FOL-on-debate eval — COREFERENCE / attribution resolution (design §6, the hard prerequisite). Increment 3.
+.DESCRIPTION
+    Resolves cross-turn referential dependencies in the ASSERTORIC clause subset so each clause is a
+    self-contained proposition before FOL extraction (§7). Per the co-signed design §6, ~40% of assertoric
+    clauses carry a demonstrative / topic-ellipsis / attributed-restatement dependency that isolated-turn
+    formalization would break — and the most contradiction-relevant sub-class (attributed opponent
+    restatements) is also the most anaphora-dependent, so coref gates the whole value case.
+
+    Only assertoric clauses reach this stage. A `self-contained` clause (per the classifier's §3.2
+    anaphora_dependency attribute) passes through with NO model call — resolution is needed only for the
+    demonstrative / topic-ellipsis / attributed-restatement clauses. Coverage loss (how many assertoric
+    clauses stay `partial`/`unresolved`) is REPORTED, keyed on anaphora_dependency (§6). A clause is never
+    dropped: an unresolved clause keeps its original text with resolution_status 'unresolved'.
+
+    Structure mirrors fol-eval-classify.ps1: pure transforms (Format-CorefContextBlock /
+    Format-CorefClauseBlock / ConvertTo-CorefResolved / Measure-CorefCoverage) are dot-source unit-tested
+    with NO AI; the impure calls (Resolve-FolClauseCorefBatch / Invoke-FolCorefResolveDebate) render
+    fol-clause-coref.prompt via Get-Prompt and call Invoke-AIByUsage. A total batch failure skips the
+    per-clause retry (no call storm on a missing key).
+
+    NOTE: Get-Prompt is module-PRIVATE — the runner dot-sources it + sets $script:ModuleRoot before
+    calling the impure functions (same handling as the classifier, t/3302). Invoke-AIByUsage IS exported.
+.LINK
+    fol-eval-classify.ps1
+.LINK
+    run-fol-debate-eval.ps1
+#>
+
+Set-StrictMode -Version Latest
+
+# Closed resolution-status set (design §6). A model status outside these is treated as 'unresolved'.
+$script:FOL_COREF_STATUS = @('self_contained', 'resolved', 'partial', 'unresolved')
+
+# The anaphora_dependency values that need resolution (everything except self-contained).
+$script:FOL_ANAPHORA_NEEDS_COREF = @('demonstrative', 'topic-ellipsis', 'attributed-restatement')
+
+# Statuses that leave a clause usable (self-contained enough) for FOL extraction.
+$script:FOL_COREF_USABLE = @('self_contained', 'resolved')
+
+function Format-CorefContextBlock {
+    <#
+    .SYNOPSIS
+        Render prior debate statement turns into the prompt's {{context_block}} (earliest first). Pure.
+    .DESCRIPTION
+        Bounds the context to the last -MaxTurns statements (token guard) — a debate referent is almost
+        always introduced within a few turns, and the cap keeps the call cost predictable (design §10 spirit).
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Statements,
+        [int]$MaxTurns = 12
+    )
+    Set-StrictMode -Version Latest
+    $ordered = @($Statements | Sort-Object { [int]$_.turn_index })
+    if ($ordered.Count -gt $MaxTurns) { $ordered = @($ordered | Select-Object -Last $MaxTurns) }
+    $sb = [System.Text.StringBuilder]::new()
+    foreach ($s in $ordered) {
+        [void]$sb.AppendLine("[turn $([int]$s.turn_index)] $([string]$s.content)")
+    }
+    return $sb.ToString().TrimEnd()
+}
+
+function Format-CorefClauseBlock {
+    <#
+    .SYNOPSIS
+        Render clauses (with their anaphora hint) into the prompt's {{clauses_block}}. Pure.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param([Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Clauses)
+    Set-StrictMode -Version Latest
+    $sb = [System.Text.StringBuilder]::new()
+    foreach ($c in $Clauses) {
+        $dep = if ($c.PSObject.Properties['anaphora_dependency']) { [string]$c.anaphora_dependency } else { 'unknown' }
+        [void]$sb.AppendLine("### $([string]$c.id)  (dependency: $dep)")
+        [void]$sb.AppendLine("TEXT: $([string]$c.text)")
+        [void]$sb.AppendLine('')
+    }
+    return $sb.ToString().TrimEnd()
+}
+
+function ConvertTo-CorefResolved {
+    <#
+    .SYNOPSIS
+        Join coref resolutions onto the assertoric clauses. Pure; no AI, no I/O. Never drops a clause.
+    .DESCRIPTION
+        - anaphora_dependency 'self-contained' -> passthrough (resolved_text = text, status 'self_contained').
+        - otherwise, from the results map -> resolved_text + status; a clause missing from the map keeps its
+          original text with status 'unresolved' (method 'missing').
+        Preserves the classification fields so the artifact stays double-annotation-ready (§11).
+    .PARAMETER Clauses
+        The ASSERTORIC classified clauses (is_assertoric = true).
+    .PARAMETER Results
+        Resolution map: id -> @{ resolved_text; resolution_status; confidence }.
+    #>
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Clauses,
+        [Parameter(Mandatory)][hashtable]$Results
+    )
+    Set-StrictMode -Version Latest
+    $out = [System.Collections.Generic.List[object]]::new()
+    foreach ($c in $Clauses) {
+        $id = [string]$c.id
+        $dep = if ($c.PSObject.Properties['anaphora_dependency']) { [string]$c.anaphora_dependency } else { 'unknown' }
+        if ($dep -eq 'self-contained') {
+            $resolvedText = [string]$c.text; $status = 'self_contained'; $conf = 1.0; $method = 'passthrough'
+        }
+        elseif ($Results.ContainsKey($id)) {
+            $r = $Results[$id]
+            $resolvedText = [string]$r['resolved_text']; $status = [string]$r['resolution_status']
+            $conf = [double]$r['confidence']; $method = 'llm'
+        }
+        else {
+            $resolvedText = [string]$c.text; $status = 'unresolved'; $conf = 0.0; $method = 'missing'
+        }
+        $usable = $status -in $script:FOL_COREF_USABLE
+        $out.Add([PSCustomObject]@{
+                id                  = $id
+                debate_id           = $c.debate_id
+                turn_index          = $c.turn_index
+                clause_index        = $c.clause_index
+                text                = $c.text
+                char_start          = $c.char_start
+                char_end            = $c.char_end
+                segmentation_rule   = $c.segmentation_rule
+                primary_type        = $c.primary_type
+                attribution         = $c.attribution
+                anaphora_dependency = $dep
+                polarity            = $c.polarity
+                resolved_text       = $resolvedText
+                resolution_status   = $status
+                coref_usable        = $usable
+                coref_confidence    = $conf
+                coref_method        = $method
+            })
+    }
+    return @($out)
+}
+
+function Measure-CorefCoverage {
+    <#
+    .SYNOPSIS
+        Coverage-loss metrics over the resolved assertoric clauses, keyed on anaphora_dependency (§6). Pure.
+    .DESCRIPTION
+        Reports, over the assertoric subset: per-status counts, the usable fraction (self_contained + resolved
+        -> reach FOL), the coverage-loss fraction (partial + unresolved), and a per-anaphora_dependency
+        breakdown so the attributed-restatement / demonstrative / topic-ellipsis cells are visible (design §6
+        central tension). This is a measurement report, not a gate.
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param([Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Resolved)
+    Set-StrictMode -Version Latest
+
+    $total = @($Resolved).Count
+    $statusCounts = @{}
+    foreach ($s in $script:FOL_COREF_STATUS) { $statusCounts[$s] = 0 }
+    $byDep = @{}
+    $usableCount = 0
+    foreach ($c in $Resolved) {
+        $st = [string]$c.resolution_status
+        if ($statusCounts.ContainsKey($st)) { $statusCounts[$st]++ } else { $statusCounts[$st] = 1 }
+        if ($st -in $script:FOL_COREF_USABLE) { $usableCount++ }
+        $dep = [string]$c.anaphora_dependency
+        if (-not $byDep.ContainsKey($dep)) { $byDep[$dep] = [ordered]@{ total = 0; usable = 0 } }
+        $byDep[$dep]['total']++
+        if ($st -in $script:FOL_COREF_USABLE) { $byDep[$dep]['usable']++ }
+    }
+
+    $perDep = [System.Collections.Generic.List[object]]::new()
+    foreach ($dep in @($byDep.Keys | Sort-Object)) {
+        $t = $byDep[$dep]['total']; $u = $byDep[$dep]['usable']
+        $perDep.Add([PSCustomObject]@{
+                anaphora_dependency = $dep
+                total               = $t
+                usable              = $u
+                usable_fraction     = if ($t -gt 0) { [Math]::Round($u / [double]$t, 4) } else { 0.0 }
+            })
+    }
+
+    $usableFrac = if ($total -gt 0) { [Math]::Round($usableCount / [double]$total, 4) } else { 0.0 }
+    $lossCount = $total - $usableCount
+    return [PSCustomObject]@{
+        total                 = $total
+        status_counts         = $statusCounts
+        usable_count          = $usableCount
+        usable_fraction       = $usableFrac
+        coverage_loss_count   = $lossCount
+        coverage_loss_fraction = if ($total -gt 0) { [Math]::Round($lossCount / [double]$total, 4) } else { 0.0 }
+        by_anaphora_dependency = @($perDep)
+    }
+}
+
+function Resolve-FolClauseCorefBatch {
+    <#
+    .SYNOPSIS
+        Resolve one batch of clauses against a rendered context block via the AI backend (design §6). IMPURE.
+    .DESCRIPTION
+        Returns a validated map id -> @{ resolved_text; resolution_status; confidence }, or $null on failure.
+        Only entries with a resolved_text and a status in the closed §6 set survive — an invalid status is a
+        miss (the caller emits 'unresolved'/'missing'), never silently trusted.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)][string]$ContextBlock,
+        [Parameter(Mandatory)][object[]]$Clauses,
+        [double]$Temperature = 0.0
+    )
+    Set-StrictMode -Version Latest
+    if (-not $Clauses -or @($Clauses).Count -eq 0) { return @{} }
+    try {
+        $clauseBlock = Format-CorefClauseBlock -Clauses $Clauses
+        $rendered = Get-Prompt -Name 'fol-clause-coref' -Replacements @{ context_block = $ContextBlock; clauses_block = $clauseBlock }
+        $resp = Invoke-AIByUsage -UsageId 'enrichment.fol-clause-coref' `
+            -Values @{ prompt = $rendered } -Override @{ temperature = $Temperature } -ErrorAction Stop
+        if (-not $resp -or -not $resp.PSObject.Properties['Text'] -or [string]::IsNullOrWhiteSpace($resp.Text)) {
+            Write-Warning "fol-clause-coref: backend returned no Text for $(@($Clauses).Count) clause(s) — check the model/key for usage 'enrichment.fol-clause-coref'."
+            return $null
+        }
+        $parsed = $resp.Text | ConvertFrom-Json -ErrorAction Stop
+        if (-not $parsed.PSObject.Properties['results']) {
+            Write-Warning 'fol-clause-coref: backend Text was not the expected { results: [...] } JSON.'
+            return $null
+        }
+        $map = @{}
+        foreach ($r in @($parsed.results)) {
+            # Positive guard only (no `continue` inside a function — Pester #2669 escapes to the caller's loop).
+            if ($r.PSObject.Properties['id'] -and $r.PSObject.Properties['resolution_status'] -and $r.PSObject.Properties['resolved_text']) {
+                $st = [string]$r.resolution_status
+                $txt = [string]$r.resolved_text
+                if ($st -in $script:FOL_COREF_STATUS -and -not [string]::IsNullOrWhiteSpace($txt)) {
+                    $conf = if ($r.PSObject.Properties['confidence']) { [double]$r.confidence } else { 0.0 }
+                    $map[[string]$r.id] = @{ resolved_text = $txt; resolution_status = $st; confidence = [Math]::Round($conf, 4) }
+                }
+            }
+        }
+        return $map
+    }
+    catch {
+        # Log the WHY (project rule: log every fallback path + reason). Usually a missing/invalid key or an
+        # unregistered model for usage 'enrichment.fol-clause-coref'.
+        Write-Warning "fol-clause-coref: model call failed: $($_.Exception.Message)"
+        return $null
+    }
+}
+
+function Invoke-FolCorefResolveDebate {
+    <#
+    .SYNOPSIS
+        Resolve one debate's non-self-contained assertoric clauses against that debate's context. IMPURE.
+    .DESCRIPTION
+        Renders the shared context once (bounded by -MaxContextTurns), then batches the clauses (batch-first,
+        per-clause fallback for misses; a total batch failure skips the per-clause retry). Returns the map
+        id -> resolution for this debate's clauses. Self-contained clauses are NOT passed here (the join
+        passes them through with no call).
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$ContextStatements,
+        [Parameter(Mandatory)][object[]]$Clauses,
+        [int]$BatchSize = 10,
+        [int]$MaxContextTurns = 12,
+        [double]$Temperature = 0.0
+    )
+    Set-StrictMode -Version Latest
+    $map = @{}
+    if (-not $Clauses -or @($Clauses).Count -eq 0) { return $map }
+    $contextBlock = Format-CorefContextBlock -Statements @($ContextStatements) -MaxTurns $MaxContextTurns
+
+    $batch = [System.Collections.Generic.List[object]]::new()
+    $flush = {
+        param($items)
+        if (@($items).Count -eq 0) { return }
+        $r = Resolve-FolClauseCorefBatch -ContextBlock $contextBlock -Clauses @($items) -Temperature $Temperature
+        if ($null -eq $r) {
+            Write-Warning "fol-clause-coref: batch of $(@($items).Count) clause(s) failed entirely — skipping per-clause fallback (backend unavailable); these clauses emit 'unresolved'."
+            return
+        }
+        foreach ($k in $r.Keys) { $map[$k] = $r[$k] }
+        foreach ($it in @($items)) {
+            $cid = [string]$it.id
+            if (-not $map.ContainsKey($cid)) {
+                $single = Resolve-FolClauseCorefBatch -ContextBlock $contextBlock -Clauses @($it) -Temperature $Temperature
+                if ($null -ne $single -and $single.ContainsKey($cid)) { $map[$cid] = $single[$cid] }
+                else { Write-Warning "fol-clause-coref: clause '$cid' unresolved after batch + per-clause fallback — emitting 'unresolved'." }
+            }
+        }
+    }
+    foreach ($c in $Clauses) {
+        $batch.Add($c)
+        if ($batch.Count -ge $BatchSize) { & $flush $batch; $batch = [System.Collections.Generic.List[object]]::new() }
+    }
+    & $flush $batch
+    return $map
+}

--- a/scripts/run-fol-debate-eval.ps1
+++ b/scripts/run-fol-debate-eval.ps1
@@ -15,10 +15,11 @@
     (§7, reuses Private/LogicalFormPass.ps1) -> CONTRADICTION + paraphrase FN-rate (§8).
 
     IMPLEMENTED stages: load, run-bound, manifest, SEGMENT (§4, rule-based, fol-eval-segment.ps1),
-    CLASSIFY (§3, AI clause classifier, fol-eval-classify.ps1). The classifier is INSTRUMENT-PROVISIONAL
-    (§5/t/3342): its per-class distribution is checked against the §3.3 bands as a SANITY gate only —
-    labels anchor no conclusion until CL scores the blind gold set (fol-eval-classifier-gold.jsonl).
-    The coref/FOL/contradiction/FN-rate stages are NOT implemented yet and throw (honest failure).
+    CLASSIFY (§3, AI clause classifier, fol-eval-classify.ps1), COREF (§6, the hard prerequisite,
+    fol-eval-coref.ps1 — resolves cross-turn deps on the assertoric subset + reports coverage loss).
+    Classifier + coref are INSTRUMENT-PROVISIONAL (§5/t/3342): the §3.3 distribution and §6 coverage are
+    measurement reports, not gates — nothing anchors a conclusion until CL scores the blind gold set.
+    The FOL/contradiction/FN-rate stages are NOT implemented yet and throw (honest failure).
     Runnable paths without a model call: -DryRun (plan+manifest) and -SkipClassify (segment only).
 
     READ-ONLY (design §1, TL tightening e/141#8): the harness writes NOTHING under the data
@@ -85,6 +86,14 @@ param(
     [switch]$SkipClassify,
 
     [Parameter()]
+    [ValidateRange(1, 50)]
+    [int]$CorefBatchSize = 10,
+
+    [Parameter()]
+    [ValidateRange(1, 100)]
+    [int]$MaxContextTurns = 12,
+
+    [Parameter()]
     [switch]$DryRun
 )
 
@@ -95,13 +104,14 @@ Import-Module (Join-Path $PSScriptRoot 'AITriad' 'AITriad.psd1') -Force -ErrorAc
 $Mod = Get-Module AITriad
 if (-not $Mod) { throw 'AITriad module failed to load; cannot resolve data-root helpers.' }
 
-# Clause segmenter (§4) + classifier (§3) — pure, dot-sourceable libraries (no top-level side effects).
+# Clause segmenter (§4) + classifier (§3) + coref (§6) — pure, dot-sourceable libraries (no side effects).
 . (Join-Path $PSScriptRoot 'fol-eval-segment.ps1')
 . (Join-Path $PSScriptRoot 'fol-eval-classify.ps1')
+. (Join-Path $PSScriptRoot 'fol-eval-coref.ps1')
 
-# Get-Prompt is a module-PRIVATE helper (Import-Module does not expose it), so the classifier's
-# Get-Prompt call would fail with 'not recognized'. Dot-source it + set $script:ModuleRoot so its
-# default Prompts/ dir resolves fol-clause-classify.prompt (same handling as the CC classifier, t/3302).
+# Get-Prompt is a module-PRIVATE helper (Import-Module does not expose it), so the classifier/coref
+# Get-Prompt calls would fail with 'not recognized'. Dot-source it + set $script:ModuleRoot so its
+# default Prompts/ dir resolves the fol-clause-*.prompt files (same handling as the CC classifier, t/3302).
 $script:ModuleRoot = Join-Path $PSScriptRoot 'AITriad'
 . (Join-Path $PSScriptRoot 'AITriad' 'Private' 'Get-Prompt.ps1')
 
@@ -191,8 +201,10 @@ $manifest = [ordered]@{
     est_model_calls_upper  = $clauseCeiling * 2   # classifier + FOL, upper bound
     dry_run                = [bool]$DryRun
     classify_batch_size    = $ClassifyBatchSize
-    stages_implemented     = @('load', 'run-bound', 'manifest', 'segment', 'classify')
-    stages_pending_pairing = @('coref', 'fol', 'contradiction', 'fn-rate', 'correlate')
+    coref_batch_size       = $CorefBatchSize
+    max_context_turns      = $MaxContextTurns
+    stages_implemented     = @('load', 'run-bound', 'manifest', 'segment', 'classify', 'coref')
+    stages_pending_pairing = @('fol', 'contradiction', 'fn-rate', 'correlate')
 }
 
 Write-Host ''
@@ -277,8 +289,45 @@ if ($dist.unclassified_count -eq $dist.total -and $dist.total -gt 0) {
     Write-Warning 'CLASSIFY: every clause is unclassified — the backend returned nothing (missing key / model?). classified-clauses.jsonl was still emitted so the run is inspectable; no labels are trustworthy.'
 }
 
-# ── COREF / FOL / CONTRADICTION / FN-rate (design §6/§7/§8) — later increments, NOT implemented ──
+# ── COREF stage (design §6, the HARD PREREQUISITE) — Increment 3 ────────────────────────────
+# Resolve cross-turn deps in the assertoric subset so each clause is self-contained before FOL.
+# Self-contained clauses pass through with NO model call; demonstrative/topic-ellipsis/attributed-
+# restatement clauses go to the AI resolver, grouped per debate (each debate's prior turns are the
+# shared context). Coverage loss is reported keyed on anaphora_dependency (§6) — a measurement, not a gate.
+Write-Host ''
+Write-Host "=== COREF stage (design §6) — cross-turn resolution on the assertoric subset (PAID; batch=$CorefBatchSize) ===" -ForegroundColor Cyan
+$assertoric = @($classified | Where-Object { $_.is_assertoric })
+
+# Per-debate statement lookup (context source) from the already-loaded selection.
+$stmtByDebate = @{}
+foreach ($deb in $selected) { $stmtByDebate[$deb.DebateId] = @($deb.Statements) }
+
+$corefMap = @{}
+$needResolve = @($assertoric | Where-Object { $_.anaphora_dependency -ne 'self-contained' })
+foreach ($g in @($needResolve | Group-Object debate_id)) {
+    $ctx = if ($stmtByDebate.ContainsKey($g.Name)) { $stmtByDebate[$g.Name] } else { @() }
+    $m = Invoke-FolCorefResolveDebate -ContextStatements @($ctx) -Clauses @($g.Group) `
+        -BatchSize $CorefBatchSize -MaxContextTurns $MaxContextTurns -Temperature 0
+    foreach ($k in $m.Keys) { $corefMap[$k] = $m[$k] }
+}
+
+$resolved = @(ConvertTo-CorefResolved -Clauses $assertoric -Results $corefMap)
+$resolvedPath = Join-Path $resolvedOut 'resolved-clauses.jsonl'
+Set-Content -LiteralPath $resolvedPath -Value @($resolved | ForEach-Object { $_ | ConvertTo-Json -Depth 4 -Compress }) -Encoding utf8
+
+$cov = Measure-CorefCoverage -Resolved $resolved
+Write-Host "  Assertoric subset: $($cov.total) clauses -> $resolvedPath  (self-contained passthrough + AI-resolved)" -ForegroundColor White
+Write-Host "  Coverage: usable (self_contained+resolved) $($cov.usable_count)/$($cov.total) = $($cov.usable_fraction); coverage-loss (partial+unresolved) $($cov.coverage_loss_count) = $($cov.coverage_loss_fraction)" -ForegroundColor White
+Write-Host '  By anaphora_dependency (§6 — attributed-restatement is the highest-value/highest-risk cell):' -ForegroundColor White
+foreach ($d in $cov.by_anaphora_dependency) {
+    Write-Host ("    {0,-24} usable {1,4}/{2,-4} = {3}" -f $d.anaphora_dependency, $d.usable, $d.total, $d.usable_fraction) -ForegroundColor DarkGray
+}
+if ($cov.total -gt 0 -and $cov.usable_count -eq 0) {
+    Write-Warning 'COREF: no assertoric clause is usable — either the classifier returned nothing (missing key) or every resolution failed. resolved-clauses.jsonl was still emitted so the run is inspectable; no resolution is trustworthy.'
+}
+
+# ── FOL / CONTRADICTION / FN-rate (design §7/§8) — later increments, NOT implemented ─────────
 throw (New-EvalError `
     'Run the full FOL-on-debate eval pipeline' `
-    "SEGMENT + CLASSIFY ran (clauses.jsonl + classified-clauses.jsonl emitted; $($dist.assertoric_count) assertoric of $($dist.total)) but the coref/FOL/contradiction/FN-rate stages are not yet implemented." `
-    'Inspect classified-clauses.jsonl now (or use -DryRun / -SkipClassify). The coref stage (design §6, the hard prerequisite on the attributed-opponent x assertoric cell) is the next increment; FOL + contradiction + paraphrase FN-rate follow.')
+    "SEGMENT + CLASSIFY + COREF ran (clauses/classified/resolved JSONL emitted; $($cov.usable_count) usable assertoric of $($cov.total)) but the FOL/contradiction/FN-rate stages are not yet implemented." `
+    'Inspect resolved-clauses.jsonl now (or use -DryRun / -SkipClassify). FOL extraction (design §7, reusing Private/LogicalFormPass.ps1 on the resolved assertoric subset) is the next increment; contradiction + paraphrase FN-rate (§8) follow.')

--- a/taxonomy-editor/src/renderer/data/promptCatalog.ts
+++ b/taxonomy-editor/src/renderer/data/promptCatalog.ts
@@ -1032,6 +1032,17 @@ export const PROMPT_CATALOG: PromptCatalogEntry[] = [
     applicableDataSources: ['taxonomyNodes'],
     promptFiles: ['fol-clause-classify'],
   },
+  {
+    id: 'ps-fol-clause-coref',
+    title: 'FOL-on-Debate Clause Coreference Resolver',
+    description: 'Resolves cross-turn referential dependencies (demonstratives, topic ellipsis, attributed restatements) in an assertoric debate clause against the debate context, rewriting it into a self-contained proposition.',
+    source: 'AITriad/Prompts/fol-clause-coref.prompt',
+    template: '(Loading from disk...)',
+    group: 'powershell',
+    purpose: 'Used by run-fol-debate-eval.ps1 (offline FOL-on-debate eval, t/3354, design §6 — the hard prerequisite) — makes the assertoric subset self-contained before FOL extraction and reports coverage loss. Read-only research eval; INSTRUMENT-PROVISIONAL (resolutions are measurement inputs, not ground truth).',
+    applicableDataSources: ['taxonomyNodes'],
+    promptFiles: ['fol-clause-coref'],
+  },
 
   // === Debate pipeline: Quality & repair prompts ===
   {

--- a/tests/DataWriteSinkGuard.Tests.ps1
+++ b/tests/DataWriteSinkGuard.Tests.ps1
@@ -59,7 +59,7 @@ BeforeAll {
         'scripts/AITriad/Public/New-SyntheticCorpus.ps1'   = 'append-checkpoint + fresh corpus generation + NEW metadata (not a whole-file data rewrite)'
         'scripts/AITriad/Public/Test-DebatePersistence.ps1' = 'writes a random persist-probe .tmp (test probe, non-data)'
         'scripts/AITriad/Private/AICallLog.ps1'            = 'append-only AI call-log JSONL (Add-Content); references Get-DataRoot only to locate the log file — never read-mutate-rewrites a data-of-record file (t/3241)'
-        'scripts/run-fol-debate-eval.ps1'                  = 'read-only FOL-on-debate eval harness (t/3354); Set-Content writes only run-manifest.json + clauses.jsonl + classified-clauses.jsonl to -OutputDir, which is fail-closed asserted OUTSIDE the data root via Test-IsUnderDataRoot (design §1) — references data tokens (debates/summaries/conflicts) as read-only inputs, never writes ../ai-triad-data'
+        'scripts/run-fol-debate-eval.ps1'                  = 'read-only FOL-on-debate eval harness (t/3354); Set-Content writes only run-manifest.json + clauses.jsonl + classified-clauses.jsonl + resolved-clauses.jsonl to -OutputDir, which is fail-closed asserted OUTSIDE the data root via Test-IsUnderDataRoot (design §1) — references data tokens (debates/summaries/conflicts) as read-only inputs, never writes ../ai-triad-data'
     }
 
     # A data-of-record path token (basename or data-dir accessor). Kept specific so

--- a/tests/FolDebateCoref.Tests.ps1
+++ b/tests/FolDebateCoref.Tests.ps1
@@ -1,0 +1,103 @@
+# Tag: qbaf (t/3354 — FOL-on-debate eval coref/attribution resolution, design §6)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Tests for the FOL-on-debate coref PURE transforms (scripts/fol-eval-coref.ps1, design §6).
+.DESCRIPTION
+    Format-CorefContextBlock, Format-CorefClauseBlock, ConvertTo-CorefResolved, and
+    Measure-CorefCoverage are pure (no AI, no I/O). The impure resolvers
+    (Resolve-FolClauseCorefBatch / Invoke-FolCorefResolveDebate, which call the AI backend) are not
+    invoked here — the coref stage's live behavior is covered by the runner's -DryRun/-SkipClassify
+    paths and manual smoke runs.
+#>
+
+BeforeAll {
+    . "$PSScriptRoot/../scripts/fol-eval-coref.ps1"
+}
+
+Describe 'Format-CorefContextBlock' -Tag 'qbaf' {
+    It 'orders prior turns earliest-first and caps to MaxTurns' {
+        $stmts = @(
+            [pscustomobject]@{ turn_index = 5; content = 'fifth' }
+            [pscustomobject]@{ turn_index = 1; content = 'first' }
+            [pscustomobject]@{ turn_index = 3; content = 'third' }
+        )
+        $block = Format-CorefContextBlock -Statements $stmts -MaxTurns 2
+        # capped to last 2 by turn order (third, fifth); earliest-first within the cap
+        $block | Should -Match '\[turn 3\] third'
+        $block | Should -Match '\[turn 5\] fifth'
+        $block | Should -Not -Match 'first'
+        $block.IndexOf('turn 3') | Should -BeLessThan $block.IndexOf('turn 5')
+    }
+    It 'tolerates an empty statement set' {
+        Format-CorefContextBlock -Statements @() | Should -Be ''
+    }
+}
+
+Describe 'ConvertTo-CorefResolved — passthrough, join, never-drop' -Tag 'qbaf' {
+    BeforeAll {
+        $script:assertoric = @(
+            [pscustomobject]@{ id = 'd:t0:c0'; debate_id = 'd'; turn_index = 0; clause_index = 0; text = 'Seven firms control 35%.'; char_start = 0; char_end = 24; segmentation_rule = 'sentence-initial'; primary_type = 'assertoric-factual'; attribution = 'own'; anaphora_dependency = 'self-contained'; polarity = 'asserted' }
+            [pscustomobject]@{ id = 'd:t2:c1'; debate_id = 'd'; turn_index = 2; clause_index = 1; text = 'that approach entrenches them.'; char_start = 0; char_end = 29; segmentation_rule = 'sentence-initial'; primary_type = 'assertoric-causal'; attribution = 'attributed-opponent'; anaphora_dependency = 'demonstrative'; polarity = 'asserted' }
+        )
+    }
+
+    It 'passes self-contained clauses through with NO resolution call (status self_contained)' {
+        $out = @(ConvertTo-CorefResolved -Clauses $assertoric -Results @{})
+        $sc = $out | Where-Object { $_.id -eq 'd:t0:c0' }
+        $sc.resolution_status | Should -Be 'self_contained'
+        $sc.resolved_text | Should -Be 'Seven firms control 35%.'
+        $sc.coref_method | Should -Be 'passthrough'
+        $sc.coref_usable | Should -BeTrue
+    }
+
+    It 'joins a resolution for a non-self-contained clause and marks it usable when resolved' {
+        $results = @{ 'd:t2:c1' = @{ resolved_text = 'the frontier-cap approach entrenches incumbents.'; resolution_status = 'resolved'; confidence = 0.8 } }
+        $out = @(ConvertTo-CorefResolved -Clauses $assertoric -Results $results)
+        $r = $out | Where-Object { $_.id -eq 'd:t2:c1' }
+        $r.resolved_text | Should -Be 'the frontier-cap approach entrenches incumbents.'
+        $r.resolution_status | Should -Be 'resolved'
+        $r.coref_usable | Should -BeTrue
+        $r.coref_method | Should -Be 'llm'
+    }
+
+    It 'never drops a non-self-contained clause with no result — emits unresolved/missing (not usable)' {
+        $out = @(ConvertTo-CorefResolved -Clauses $assertoric -Results @{})
+        $r = $out | Where-Object { $_.id -eq 'd:t2:c1' }
+        $r.resolution_status | Should -Be 'unresolved'
+        $r.coref_method | Should -Be 'missing'
+        $r.coref_usable | Should -BeFalse
+        $r.resolved_text | Should -Be 'that approach entrenches them.'   # original text preserved
+    }
+}
+
+Describe 'Measure-CorefCoverage — §6 coverage loss keyed on anaphora_dependency' -Tag 'qbaf' {
+    It 'computes usable/loss fractions overall and per dependency' {
+        $resolved = @(
+            [pscustomobject]@{ resolution_status = 'self_contained'; anaphora_dependency = 'self-contained' }
+            [pscustomobject]@{ resolution_status = 'resolved'; anaphora_dependency = 'demonstrative' }
+            [pscustomobject]@{ resolution_status = 'unresolved'; anaphora_dependency = 'attributed-restatement' }
+            [pscustomobject]@{ resolution_status = 'partial'; anaphora_dependency = 'attributed-restatement' }
+        )
+        $cov = Measure-CorefCoverage -Resolved $resolved
+        $cov.total | Should -Be 4
+        $cov.usable_count | Should -Be 2                 # self_contained + resolved
+        $cov.usable_fraction | Should -Be 0.5
+        $cov.coverage_loss_count | Should -Be 2          # unresolved + partial
+        $ar = $cov.by_anaphora_dependency | Where-Object { $_.anaphora_dependency -eq 'attributed-restatement' }
+        $ar.total | Should -Be 2
+        $ar.usable | Should -Be 0                        # both attributed-restatement clauses failed
+        $ar.usable_fraction | Should -Be 0.0
+    }
+
+    It 'handles an empty set' {
+        $cov = Measure-CorefCoverage -Resolved @()
+        $cov.total | Should -Be 0
+        $cov.usable_fraction | Should -Be 0.0
+        $cov.coverage_loss_fraction | Should -Be 0.0
+    }
+}


### PR DESCRIPTION
## Increment 3 — coref/attribution (design §6, the hard prerequisite)

Fourth build increment of the offline FOL-on-debate eval harness (t/3354), after the foundation (#2045), segmenter (#2081), and classifier (#2086). Implements the **coreference/attribution stage** from the co-signed design §6 — the *hard prerequisite*: ~40% of assertoric clauses carry a cross-turn dependency that isolated-turn formalization breaks, and the most contradiction-relevant sub-class (attributed opponent restatements) is the most anaphora-dependent, so coref gates the whole value case.

### What lands
- **`scripts/fol-eval-coref.ps1`** — pure transforms (`Format-CorefContextBlock` / `Format-CorefClauseBlock` / `ConvertTo-CorefResolved` / `Measure-CorefCoverage`) + guarded AI calls (`Resolve-FolClauseCorefBatch` / `Invoke-FolCorefResolveDebate`), mirroring the classifier. Operates on the **assertoric subset only**; `self-contained` clauses pass through with **no model call**; demonstrative / topic-ellipsis / attributed-restatement clauses are resolved **per debate** against that debate's prior turns (shared, bounded context). Never drops a clause (`unresolved` → original text); total batch failure skips the per-clause retry. **Coverage loss reported keyed on `anaphora_dependency`** (§6).
- **`Prompts/fol-clause-coref.prompt`** + **`ai-usages.json`** (`enrichment.fol-clause-coref`) + a **`ps-fol-clause-coref` promptCatalog entry** — the taxonomy-editor coupling site, added **pre-emptively** this time (the #2086 lesson).
- **`run-fol-debate-eval.ps1`** — COREF stage after CLASSIFY emits `resolved-clauses.jsonl` + a coverage report (usable vs coverage-loss, per `anaphora_dependency`), then throws at the pending FOL stage. New `-CorefBatchSize` / `-MaxContextTurns`.
- Tests: **`FolDebateCoref.Tests.ps1`** (7 pure-transform cases); `DataWriteSinkGuard.Tests.ps1` exemption reason updated for `resolved-clauses.jsonl`.

### Verification
- **28/28 Pester** green (coref 7 + classifier 8 + segmenter 12 + sink-guard 3).
- Usage + prompt resolve; degraded **no-key** full run emits all four JSONL artifacts, prints the coverage report, and throws at FOL; the impure per-debate resolve path handles the total-failure guard + self-contained passthrough + never-drop correctly on a synthetic assertoric set.

### Scope / gates
Read-only over `../ai-triad-data` (§1, fail-closed). Coref is INSTRUMENT-PROVISIONAL — coverage is a measurement report, not a gate; nothing anchors a conclusion until CL scores the blind gold set (§5). No `ai-models.json`/schema change → no Second Opinion (t/3361). **Next: FOL extraction (§7)** — neo-Davidsonian on the resolved assertoric subset, reusing `Private/LogicalFormPass.ps1` — then contradiction + paraphrase FN-rate (§8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)