### PR TITLE
feat(fol-eval): FOL extraction stage (§7) reusing LogicalFormPass core — Increment 4 (t/3354)

### DIFF
--- a/scripts/fol-eval-fol.ps1
+++ b/scripts/fol-eval-fol.ps1
@@ -1,0 +1,233 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    FOL-on-debate eval — FOL EXTRACTION (design §7). Increment 4. Reuses LogicalFormPass core, NO fork.
+.DESCRIPTION
+    Formalizes the RESOLVED, usable assertoric clause subset (from fol-eval-coref.ps1) into neo-Davidsonian
+    first-order logical forms — the SAME instrument the summary FOL corpus uses, so the §8 cross-corpus
+    contradiction check is apples-to-apples (design §7, TL condition: no fork).
+
+    Reuse (no fork): each clause's resolved_text is formalized through the identical path
+    Invoke-LogicalFormPass uses for a summary claim —
+      Get-Prompt 'logical-form-formalization'  ->  Invoke-AIByUsage 'enrichment.logical-form-formalization'
+      ->  ConvertTo-GroundedLogicalForm  ->  Test-LogicalFormStructure.
+    The grounding/validation helpers (ConvertTo-GroundedLogicalForm / Test-LogicalFormStructure /
+    Get-LogicalFormRefTable / ConvertTo-EntityRefsPromptJson) are module-PRIVATE, so they are reached
+    through the AITriad module session state (`& $Module { ... }`) — the same reliable mechanism the
+    runner uses for the data-root helpers, NOT a reimplementation.
+
+    Debate clauses carry NO entity_refs[], so the ref table is empty and every participant becomes a
+    lit:"…" (the -IncludeUngrounded case). Clauses are formalized as CLAIM_CATEGORY 'factual' with an
+    empty CAMP (modality:null) — the clause's own attribution/camp is kept as clause metadata, NOT baked
+    into modality, so a debate logical_form is shape-identical to a summary factual_claim logical_form
+    (the apples-to-apples requirement). Genericity/value-load of an assertoric-causal generic is carried
+    by the predicate + polarity the model emits, exactly as for summary causal claims.
+
+    Only coref-USABLE clauses (self_contained | resolved) are formalized; partial/unresolved clauses are
+    excluded (fol_status 'skipped-unresolved') — formalizing an under-specified clause would inject noise
+    into §8. A clause is never dropped from the record: every assertoric clause appears in the output with
+    a fol_status. An invalid/failed formalization is recorded (status), never a fabricated logical_form.
+.LINK
+    fol-eval-coref.ps1
+.LINK
+    run-fol-debate-eval.ps1
+#>
+
+Set-StrictMode -Version Latest
+
+# Extraction outcome for a clause that was ATTEMPTED (usable). Join adds 'skipped-unresolved' / 'missing'.
+$script:FOL_EXTRACT_STATUS = @('formalized', 'invalid', 'failed')
+
+function Invoke-FolClauseFormalize {
+    <#
+    .SYNOPSIS
+        Formalize ONE resolved clause proposition into a grounded logical form, reusing the LogicalFormPass
+        core via the AITriad module session state (design §7, no fork). IMPURE.
+    .DESCRIPTION
+        Renders the shared logical-form-formalization prompt (CLAIM_CATEGORY 'factual', empty CAMP, empty
+        ENTITY_REFS), calls enrichment.logical-form-formalization, then grounds + validates through the
+        module-private helpers. Returns @{ status; logical_form?; reason? }:
+          status 'formalized' -> logical_form present (validated);
+          status 'invalid'    -> the model form failed Test-LogicalFormStructure (reason set), no form;
+          status 'failed'     -> no/empty/unparseable model output (reason set), no form.
+    .PARAMETER Module
+        The imported AITriad module (Get-Module AITriad) — session state for the private grounders.
+    .PARAMETER Text
+        The resolved, self-contained clause proposition to formalize.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)][System.Management.Automation.PSModuleInfo]$Module,
+        [Parameter(Mandatory)][string]$Text,
+        [double]$Temperature = 0.1
+    )
+    Set-StrictMode -Version Latest
+
+    # Empty ref table (debate clauses have no entity_refs) -> ENTITY_REFS "[]"; every arg becomes a lit:.
+    $refsJson = & $Module { ConvertTo-EntityRefsPromptJson -RefTable @() }
+
+    $rendered = Get-Prompt -Name 'logical-form-formalization' -Replacements @{
+        CLAIM_CATEGORY = 'factual'
+        CAMP           = ''
+        PROPOSITION    = $Text
+        ENTITY_REFS    = $refsJson
+    }
+
+    try {
+        $ai = Invoke-AIByUsage -UsageId 'enrichment.logical-form-formalization' `
+            -Values @{ prompt = $rendered } -Override @{ temperature = $Temperature } -ErrorAction Stop
+    }
+    catch {
+        # Fallback-path logging (docs/error-handling.md): usually a missing/invalid key or unregistered model.
+        Write-Warning "fol-extract: model call failed: $($_.Exception.Message)"
+        return @{ status = 'failed'; reason = $_.Exception.Message }
+    }
+    if ($null -eq $ai -or -not $ai.PSObject.Properties['Text'] -or [string]::IsNullOrWhiteSpace($ai.Text)) {
+        Write-Warning 'fol-extract: empty model response.'
+        return @{ status = 'failed'; reason = 'empty model response' }
+    }
+
+    # Defensive fence-strip + parse (prompt says raw JSON, but models sometimes fence) — same as LogicalFormPass.
+    $body = [string]$ai.Text
+    $body = $body -replace '^\s*```(json)?\s*', ''
+    $body = $body -replace '\s*```\s*$', ''
+    try { $raw = $body.Trim() | ConvertFrom-Json -ErrorAction Stop }
+    catch {
+        Write-Warning "fol-extract: unparseable model JSON: $($_.Exception.Message)"
+        return @{ status = 'failed'; reason = "unparseable JSON: $($_.Exception.Message)" }
+    }
+
+    # Ground + validate through the module-private core (no fork).
+    $lf = & $Module { param($r) ConvertTo-GroundedLogicalForm -Raw $r -RefTable @() -Category 'factual' -Camp '' } $raw
+    $check = & $Module { param($l) Test-LogicalFormStructure -LogicalForm $l -Category 'factual' } $lf
+    if (-not $check.Ok) {
+        return @{ status = 'invalid'; reason = [string]$check.Reason }
+    }
+    return @{ status = 'formalized'; logical_form = $lf }
+}
+
+function Invoke-FolClauseExtraction {
+    <#
+    .SYNOPSIS
+        Formalize every coref-usable clause in turn, returning the map id -> @{ status; logical_form?; reason? }.
+        IMPURE (one model call per usable clause; FOL formalization is per-proposition, not batched).
+    .DESCRIPTION
+        Bounded by the caller's clause selection (the run cap). A failed/invalid clause is recorded, never
+        retried in a storm. Self-contained + resolved clauses are the input; partial/unresolved are excluded
+        upstream by the caller (they carry fol_status 'skipped-unresolved' in the join).
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)][System.Management.Automation.PSModuleInfo]$Module,
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Clauses,
+        [double]$Temperature = 0.1
+    )
+    Set-StrictMode -Version Latest
+    $map = @{}
+    foreach ($c in $Clauses) {
+        $txt = if ($c.PSObject.Properties['resolved_text'] -and $c.resolved_text) { [string]$c.resolved_text } else { [string]$c.text }
+        $map[[string]$c.id] = Invoke-FolClauseFormalize -Module $Module -Text $txt -Temperature $Temperature
+    }
+    return $map
+}
+
+function ConvertTo-FolClauseFormalized {
+    <#
+    .SYNOPSIS
+        Join FOL extraction results onto the resolved assertoric clauses. Pure; no AI, no I/O. Never drops.
+    .DESCRIPTION
+        Every resolved clause appears once with a fol_status:
+          - coref-unusable (partial/unresolved)     -> 'skipped-unresolved' (not formalized, no logical_form)
+          - usable + result 'formalized'            -> 'formalized' + logical_form attached
+          - usable + result 'invalid'/'failed'      -> that status + fol_reason (no logical_form)
+          - usable but absent from the map          -> 'missing'
+        Preserves the resolved-clause fields (double-annotation-ready, §11).
+    .PARAMETER Clauses
+        The resolved assertoric clauses (from ConvertTo-CorefResolved).
+    .PARAMETER Results
+        Extraction map id -> @{ status; logical_form?; reason? } for the clauses that were attempted.
+    #>
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Clauses,
+        [Parameter(Mandatory)][hashtable]$Results
+    )
+    Set-StrictMode -Version Latest
+    $out = [System.Collections.Generic.List[object]]::new()
+    foreach ($c in $Clauses) {
+        $id = [string]$c.id
+        $usable = ($c.PSObject.Properties['coref_usable'] -and $c.coref_usable)
+        $logicalForm = $null
+        $reason = ''
+        if (-not $usable) {
+            $status = 'skipped-unresolved'
+        }
+        elseif ($Results.ContainsKey($id)) {
+            $r = $Results[$id]
+            $status = [string]$r['status']
+            if ($status -eq 'formalized' -and $r.ContainsKey('logical_form')) { $logicalForm = $r['logical_form'] }
+            if ($r.ContainsKey('reason')) { $reason = [string]$r['reason'] }
+        }
+        else {
+            $status = 'missing'
+        }
+        $out.Add([PSCustomObject]@{
+                id                  = $id
+                debate_id           = $c.debate_id
+                turn_index          = $c.turn_index
+                clause_index        = $c.clause_index
+                text                = $c.text
+                resolved_text       = $c.resolved_text
+                char_start          = $c.char_start
+                char_end            = $c.char_end
+                primary_type        = $c.primary_type
+                attribution         = $c.attribution
+                anaphora_dependency = $c.anaphora_dependency
+                polarity            = $c.polarity
+                resolution_status   = $c.resolution_status
+                fol_status          = $status
+                fol_reason          = $reason
+                logical_form        = $logicalForm
+            })
+    }
+    return @($out)
+}
+
+function Measure-FolExtraction {
+    <#
+    .SYNOPSIS
+        Extraction outcome counts over the formalized assertoric clauses. Pure; no AI, no I/O.
+    .DESCRIPTION
+        Reports total, per-fol_status counts, and the formalized fraction over the ATTEMPTED (usable) set
+        — a measurement report, not a gate. skipped-unresolved clauses are excluded from the attempted
+        denominator (they were never sent to FOL).
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param([Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Formalized)
+    Set-StrictMode -Version Latest
+
+    $counts = @{}
+    foreach ($c in $Formalized) {
+        $st = [string]$c.fol_status
+        if ($counts.ContainsKey($st)) { $counts[$st]++ } else { $counts[$st] = 1 }
+    }
+    # NB: local names must NOT collide (case-insensitively) with the typed [object[]]$Formalized param —
+    # assigning an int to such a name would coerce it back into a 1-element array (op_Division trap).
+    $total = @($Formalized).Count
+    $formalizedN = if ($counts.ContainsKey('formalized')) { [int]$counts['formalized'] } else { 0 }
+    $skippedN = if ($counts.ContainsKey('skipped-unresolved')) { [int]$counts['skipped-unresolved'] } else { 0 }
+    $attempted = $total - $skippedN
+    return [PSCustomObject]@{
+        total                = $total
+        attempted            = $attempted
+        formalized_count     = $formalizedN
+        status_counts        = $counts
+        formalized_fraction  = if ($attempted -gt 0) { [Math]::Round($formalizedN / [double]$attempted, 4) } else { 0.0 }
+    }
+}

--- a/scripts/run-fol-debate-eval.ps1
+++ b/scripts/run-fol-debate-eval.ps1
@@ -16,10 +16,12 @@
 
     IMPLEMENTED stages: load, run-bound, manifest, SEGMENT (§4, rule-based, fol-eval-segment.ps1),
     CLASSIFY (§3, AI clause classifier, fol-eval-classify.ps1), COREF (§6, the hard prerequisite,
-    fol-eval-coref.ps1 — resolves cross-turn deps on the assertoric subset + reports coverage loss).
+    fol-eval-coref.ps1 — resolves cross-turn deps on the assertoric subset + reports coverage loss),
+    FOL (§7, fol-eval-fol.ps1 — neo-Davidsonian formalization of the resolved usable subset, REUSING the
+    LogicalFormPass core via module session state, no fork, so it is shape-identical to the summary FOL corpus).
     Classifier + coref are INSTRUMENT-PROVISIONAL (§5/t/3342): the §3.3 distribution and §6 coverage are
     measurement reports, not gates — nothing anchors a conclusion until CL scores the blind gold set.
