### PR TITLE
fix(reflections): show CURRENT description on label-only Revise edits (t/3402)

### DIFF
--- a/taxonomy-editor/src/renderer/components/shared/ReflectionsPanel.test.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/ReflectionsPanel.test.tsx
@@ -102,6 +102,48 @@ describe('ReflectionsPanel — plain description for new (add) proposals', () =>
   });
 });
 
+// ── Revise cards: current-description box visibility (t/3402) ─
+// Regression: EditCardCurrentDesc's visibility guard used to require
+// current_description !== proposed_description, hiding the CURRENT box
+// entirely on a label-only revise (where the descriptions genuinely match) —
+// the user saw the proposed description with zero context on the original.
+
+function addReviseReflection(descriptionChanged: boolean) {
+  debateStore.reflections = [{
+    pover: 'accelerationist',
+    label: 'Accelerationist',
+    reflection_summary: '',
+    edits: [{
+      edit_type: 'revise',
+      status: 'pending',
+      category: 'Beliefs',
+      node_id: 'acc-beliefs-001',
+      proposed_label: 'Revised label',
+      current_description: 'The original current description.',
+      proposed_description: descriptionChanged ? 'A meaningfully different proposed description.' : 'The original current description.',
+      rationale: 'because the label was imprecise',
+      evidence_entries: [],
+    }],
+  }];
+}
+
+describe('ReflectionsPanel — Revise card current-description visibility (t/3402)', () => {
+  it('shows the CURRENT description box on a label-only revise (descriptions match)', () => {
+    addReviseReflection(false);
+    render(<ReflectionsPanel onClose={vi.fn()} />);
+    expect(screen.getByText('CURRENT')).toBeInTheDocument();
+    // The current description text renders even though it equals the proposed text.
+    expect(screen.getAllByText('The original current description.').length).toBeGreaterThan(0);
+  });
+
+  it('still shows the CURRENT description box when the description genuinely changed (regression guard)', () => {
+    addReviseReflection(true);
+    render(<ReflectionsPanel onClose={vi.fn()} />);
+    expect(screen.getByText('CURRENT')).toBeInTheDocument();
+    expect(screen.getByText('The original current description.')).toBeInTheDocument();
+  });
+});
+
 // ── propose_new item proposals (t/1773 AC1) ───────────────────
 
 function addProposalReflection() {

--- a/taxonomy-editor/src/renderer/components/shared/ReflectionsPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/ReflectionsPanel.tsx
@@ -235,7 +235,10 @@ function EditCardCurrentDesc({ edit, currentNode, descMode, setDescMode }: {
   descMode: DescMode;
   setDescMode: SetDescMode;
 }) {
-  if (!(edit.current_description && edit.edit_type !== 'add' && edit.current_description !== edit.proposed_description)) return null;
+  // t/3402: the equality check must gate diff-highlighting (in EditCardProposedBox), not this box's
+  // visibility — a label-only revise has current_description === proposed_description, and hiding the
+  // CURRENT box entirely left the user with no context for what they're approving.
+  if (!(edit.current_description && edit.edit_type !== 'add')) return null;
   const resolved_desc = resolveDescription(
     currentNode ? { description: edit.current_description, plain_description: (currentNode as { plain_description?: string | null }).plain_description } : { description: edit.current_description },
     descMode,


### PR DESCRIPTION
## t/3402 — Revise cards hide the CURRENT description when only the label changes

PI-reported (Jeffrey via p/294#3, screenshot of `acc-beliefs-077`'s Revise card). Traced by DebateTool (p/61#93-95).

### Root cause
`EditCardCurrentDesc`'s visibility guard required `current_description !== proposed_description` to render the CURRENT box **at all**. For a label-only revision the descriptions genuinely match, so the box was hidden entirely — the user saw the proposed description with zero context on the original.

### Fix
The equality check correctly belongs to `EditCardProposedBox` (gates word-diff highlighting on the PROPOSED box — unchanged) — it had been duplicated onto the CURRENT box's visibility guard by mistake. Dropped it there; the CURRENT box now always renders for a revise/qualify/deprecate edit with a `current_description`, whether or not it happens to match the proposed text.

### Tests (both-arms)
- label-only revise (descriptions match) → CURRENT box renders.
- description genuinely changed → CURRENT box still renders (regression guard).

**RED arm proven** — reverted the one-line guard, confirmed exactly the label-only-revise case fails while the changed-description case still passes.

### Verification
renderer tsc clean · eslint clean (pure condition simplification, no new complexity) · `ReflectionsPanel.test.tsx` 7/7.

Self-cert (`/trivial-change`) — tiny single-file guard fix, no cross-role/data-model change.

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>

🤖 Generated with [Claude Code](https://claude.com/claude-code)