### PR TITLE
chore(debate): gate useSyntheticPhraseGrounding embed loop to primary nodes only (t/3403)

### DIFF
--- a/lib/debate/debateEngine/taxonomyContext.ts
+++ b/lib/debate/debateEngine/taxonomyContext.ts
@@ -461,7 +461,8 @@ export async function getRelevantTaxonomyContext(engine: DebateEngineInternals, 
       getGlobalRecorder()?.record({ type: 'system.error', component: 'debate-engine', level: 'warn', debate_id: engine.session?.id, message: 'useSyntheticPhraseGrounding: adapter has no computeQueryEmbedding — falling back to description for all nodes' });
     } else {
       syntheticPhraseOverrides = new Map<string, string>();
-      const allNodes = filteredCtx.povNodes;
+      const primaryIds = new Set(engine._lastInjectionManifest?.povPrimaryIds ?? []);
+      const allNodes = filteredCtx.povNodes.filter(n => primaryIds.has(n.id));
       await Promise.all(allNodes.map(async (n) => {
         const phrases = n.graph_attributes?.synthetic_phrases;
         if (!phrases || phrases.length === 0) {


### PR DESCRIPTION
Gate the per-node embed calls in `useSyntheticPhraseGrounding` to primary-tier nodes only, eliminating wasted embed calls on non-primary nodes that are never injected as grounding text.

## Change
`lib/debate/debateEngine/taxonomyContext.ts`: replace `filteredCtx.povNodes` scan with `primaryIds` filter (built from `engine._lastInjectionManifest?.povPrimaryIds`, which is set at line 374 before this block).

## Test
128/128 debate engine tests pass.

Self-certifying under /trivial-change: 2-line change, single file, no new API, no interface changes.

Closes t/3403
