### PR TITLE
feat(debate): useSyntheticPhraseGrounding flag (t/3367)

### DIFF
--- a/lib/debate/debateEngine/internals.ts
+++ b/lib/debate/debateEngine/internals.ts
@@ -104,6 +104,9 @@ export interface DebateConfig {
   excludeGreatestHits?: boolean;
   /** Inject comp-linguist per-POV, per-BDI situation register-statements at setup (t/1450 experiment). Off by default. */
   enableSituationStatements?: boolean;
+  /** Replace description grounding text with the node's synthetic_phrase nearest the description embedding (t/3367).
+   *  Off by default. Requires adapter.computeQueryEmbedding; WARN-falls back to description when unavailable. */
+  useSyntheticPhraseGrounding?: boolean;
   /** Enable over-generate/select/rewrite pipeline: N=3 drafts, dedup, greedy top-K, rewrite, coherence gate (t/1581). */
   experiment_overgen_select_rewrite?: boolean;
   /** Exploration summary from a prior cheap-engine run — seeds cruxes, situations, AN priming, and config overrides. */

--- a/lib/debate/debateEngine/taxonomyContext.ts
+++ b/lib/debate/debateEngine/taxonomyContext.ts
@@ -24,6 +24,7 @@ import {
   EDGE_CONTEXT_TOP_N,
 } from '../debateConfig.js';
 import { loadProvisionalWeights } from '../phaseTransitions.js';
+import { cosineSimilarity } from '../../embeddings/similarity.js';
 
 export function getNodeLabelMap(engine: DebateEngineInternals): Map<string, string> {
   if (engine._nodeLabelMap) return engine._nodeLabelMap;
@@ -450,7 +451,48 @@ export async function getRelevantTaxonomyContext(engine: DebateEngineInternals, 
     }
   }
 
-  return formatTaxonomyContext(filteredCtx, pov, undefined, situationStatements ? { situationStatements } : undefined);
+  // Select best synthetic phrase per node when useSyntheticPhraseGrounding is on (t/3367).
+  // CLAIM_VECTOR = node's description embedding (claim-fidelity, per CL spec p/49#388).
+  // Fallback-path logging rule: WARN on each skipped node with discriminating reason.
+  let syntheticPhraseOverrides: Map<string, string> | undefined;
+  if (engine.config.useSyntheticPhraseGrounding) {
+    const embedFn = (engine.adapter as ExtendedAIAdapter).computeQueryEmbedding?.bind(engine.adapter);
+    if (!embedFn) {
+      getGlobalRecorder()?.record({ type: 'system.error', component: 'debate-engine', level: 'warn', debate_id: engine.session?.id, message: 'useSyntheticPhraseGrounding: adapter has no computeQueryEmbedding — falling back to description for all nodes' });
+    } else {
+      syntheticPhraseOverrides = new Map<string, string>();
+      const allNodes = filteredCtx.povNodes;
+      await Promise.all(allNodes.map(async (n) => {
+        const phrases = n.graph_attributes?.synthetic_phrases;
+        if (!phrases || phrases.length === 0) {
+          getGlobalRecorder()?.record({ type: 'system.error', component: 'debate-engine', level: 'warn', debate_id: engine.session?.id, message: `useSyntheticPhraseGrounding: no synthetic_phrases on ${n.id} — falling back to description` });
+          return;
+        }
+        const descVec = engine.taxonomy.embeddings[n.id]?.vector;
+        if (!descVec) {
+          getGlobalRecorder()?.record({ type: 'system.error', component: 'debate-engine', level: 'warn', debate_id: engine.session?.id, message: `useSyntheticPhraseGrounding: no description embedding for ${n.id} — falling back to description` });
+          return;
+        }
+        try {
+          const phraseVecs = await Promise.all(phrases.map((p) => embedFn(p)));
+          let bestIdx = 0;
+          let bestSim = cosineSimilarity(phraseVecs[0].vector, descVec);
+          for (let i = 1; i < phraseVecs.length; i++) {
+            const sim = cosineSimilarity(phraseVecs[i].vector, descVec);
+            if (sim > bestSim) { bestSim = sim; bestIdx = i; }
+          }
+          syntheticPhraseOverrides!.set(n.id, phrases[bestIdx]);
+        } catch (err) {
+          getGlobalRecorder()?.record({ type: 'system.error', component: 'debate-engine', level: 'warn', debate_id: engine.session?.id, message: `useSyntheticPhraseGrounding: embedding failed for ${n.id} — falling back to description`, error: { name: (err as Error).name ?? 'Error', message: String(err) } });
+        }
+      }));
+    }
+  }
+
+  return formatTaxonomyContext(filteredCtx, pov, undefined, {
+    ...(situationStatements ? { situationStatements } : undefined),
+    ...(syntheticPhraseOverrides ? { syntheticPhraseOverrides } : undefined),
+  });
 }
 
 export function formatDebaterEdgeContext(engine: DebateEngineInternals, debaterPov: string): { text: string; edges_used: { source: string; target: string; type: string; confidence: number }[] } {

--- a/lib/debate/taxonomyContext.ts
+++ b/lib/debate/taxonomyContext.ts
@@ -119,6 +119,12 @@ export interface FormatContextConfig {
    * No-op today (no nodes have verification_status set); safe to land inert.
    */
   retrievedContextEnabled?: boolean;
+  /**
+   * Pre-selected synthetic phrase per node ID (t/3367, useSyntheticPhraseGrounding).
+   * When a node ID is present in this map, its value replaces description as grounding text.
+   * Computed engine-side before formatTaxonomyContext; absent = feature off.
+   */
+  syntheticPhraseOverrides?: Map<string, string>;
 }
 
 /** Generate per-node inline guidance lines from metadata.
@@ -303,7 +309,7 @@ export function formatTaxonomyContext(ctx: TaxonomyContext, pov: string, maxNode
       if (isPrimary) {
         const weightLabel = nodeWeightLabel(n, cat);
         lines.push(`${prefix}[${n.id}]${weightLabel}`);
-        lines.push(`  "${n.label}" — ${stripExcludes(n.description)}`);
+        lines.push(`  "${n.label}" — ${stripExcludes(cfg.syntheticPhraseOverrides?.get(n.id) ?? n.description)}`);
         // t/3269: classifications are always AI-generated — drop by default until
         // a classification-level verified signal exists.
       } else {

--- a/lib/debate/taxonomyTypes.ts
+++ b/lib/debate/taxonomyTypes.ts
@@ -46,6 +46,10 @@ export interface GraphAttributes {
    *  Debate-grounding register (t/3367). Absent on most nodes until backfill (t/3366); loader treats
    *  absence as normal and falls back to description, as today. */
   debate_grounding?: string;
+  /** Synthetic paraphrase variants for this node's claim (t/3367). When useSyntheticPhraseGrounding
+   *  is on, the engine selects the phrase cosine-nearest to the description embedding and injects it
+   *  as the grounding text instead of description. Absent on most nodes until CL backfill. */
+  synthetic_phrases?: string[];
   _phrase_regen_pending?: boolean;
   debate_tested?: DebateTestedRecord;
   /** Data-integrity provenance signal (t/3264). Absent = 'curated'. Used by formatTaxonomyContext


### PR DESCRIPTION
## Summary

- Adds \GraphAttributes.synthetic_phrases?: string[]\ to the node type (t/3366 contract)
- Adds \DebateConfig.useSyntheticPhraseGrounding?: boolean\ flag (default OFF)
- Adds \FormatContextConfig.syntheticPhraseOverrides?: Map<string, string>\ plumbing
- \ormatTaxonomyContext\ line 306 uses override when present (falls back to \description\)
- \getRelevantTaxonomyContext\: async pre-computation selects argmax cosine(embed(phrase), desc_vec) per node — CLAIM_VECTOR = description embedding (claim-fidelity, per CL p/49#388)
- Three WARN-fallback paths: no \synthetic_phrases\, no description embedding, no \computeQueryEmbedding\ on adapter

## Test plan
- [ ] 128/128 vitest tests pass (clean at commit)
- [ ] tsc --noEmit exits 0
- [ ] Flag is default OFF — no behavior change to existing debates