### PR TITLE
fix(taxonomy): resolve pol-* refs in the debate ref-popup (t/3401)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/TaxonomyRefs.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/TaxonomyRefs.tsx
@@ -96,12 +96,22 @@ export function TaxonomyPill({ taxRef, onSelect, selected }: {
 function TaxNodeDetail({ nodeId, onClose }: { nodeId: string; onClose: () => void }) {
   const lookupPinnedData = useTaxonomyStore(s => s.lookupPinnedData);
   const data = lookupPinnedData(nodeId);
-  const node = data && data.type !== 'conflict'
+  // t/3401: pol-* ids resolve to a 'policy' PinnedData variant, not a POV/situations node.
+  const node = data && data.type !== 'conflict' && data.type !== 'policy'
     ? (data.node as unknown as TaxRefNode)
     : undefined;
   const pov = data?.type === 'pov' ? data.pov
     : data?.type === 'situations' ? 'situations' : '';
-  return <TaxonomyRefDetail nodeId={nodeId} node={node} pov={pov} onClose={onClose} />;
+  return (
+    <TaxonomyRefDetail
+      nodeId={nodeId}
+      node={node}
+      pov={pov}
+      onClose={onClose}
+      policy={data?.type === 'policy' ? data.policy : undefined}
+      policyReferencingNodes={data?.type === 'policy' ? data.referencingNodes : undefined}
+    />
+  );
 }
 
 function CaveatsBox({ caveats }: { caveats: string[] }) {

--- a/taxonomy-editor/src/renderer/components/shared/LinkedNodePreview.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/LinkedNodePreview.tsx
@@ -61,6 +61,24 @@ export function LinkedNodePreview({ nodeId }: { nodeId: string }) {
     );
   }
 
+  if (data.type === 'policy') {
+    const { policy, referencingNodes } = data;
+    return (
+      <div className="linked-node-preview">
+        <div className="linked-node-preview-header">
+          <span className="linked-node-preview-pov">Policy</span>
+          <span className="linked-node-preview-id">{nodeId}</span>
+        </div>
+        <div className="linked-node-preview-label">{policy.action}</div>
+        {policy.description && <div className="linked-node-preview-description">{policy.description}</div>}
+        <div className="linked-node-preview-attrs">
+          <span className="linked-node-preview-attr-label">Referenced by:</span>
+          <span>{referencingNodes.length} node{referencingNodes.length === 1 ? '' : 's'}</span>
+        </div>
+      </div>
+    );
+  }
+
   const node = data.node;
   const povLabel = data.type === 'pov' ? POV_LABELS[data.pov] ?? data.pov : 'Situation';
   const category = data.type === 'pov' ? data.node.category : null;

--- a/taxonomy-editor/src/renderer/components/taxonomy/TaxonomyRefDetail.test.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/TaxonomyRefDetail.test.tsx
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3401: the debate ref-popup couldn't resolve pol-* ids ("Node not found in loaded Perspective
+// files"). Regression coverage for the new policy view.
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TaxonomyRefDetail } from './TaxonomyRefDetail';
+
+vi.mock('../../hooks/useTaxonomyStore', () => ({
+  useTaxonomyStore: () => ({}),
+}));
+
+describe('TaxonomyRefDetail — policy view (t/3401)', () => {
+  it('renders the policy action, description, and referencing nodes when given a policy prop', () => {
+    render(
+      <TaxonomyRefDetail
+        nodeId="pol-001"
+        node={undefined}
+        pov=""
+        onClose={vi.fn()}
+        policy={{ id: 'pol-001', action: 'Fund retraining programs.', description: 'Workforce policy.', source_povs: ['skeptic'], member_count: 3 }}
+        policyReferencingNodes={[
+          { id: 'skp-beliefs-042', label: 'A Skeptic Belief', pov: 'skeptic', action: 'Node-level action', framing: 'Node-level framing' },
+        ]}
+      />,
+    );
+    // Appears twice by design: the header title AND the body "Action" section.
+    expect(screen.getAllByText('Fund retraining programs.').length).toBe(2);
+    expect(screen.getByText('Workforce policy.')).toBeInTheDocument();
+    expect(screen.getByText('A Skeptic Belief')).toBeInTheDocument();
+    expect(screen.getByText(/Node-level framing/)).toBeInTheDocument();
+    expect(screen.queryByText(/Node not found/)).not.toBeInTheDocument();
+  });
+
+  it('shows an empty-state message when no loaded node references the policy', () => {
+    render(
+      <TaxonomyRefDetail
+        nodeId="pol-002"
+        node={undefined}
+        pov=""
+        onClose={vi.fn()}
+        policy={{ id: 'pol-002', action: 'Some other policy.', source_povs: [], member_count: 0 }}
+        policyReferencingNodes={[]}
+      />,
+    );
+    expect(screen.getByText(/No loaded node currently references this policy/)).toBeInTheDocument();
+  });
+
+  it('falls back to "Node not found" when neither node nor policy is provided (regression guard)', () => {
+    render(<TaxonomyRefDetail nodeId="unknown-999" node={undefined} pov="" onClose={vi.fn()} />);
+    expect(screen.getByText(/Node not found in loaded Perspective files/)).toBeInTheDocument();
+  });
+
+  it('still renders the normal node view when a node is provided (regression guard, no policy)', () => {
+    render(
+      <TaxonomyRefDetail
+        nodeId="acc-beliefs-001"
+        node={{ id: 'acc-beliefs-001', label: 'A POV Node', description: 'A description.' }}
+        pov="accelerationist"
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('A POV Node')).toBeInTheDocument();
+    expect(screen.getByText('A description.')).toBeInTheDocument();
+  });
+});

--- a/taxonomy-editor/src/renderer/components/taxonomy/TaxonomyRefDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/TaxonomyRefDetail.tsx
@@ -51,6 +51,25 @@ export interface TaxRefEdge {
   notes?: string;
 }
 
+/** t/3401: pol-* ids live in policy_actions.json, not the Perspective files — a policy is not a
+ *  POV/situation node, so it gets a dedicated (simpler) view rather than reusing the tab machinery. */
+export interface TaxRefPolicy {
+  id: string;
+  action: string;
+  description?: string;
+  source_povs: string[];
+  member_count: number;
+}
+
+export interface TaxRefPolicyReferencingNode {
+  id: string;
+  label: string;
+  pov: string;
+  /** How THIS node's own graph_attributes.policy_actions entry frames the policy — per-node, not on the registry. */
+  action?: string;
+  framing?: string;
+}
+
 type TabId = 'content' | 'related' | 'attributes' | 'pov-acc' | 'pov-saf' | 'pov-skp';
 
 interface Props {
@@ -59,9 +78,11 @@ interface Props {
   pov: string;
   onClose: () => void;
   edges?: TaxRefEdge[];
+  policy?: TaxRefPolicy;
+  policyReferencingNodes?: TaxRefPolicyReferencingNode[];
 }
 
-export function TaxonomyRefDetail({ nodeId, node, pov, onClose, edges }: Props) {
+export function TaxonomyRefDetail({ nodeId, node, pov, onClose, edges, policy, policyReferencingNodes }: Props) {
   const [tab, setTab] = useState<TabId>('content');
   const ga = node?.graph_attributes;
 
@@ -96,9 +117,11 @@ export function TaxonomyRefDetail({ nodeId, node, pov, onClose, edges }: Props) 
       <div className="nd-header taxref-header-pad">
         <div className="nd-header-title">
           <span className="nd-header-label taxref-title">
-            {node?.label || nodeId}
+            {policy ? policy.action : (node?.label || nodeId)}
           </span>
-          {pov && (
+          {policy ? (
+            <span className="taxref-pov-pill">policy</span>
+          ) : pov && (
             <span className="taxref-pov-pill">{pov}</span>
           )}
           <span className="taxref-node-id">
@@ -115,7 +138,9 @@ export function TaxonomyRefDetail({ nodeId, node, pov, onClose, edges }: Props) 
         >Close</button>
       </div>
 
-      {!node ? (
+      {policy ? (
+        <PolicyView policy={policy} referencingNodes={policyReferencingNodes ?? []} />
+      ) : !node ? (
         <div className="taxref-not-found">
           Node not found in loaded Perspective files. (Taxonomy may not be loaded yet, or this id belongs to a non-Perspective registry.)
         </div>
@@ -166,6 +191,50 @@ export function TaxonomyRefDetail({ nodeId, node, pov, onClose, edges }: Props) 
             {tab === 'pov-skp' && <PovInterpretationTab interp={interps?.skeptic} povLabel="Skeptic" povColor="var(--color-skp, #a855f7)" />}
           </div>
         </>
+      )}
+    </div>
+  );
+}
+
+/* ── Policy view (t/3401) ─────────────────────────────── */
+
+function PolicyView({ policy, referencingNodes }: { policy: TaxRefPolicy; referencingNodes: TaxRefPolicyReferencingNode[] }) {
+  return (
+    <div className="taxref-tab-content">
+      {policy.description && (
+        <div>
+          <div className="taxref-section-header taxref-section-header-mt0">Description</div>
+          <div className="taxref-desc-box">{policy.description}</div>
+        </div>
+      )}
+
+      <div className="taxref-section-header taxref-section-header-mt0">Action</div>
+      <div className="taxref-desc-box">{policy.action}</div>
+
+      {policy.source_povs.length > 0 && (
+        <>
+          <div className="taxref-section-header">Source Perspectives</div>
+          <div>
+            {policy.source_povs.map(p => <span key={p} className="taxref-chip">{p}</span>)}
+          </div>
+        </>
+      )}
+
+      <div className="taxref-section-header taxref-section-header-flex">
+        Referenced By
+        <span className="taxref-related-count-badge">{referencingNodes.length}</span>
+      </div>
+      {referencingNodes.length === 0 ? (
+        <div className="taxref-empty-msg">No loaded node currently references this policy.</div>
+      ) : (
+        referencingNodes.map(n => (
+          <div key={n.id} className="taxref-attr-block">
+            <span className="taxref-chip taxref-chip-strong">{n.label}</span>
+            <span className="taxref-node-id">{n.id} · {n.pov}</span>
+            {n.action && <div><strong className="taxref-attr-label">Action:</strong> {n.action}</div>}
+            {n.framing && <div><strong className="taxref-attr-label">Framing:</strong> {n.framing}</div>}
+          </div>
+        ))
       )}
     </div>
   );

--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore.test.ts
@@ -1094,6 +1094,42 @@ describe('useTaxonomyStore', () => {
         expect(useTaxonomyStore.getState().lookupPinnedData('unknown-999')).toBeNull();
       });
 
+      // t/3401: pol-* ids previously fell through every branch to null — the debate ref-popup
+      // showed "Node not found" for a policy reference. Both arms per the ticket's UAT triage.
+      describe('policy refs (t/3401)', () => {
+        it('resolves a pol-* id to the policy registry entry, with referencing nodes', () => {
+          useTaxonomyStore.setState({
+            accelerationist: makePovFile([
+              makePovNode({
+                id: 'acc-beliefs-001',
+                label: 'Acc Belief',
+                graph_attributes: { policy_actions: [{ policy_id: 'pol-001', action: 'Node action', framing: 'Node framing' }] } as never,
+              }),
+            ]),
+          });
+          const result = useTaxonomyStore.getState().lookupPinnedData('pol-001');
+          expect(result).not.toBeNull();
+          expect(result!.type).toBe('policy');
+          if (result!.type === 'policy') {
+            expect(result!.policy.action).toBe('Policy Action');
+            expect(result!.referencingNodes).toEqual([
+              { id: 'acc-beliefs-001', label: 'Acc Belief', pov: 'accelerationist', action: 'Node action', framing: 'Node framing' },
+            ]);
+          }
+        });
+
+        it('returns a policy with an empty referencingNodes list when no loaded node references it', () => {
+          const result = useTaxonomyStore.getState().lookupPinnedData('pol-001');
+          expect(result).not.toBeNull();
+          expect(result!.type).toBe('policy');
+          if (result!.type === 'policy') expect(result!.referencingNodes).toEqual([]);
+        });
+
+        it('returns null for an unknown pol-* id (graceful fallback persists)', () => {
+          expect(useTaxonomyStore.getState().lookupPinnedData('pol-does-not-exist')).toBeNull();
+        });
+      });
+
       it('returns structuredClone (not a reference)', () => {
         const result = useTaxonomyStore.getState().lookupPinnedData('acc-beliefs-001')!;
         if (result.type === 'pov') {

--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/taxonomyDataSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/taxonomyDataSlice.ts
@@ -136,10 +136,21 @@ function recordLogicalFormStripSummary(pov: string, strippedCount: number): void
   });
 }
 
+/** A POV node referencing a policy via its own graph_attributes.policy_actions[] entry (t/3401) —
+ *  "framing" is a per-node field (how THAT node frames the policy), not on the registry entry. */
+export interface PolicyReferencingNode {
+  id: string;
+  label: string;
+  pov: Pov;
+  action?: string;
+  framing?: string;
+}
+
 export type PinnedData =
   | { type: 'pov'; pov: Pov; node: PovNode }
   | { type: 'situations'; node: SituationNode }
-  | { type: 'conflict'; conflict: ConflictFile };
+  | { type: 'conflict'; conflict: ConflictFile }
+  | { type: 'policy'; policy: PolicyRegistryEntry; referencingNodes: PolicyReferencingNode[] };
 
 export interface PolicyRegistryEntry {
   id: string;
@@ -1267,6 +1278,23 @@ export const createTaxonomyDataSlice: StateCreator<TaxonomyStore, [], [], Taxono
       const conflict = state.conflicts.find(c => c.claim_id === id);
       if (conflict) return { type: 'conflict', conflict: structuredClone(conflict) };
       return null;
+    }
+    // t/3401: pol-* ids live in policy_actions.json (policyRegistry), not the Perspective files —
+    // the popup previously fell through every branch to "Node not found." Reuses the already-loaded
+    // registry (same source getLabelForId/getDescriptionForId already dispatch on, above).
+    if (id.startsWith('pol-')) {
+      const policy = state.policyRegistry?.find(p => p.id === id);
+      if (!policy) return null;
+      const referencingNodes: PolicyReferencingNode[] = [];
+      for (const pov of POV_KEYS) {
+        const file = state[pov];
+        if (!file?.nodes) continue;
+        for (const n of file.nodes) {
+          const match = n.graph_attributes?.policy_actions?.find(p => p.policy_id === id);
+          if (match) referencingNodes.push({ id: n.id, label: n.label, pov, action: match.action, framing: match.framing });
+        }
+      }
+      return { type: 'policy', policy: structuredClone(policy), referencingNodes: structuredClone(referencingNodes) };
     }
     for (const pov of POV_KEYS) {
       const file = state[pov];


### PR DESCRIPTION
## t/3401 — debate ref-popup can't resolve pol-* ids

PI-reported (screenshot, p/548#94). Clicking a `pol-*` reference (e.g. `pol-1004`) in a debate opened the ref popup with "Node not found in loaded Perspective files" — the policy was inaccessible.

### Root cause (traced, matches the ticket exactly)
`lookupPinnedData` checks situation → `conflict-*` → the 3 POV files loop → `null`. No `pol-*` branch. Every entry point into this popup (BDI/PLAN section pills in `TaxonomyRefs.tsx`) funnels through the same lookup, so this is one fix point.

### Fix
- `PinnedData` gets a 4th `'policy'` variant (registry entry + `referencingNodes`: which loaded POV nodes reference it via their own `graph_attributes.policy_actions`, since per-node "framing" is per-node, not on the registry entry).
- `lookupPinnedData`'s new `pol-*` branch **reuses the already-loaded `policyRegistry`** — the same source `getLabelForId`/`getDescriptionForId` already dispatch on. No new load path (shared-utility rule).
- `TaxonomyRefDetail` gets a dedicated `PolicyView` instead of "Node not found" when given a `policy` prop.
- `LinkedNodePreview` (the other `PinnedData` consumer, caught by `tsc` widening the union) gets a matching preview branch.
- `TaxonomyRefs.tsx`'s `TaxNodeDetail` (DebateWorkspace-owned, ~10-line mechanical extension of an existing type-narrow) wires the new prop through.

**Checked other reachable prefixes** per the ticket's ask: `cc-*` already resolves via `nodeTypeFromId`'s situation branch; no `ent-*` refs are clickable from this popup today. `pol-*` was the only broken prefix.

### Tests (both-arms)
`lookupPinnedData` resolves `pol-*` with correct referencing nodes / empty-list when unreferenced / `null` for an unknown id; `TaxonomyRefDetail` renders the policy view + regression-guards the existing node/fallback paths. **RED arm proven** (disabled the branch, confirmed exactly the 2 positive tests fail).

### Verification
renderer tsc clean · `useTaxonomyStore.test.ts` 129/129 · `TaxonomyRefDetail.test.tsx` 4/4 · `TaxonomyRefs` (debate-workspace) suite 15/15 · eslint 0 errors (10 pre-existing complexity warnings; +3/+4/new-19 from the new dispatch branches, confirmed via git-stash baseline diff — noted transparently, not refactored out-of-scope for a bug fix).

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>

🤖 Generated with [Claude Code](https://claude.com/claude-code)