-    The FOL/contradiction/FN-rate stages are NOT implemented yet and throw (honest failure).
+    The contradiction/FN-rate/correlation stages are NOT implemented yet and throw (honest failure).
     Runnable paths without a model call: -DryRun (plan+manifest) and -SkipClassify (segment only).
 
     READ-ONLY (design §1, TL tightening e/141#8): the harness writes NOTHING under the data
@@ -104,10 +106,11 @@ Import-Module (Join-Path $PSScriptRoot 'AITriad' 'AITriad.psd1') -Force -ErrorAc
 $Mod = Get-Module AITriad
 if (-not $Mod) { throw 'AITriad module failed to load; cannot resolve data-root helpers.' }
 
-# Clause segmenter (§4) + classifier (§3) + coref (§6) — pure, dot-sourceable libraries (no side effects).
+# Clause segmenter (§4) + classifier (§3) + coref (§6) + FOL (§7) — pure, dot-sourceable libraries.
 . (Join-Path $PSScriptRoot 'fol-eval-segment.ps1')
 . (Join-Path $PSScriptRoot 'fol-eval-classify.ps1')
 . (Join-Path $PSScriptRoot 'fol-eval-coref.ps1')
+. (Join-Path $PSScriptRoot 'fol-eval-fol.ps1')
 
 # Get-Prompt is a module-PRIVATE helper (Import-Module does not expose it), so the classifier/coref
 # Get-Prompt calls would fail with 'not recognized'. Dot-source it + set $script:ModuleRoot so its
@@ -203,8 +206,8 @@ $manifest = [ordered]@{
     classify_batch_size    = $ClassifyBatchSize
     coref_batch_size       = $CorefBatchSize
     max_context_turns      = $MaxContextTurns
-    stages_implemented     = @('load', 'run-bound', 'manifest', 'segment', 'classify', 'coref')
-    stages_pending_pairing = @('fol', 'contradiction', 'fn-rate', 'correlate')
+    stages_implemented     = @('load', 'run-bound', 'manifest', 'segment', 'classify', 'coref', 'fol')
+    stages_pending_pairing = @('contradiction', 'fn-rate', 'correlate')
 }
 
 Write-Host ''
@@ -326,8 +329,32 @@ if ($cov.total -gt 0 -and $cov.usable_count -eq 0) {
     Write-Warning 'COREF: no assertoric clause is usable — either the classifier returned nothing (missing key) or every resolution failed. resolved-clauses.jsonl was still emitted so the run is inspectable; no resolution is trustworthy.'
 }
 
-# ── FOL / CONTRADICTION / FN-rate (design §7/§8) — later increments, NOT implemented ─────────
+# ── FOL stage (design §7) — Increment 4. Reuses the LogicalFormPass core (no fork) ──────────
+# Formalize the coref-USABLE assertoric clauses into neo-Davidsonian logical forms via the SAME
+# prompt/usage/grounding/validation the summary FOL corpus uses (fol-eval-fol.ps1 -> module session
+# state for the private grounders), so the §8 cross-corpus contradiction check is apples-to-apples.
+# partial/unresolved clauses are excluded (fol_status 'skipped-unresolved'); no clause is dropped.
+Write-Host ''
+Write-Host '=== FOL stage (design §7) — neo-Davidsonian formalization of the resolved assertoric subset (PAID) ===' -ForegroundColor Cyan
+$usableAssertoric = @($resolved | Where-Object { $_.coref_usable })
+$folMap = Invoke-FolClauseExtraction -Module $Mod -Clauses $usableAssertoric -Temperature 0.1
+$formalized = @(ConvertTo-FolClauseFormalized -Clauses $resolved -Results $folMap)
+
+$formalizedPath = Join-Path $resolvedOut 'formalized-clauses.jsonl'
+Set-Content -LiteralPath $formalizedPath -Value @($formalized | ForEach-Object { $_ | ConvertTo-Json -Depth 12 -Compress }) -Encoding utf8
+
+$folStats = Measure-FolExtraction -Formalized $formalized
+Write-Host "  Assertoric clauses: $($folStats.total) -> $formalizedPath  (attempted $($folStats.attempted) usable; skipped-unresolved $($folStats.total - $folStats.attempted))" -ForegroundColor White
+Write-Host "  Formalized: $($folStats.formalized_count)/$($folStats.attempted) = $($folStats.formalized_fraction)" -ForegroundColor White
+foreach ($k in @($folStats.status_counts.Keys | Sort-Object)) {
+    Write-Host ("    {0,-20} {1}" -f $k, $folStats.status_counts[$k]) -ForegroundColor DarkGray
+}
+if ($folStats.attempted -gt 0 -and $folStats.formalized_count -eq 0) {
+    Write-Warning 'FOL: no clause formalized — the backend returned nothing (missing key / model?). formalized-clauses.jsonl was still emitted so the run is inspectable; no logical_form is present.'
+}
+
+# ── CONTRADICTION + paraphrase FN-rate (design §8) — later increment, NOT implemented ────────
 throw (New-EvalError `
     'Run the full FOL-on-debate eval pipeline' `
-    "SEGMENT + CLASSIFY + COREF ran (clauses/classified/resolved JSONL emitted; $($cov.usable_count) usable assertoric of $($cov.total)) but the FOL/contradiction/FN-rate stages are not yet implemented." `
-    'Inspect resolved-clauses.jsonl now (or use -DryRun / -SkipClassify). FOL extraction (design §7, reusing Private/LogicalFormPass.ps1 on the resolved assertoric subset) is the next increment; contradiction + paraphrase FN-rate (§8) follow.')
+    "SEGMENT + CLASSIFY + COREF + FOL ran (formalized-clauses.jsonl emitted; $($folStats.formalized_count) logical forms of $($folStats.attempted) attempted) but the contradiction/FN-rate/correlation stages are not yet implemented." `
+    'Inspect formalized-clauses.jsonl now (or use -DryRun / -SkipClassify). Contradiction + paraphrase FN-rate (design §8, the make-or-break primary metric) is the next increment; correlation outputs (§9) follow.')

--- a/tests/DataWriteSinkGuard.Tests.ps1
+++ b/tests/DataWriteSinkGuard.Tests.ps1
@@ -59,7 +59,7 @@ BeforeAll {
         'scripts/AITriad/Public/New-SyntheticCorpus.ps1'   = 'append-checkpoint + fresh corpus generation + NEW metadata (not a whole-file data rewrite)'
         'scripts/AITriad/Public/Test-DebatePersistence.ps1' = 'writes a random persist-probe .tmp (test probe, non-data)'
         'scripts/AITriad/Private/AICallLog.ps1'            = 'append-only AI call-log JSONL (Add-Content); references Get-DataRoot only to locate the log file — never read-mutate-rewrites a data-of-record file (t/3241)'
-        'scripts/run-fol-debate-eval.ps1'                  = 'read-only FOL-on-debate eval harness (t/3354); Set-Content writes only run-manifest.json + clauses.jsonl + classified-clauses.jsonl + resolved-clauses.jsonl to -OutputDir, which is fail-closed asserted OUTSIDE the data root via Test-IsUnderDataRoot (design §1) — references data tokens (debates/summaries/conflicts) as read-only inputs, never writes ../ai-triad-data'
+        'scripts/run-fol-debate-eval.ps1'                  = 'read-only FOL-on-debate eval harness (t/3354); Set-Content writes only run-manifest.json + clauses.jsonl + classified-clauses.jsonl + resolved-clauses.jsonl + formalized-clauses.jsonl to -OutputDir, which is fail-closed asserted OUTSIDE the data root via Test-IsUnderDataRoot (design §1) — references data tokens (debates/summaries/conflicts) as read-only inputs, never writes ../ai-triad-data'
     }
 
     # A data-of-record path token (basename or data-dir accessor). Kept specific so

--- a/tests/FolDebateFol.Tests.ps1
+++ b/tests/FolDebateFol.Tests.ps1
@@ -1,0 +1,85 @@
+# Tag: qbaf (t/3354 — FOL-on-debate eval FOL extraction, design §7)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Tests for the FOL-on-debate FOL-extraction PURE transforms (scripts/fol-eval-fol.ps1, design §7).
+.DESCRIPTION
+    ConvertTo-FolClauseFormalized and Measure-FolExtraction are pure (no AI, no I/O). The impure
+    Invoke-FolClauseFormalize / Invoke-FolClauseExtraction (which reuse the LogicalFormPass core via the
+    module and call the AI backend) are not invoked here — the extraction stage's live behavior is
+    covered by the runner's degraded no-key run + the module's own LogicalFormPass tests.
+#>
+
+BeforeAll {
+    . "$PSScriptRoot/../scripts/fol-eval-fol.ps1"
+}
+
+Describe 'ConvertTo-FolClauseFormalized — join, skip-unresolved, never-drop' -Tag 'qbaf' {
+    BeforeAll {
+        $script:resolved = @(
+            # usable (self_contained) -> attempted
+            [pscustomobject]@{ id = 'd:t0:c0'; debate_id = 'd'; turn_index = 0; clause_index = 0; text = 'Seven firms control 35%.'; resolved_text = 'Seven firms control 35%.'; char_start = 0; char_end = 24; primary_type = 'assertoric-factual'; attribution = 'own'; anaphora_dependency = 'self-contained'; polarity = 'asserted'; resolution_status = 'self_contained'; coref_usable = $true }
+            # usable (resolved) -> attempted
+            [pscustomobject]@{ id = 'd:t2:c1'; debate_id = 'd'; turn_index = 2; clause_index = 1; text = 'that entrenches them.'; resolved_text = 'caps entrench incumbents.'; char_start = 0; char_end = 21; primary_type = 'assertoric-causal'; attribution = 'attributed-opponent'; anaphora_dependency = 'demonstrative'; polarity = 'asserted'; resolution_status = 'resolved'; coref_usable = $true }
+            # NOT usable (coref unresolved) -> skipped, never formalized
+            [pscustomobject]@{ id = 'd:t3:c0'; debate_id = 'd'; turn_index = 3; clause_index = 0; text = 'the threshold matters.'; resolved_text = 'the threshold matters.'; char_start = 0; char_end = 22; primary_type = 'assertoric-factual'; attribution = 'own'; anaphora_dependency = 'topic-ellipsis'; polarity = 'asserted'; resolution_status = 'unresolved'; coref_usable = $false }
+        )
+    }
+
+    It 'attaches a formalized logical_form and records status' {
+        $lf = [pscustomobject]@{ predicate = 'control'; status = 'proposed' }
+        $results = @{
+            'd:t0:c0' = @{ status = 'formalized'; logical_form = $lf }
+            'd:t2:c1' = @{ status = 'invalid'; reason = 'no core event' }
+        }
+        $out = @(ConvertTo-FolClauseFormalized -Clauses $resolved -Results $results)
+        $out.Count | Should -Be 3
+        $c0 = $out | Where-Object { $_.id -eq 'd:t0:c0' }
+        $c0.fol_status | Should -Be 'formalized'
+        $c0.logical_form.predicate | Should -Be 'control'
+        $c1 = $out | Where-Object { $_.id -eq 'd:t2:c1' }
+        $c1.fol_status | Should -Be 'invalid'
+        $c1.fol_reason | Should -Be 'no core event'
+        $null -eq $c1.logical_form | Should -BeTrue
+    }
+
+    It 'skips coref-unusable clauses (skipped-unresolved, never sent to FOL)' {
+        $out = @(ConvertTo-FolClauseFormalized -Clauses $resolved -Results @{})
+        $skip = $out | Where-Object { $_.id -eq 'd:t3:c0' }
+        $skip.fol_status | Should -Be 'skipped-unresolved'
+        $null -eq $skip.logical_form | Should -BeTrue
+    }
+
+    It 'never drops a usable clause absent from the results — emits missing' {
+        $out = @(ConvertTo-FolClauseFormalized -Clauses $resolved -Results @{})
+        $out.Count | Should -Be 3
+        ($out | Where-Object { $_.id -eq 'd:t0:c0' }).fol_status | Should -Be 'missing'
+    }
+}
+
+Describe 'Measure-FolExtraction — outcome counts over the attempted subset' -Tag 'qbaf' {
+    It 'excludes skipped-unresolved from the attempted denominator' {
+        $formalized = @(
+            [pscustomobject]@{ fol_status = 'formalized' }
+            [pscustomobject]@{ fol_status = 'formalized' }
+            [pscustomobject]@{ fol_status = 'invalid' }
+            [pscustomobject]@{ fol_status = 'skipped-unresolved' }
+        )
+        $s = Measure-FolExtraction -Formalized $formalized
+        $s.total | Should -Be 4
+        $s.attempted | Should -Be 3                 # 4 total - 1 skipped
+        $s.formalized_count | Should -Be 2
+        $s.formalized_fraction | Should -Be ([Math]::Round(2 / 3, 4))
+    }
+
+    It 'handles an empty set' {
+        $s = Measure-FolExtraction -Formalized @()
+        $s.total | Should -Be 0
+        $s.attempted | Should -Be 0
+        $s.formalized_fraction | Should -Be 0.0
+    }
+}


### PR DESCRIPTION
## Increment 4 — FOL extraction (design §7, reuses the LogicalFormPass core, no fork)

Fifth build increment of the offline FOL-on-debate eval harness (t/3354), after foundation (#2045), segmenter (#2081), classifier (#2086), coref (#2088). Formalizes the coref-usable assertoric subset into neo-Davidsonian logical forms via the **same instrument the summary FOL corpus uses** — so the §8 cross-corpus contradiction check is apples-to-apples (TL condition: no fork).

### What lands
- **`scripts/fol-eval-fol.ps1`** — pure transforms (`ConvertTo-FolClauseFormalized` / `Measure-FolExtraction`) + the impure `Invoke-FolClauseFormalize` / `Invoke-FolClauseExtraction`. Each usable clause's `resolved_text` is formalized through the identical path `Invoke-LogicalFormPass` uses (`Get-Prompt 'logical-form-formalization'` → `Invoke-AIByUsage 'enrichment.logical-form-formalization'` → `ConvertTo-GroundedLogicalForm` → `Test-LogicalFormStructure`). The grounding/validation helpers are module-**private**, so they are **reused via the AITriad module session state** (`& $Module { … }`), not reimplemented. Debate clauses have no `entity_refs` → empty ref table (all args become `lit:`), formalized as `factual`/empty-CAMP (modality:null) so a debate `logical_form` is **shape-identical** to a summary `factual_claim` one. Only coref-usable clauses are formalized; partial/unresolved → `fol_status 'skipped-unresolved'`; no clause dropped; invalid/failed recorded, never fabricated.
- **`run-fol-debate-eval.ps1`** — FOL stage emits `formalized-clauses.jsonl` + an extraction report (formalized fraction over the attempted/usable subset), then throws at the pending contradiction stage.
- Tests: **`FolDebateFol.Tests.ps1`** (5 pure-transform cases); `DataWriteSinkGuard.Tests.ps1` exemption reason updated for `formalized-clauses.jsonl`.

### Bug fixed
A local named `$formalized` collided case-insensitively with the typed `[object[]]$Formalized` param, coercing the int count into a 1-element array (`op_Division` failure) — renamed the local. (Strict-mode + typed-param trap.)

### Verification
- **33/33 Pester** green.
- Degraded **no-key** full run emits all five JSONL artifacts + the extraction report and throws at contradiction.
- The crux reuse is confirmed directly: `ConvertTo-EntityRefsPromptJson`→`[]`, `ConvertTo-GroundedLogicalForm`→`predicate=control`, `Test-LogicalFormStructure`→`Ok=True`, all resolving through module session state; no-key formalize → `status=failed` cleanly.

### Scope / gates
Read-only over `../ai-triad-data` (§1). **No new prompt/usage** (reuses the existing `logical-form-formalization` instrument) → no promptCatalog coupling; no `ai-models.json`/schema change → no Second Opinion (t/3361). **Next: contradiction + paraphrase FN-rate (§8)** — the make-or-break primary metric — then correlation outputs (§9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)