### PR TITLE
fix(debate-workspace): align Fact Check web-evidence panel width to prose (t/3407)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.css
@@ -438,8 +438,20 @@ a.lineage-link,
  * above doesn't reach them — cap them directly so both surfaces read as one system.
  * Flag-gated via `.debate-redesign` on the card root, so flag-off stays full-width.
  */
-.debate-statement.debate-type-fact-check.debate-redesign .debate-statement-content,
-.debate-redesign .debate-fact-check-web-evidence-body {
+.debate-statement.debate-type-fact-check.debate-redesign .debate-statement-content {
+  max-width: 95ch;
+}
+
+/*
+ * t/3407: the evidence BOX (not its inner body) carries the 95ch cap, evaluated at
+ * the same font-size as .debate-statement-content above (`--text-md`) so the two
+ * measures resolve to identical pixel widths — `ch` is font-relative, and the body's
+ * own font-size (`--text-sm`) previously made its independent 95ch cap narrower,
+ * leaving an empty gutter inside the bordered box. The body itself is uncapped and
+ * fills 100% of the box, so no internal gutter regardless of its smaller font-size.
+ */
+.debate-statement.debate-type-fact-check.debate-redesign .debate-fact-check-web-evidence {
+  font-size: var(--text-md);
   max-width: 95ch;
 }
 


### PR DESCRIPTION
## Summary
- Fixes t/3407 (Design-reported): the Fact Check **Web Search Evidence** panel was narrower than the fact-check prose above it, leaving an empty right gutter inside the bordered box.
- Root cause: `.debate-statement-content` and `.debate-fact-check-web-evidence-body` each carried an independent `max-width: 95ch` — `ch` is font-relative, and the two elements render at different font-sizes (`--text-md` 0.875rem vs `--text-sm` 0.8125rem), so the "same" 95ch resolved to different pixel widths.
- Fix: move the cap off the inner body and onto the bordered container (`.debate-fact-check-web-evidence`), pinned to the same font-size as the prose content (`--text-md`) so both measures resolve identically. The body is now uncapped and fills 100% of the container — no internal gutter regardless of its own smaller font-size.

## Verification
- Built a harness loading the actual `styles.css` + `StatementCard.css` in a real Chromium engine (Playwright) and measured `getBoundingClientRect()` on both elements:
  - **redesign ON** (95ch capped): content right edge 765.95px, evidence right edge 765.95px → **0.00px delta**
  - **redesign OFF** (full-width): content right edge 1354.00px, evidence right edge 1354.00px → **0.00px delta**
- `--text-md`/`--text-sm` are theme-invariant typography tokens (not redefined under any `[data-theme]` block), so the fix holds across light/dark/bkc/harvard — confirmed by inspection of `styles.css`.
- `npx vitest run src/renderer/components/debate-workspace/` — 272/272 pass (CSS-only change, no behavior touched)

## Test plan
- [x] Automated pixel-measurement verification (see above) — both flag states, 0px delta
- [ ] Design sign-off via `/design-review-workflow` (4 themes) per the ticket's AC

🤖 Generated with [Claude Code](https://claude.com/claude-code)
