### PR TITLE
feat(entities): Option-C phase-1 — accept topical_candidates in logicalFormSchema (t/3408)

### DIFF
--- a/lib/entities/logicalForm.test.ts
+++ b/lib/entities/logicalForm.test.ts
@@ -9,7 +9,8 @@
 // documents that so a future reader knows drift is caught at build, not here.
 import { describe, it, expect } from 'vitest';
 import {
-  logicalFormSchema, particularSortSchema, universalSortSchema, type LogicalForm,
+  logicalFormSchema, particularSortSchema, universalSortSchema,
+  lfTopicalCandidatesSchema, lfTopicalCandidateRefSchema, type LogicalForm,
 } from './logicalForm.js';
 
 // The canonical example from research/comp-linguist/docs/logical-form-schema.md §Schema, verbatim.
@@ -171,5 +172,60 @@ describe('universal sort (t/3251) — concept_refs are universals, not particula
     expect(universalSortSchema.safeParse('non-agentive-social-object').success).toBe(false);
     expect(particularSortSchema.safeParse('non-agentive-social-object').success).toBe(true);
     expect(universalSortSchema.safeParse('universal').success).toBe(true);
+  });
+});
+
+describe('topical_candidates (Option C phase-1, t/3408) — additive marking object', () => {
+  const TOPICAL = {
+    validated: false,
+    generator: 'formalize_node_lf.py',
+    golden_ref: 't/3381',
+    blind_golden_precision: 0.54,
+    refs: [
+      { ref: 'term:liability_strict', match_level: 'exact' },
+      { ref: 'ent-360', match_level: 'exact' },
+    ],
+  };
+
+  it('a frame WITH topical_candidates parses (additive; strip-safe — stripInvalidLogicalForm keeps it)', () => {
+    const r = logicalFormSchema.safeParse({ ...CANONICAL, topical_candidates: TOPICAL });
+    expect(r.success).toBe(true);
+  });
+
+  it('a frame WITHOUT topical_candidates still parses (optional; existing frames unaffected)', () => {
+    expect(logicalFormSchema.safeParse(CANONICAL).success).toBe(true); // CANONICAL has no topical_candidates
+  });
+
+  it('rejects a malformed topical_candidates — missing validated', () => {
+    const { validated: _drop, ...noValidated } = TOPICAL;
+    expect(logicalFormSchema.safeParse({ ...CANONICAL, topical_candidates: noValidated }).success).toBe(false);
+  });
+
+  it('rejects a malformed topical_candidates — missing blind_golden_precision', () => {
+    const { blind_golden_precision: _drop, ...noPrecision } = TOPICAL;
+    expect(logicalFormSchema.safeParse({ ...CANONICAL, topical_candidates: noPrecision }).success).toBe(false);
+  });
+
+  it('refs ref format is enforced ^(term:|ent-): term: and ent- (HYPHEN) accepted', () => {
+    expect(lfTopicalCandidateRefSchema.safeParse({ ref: 'term:foo', match_level: 'exact' }).success).toBe(true);
+    expect(lfTopicalCandidateRefSchema.safeParse({ ref: 'ent-360', match_level: 'exact' }).success).toBe(true);
+  });
+
+  it('refs ref format REJECTS ent: (colon) and other prefixes (the SO e/145#14 typo guard)', () => {
+    expect(lfTopicalCandidateRefSchema.safeParse({ ref: 'ent:360', match_level: 'exact' }).success).toBe(false); // colon, not hyphen
+    expect(lfTopicalCandidateRefSchema.safeParse({ ref: 'pol-1', match_level: 'exact' }).success).toBe(false);
+    expect(lfTopicalCandidateRefSchema.safeParse({ ref: 'frontier-model', match_level: 'exact' }).success).toBe(false);
+  });
+
+  it('a full topical_candidates with a bad ref in refs[] fails the whole frame parse', () => {
+    const bad = { ...TOPICAL, refs: [{ ref: 'not-a-valid-prefix', match_level: 'exact' }] };
+    expect(logicalFormSchema.safeParse({ ...CANONICAL, topical_candidates: bad }).success).toBe(false);
+  });
+
+  // PHASE-3 REMOVAL: this tolerance-arm test is DELETED when about[].ref is tightened to ^ent- after
+  // the t/3391 migration (c-design.md §6). Until then about[] must accept term: refs on the live corpus.
+  it('about[] STILL tolerates a term: ref in phase-1 (removed in phase-3)', () => {
+    const r = logicalFormSchema.safeParse({ ...CANONICAL, about: [{ ref: 'term:frontier-model', match_level: 'exact' }] });
+    expect(r.success).toBe(true);
   });
 });

--- a/lib/entities/logicalForm.ts
+++ b/lib/entities/logicalForm.ts
@@ -79,11 +79,41 @@ export const lfArgSchema = z.object({
   match_level: lfMatchLevelSchema,
 }).passthrough();
 
-/** Topical grounding entry — an `ent-*` id the claim is *about* (schema doc §about[]).
- *  Superset convention: a topical participant appears in BOTH `args[]` and `about[]`. */
+/** Topical grounding entry — an id the claim is *about* (schema doc §about[]).
+ *  Superset convention: a topical participant appears in BOTH `args[]` and `about[]`.
+ *  PHASE-1 (Option C, t/3408 / e/145): `ref` stays a plain string — about[] remains TOLERANT of
+ *  `term:` refs. Do NOT tighten to `^ent-` here — enforcement is PHASE-3, AFTER the t/3391 corpus
+ *  migration moves the 1560 `term:` refs into `topical_candidates`. The land-order is load-bearing:
+ *  tightening before the data moves would red the fleet on the not-yet-migrated corpus (c-design.md §6). */
 export const lfAboutSchema = z.object({
   ref: z.string(),
   match_level: lfMatchLevelSchema,
+}).passthrough();
+
+/** A single candidate topical ref (Option C phase-1, t/3408). Same shape as an about[] entry, but the
+ *  ref format IS enforced here: `^(term:|ent-)` — concepts are colon-prefixed (`term:…`), entities are
+ *  HYPHENATED (`ent-360`), NOT `ent:*` (SO e/145#14 d2 — a colon-vs-hyphen typo would reject real
+ *  entity refs). `match_level` is retained for structural parity, not load-bearing (it was the t/3379
+ *  enum-leak axis). */
+export const lfTopicalCandidateRefSchema = z.object({
+  ref: z.string().regex(/^(term:|ent-)/, 'topical_candidates ref must start with "term:" or "ent-"'),
+  match_level: lfMatchLevelSchema,
+}).passthrough();
+
+/** `topical_candidates` — the Option-C sibling of `about[]` (t/3408 / e/145; c-design.md §2/§3).
+ *  Homes the concept (`term:`) topical refs the divergent generator wrote, kept SEPARATE from the
+ *  validated ent-only `about[]` so the frozen ent-only golden metric still describes about[] as-is.
+ *  The object shape is the in-DATA quality-marking GATE (§3): `validated` + `generator` + `golden_ref`
+ *  + `blind_golden_precision` let any consumer tell from the artifact alone that this is a RAW
+ *  candidate layer (P≈0.54), not a curated index — a clean-named field is explicitly forbidden.
+ *  Provenance-lifecycle (§3): a repaired generator (t/3390) MUST move refs to about[] on revalidation
+ *  ≥0.80 OR update this provenance in lockstep — never fresh refs under stale metadata. */
+export const lfTopicalCandidatesSchema = z.object({
+  validated: z.boolean(),
+  generator: z.string(),
+  golden_ref: z.string(),
+  blind_golden_precision: z.number(),
+  refs: z.array(lfTopicalCandidateRefSchema),
 }).passthrough();
 
 /** BDI attribution — present for POV/BDI claims, `null` for `factual_claims` (unattributed
@@ -124,6 +154,11 @@ export const logicalFormSchema = z.object({
   temporal: lfTemporalSchema,
   /** Topical index (additive, optional) — the complete set of `ent-*` ids the claim is about. */
   about: z.array(lfAboutSchema).optional(),
+  /** Option-C candidate topical layer (additive, optional; t/3408 / e/145). Concept (`term:`) topical
+   *  refs live here, quality-marked, SEPARATE from the validated ent-only `about[]`. See
+   *  {@link lfTopicalCandidatesSchema}. Optional → existing frames without it still parse (additive-first,
+   *  so `stripInvalidLogicalForm` never drops a node carrying it — c-design.md §6 phase-1). */
+  topical_candidates: lfTopicalCandidatesSchema.optional(),
   /** [0,1] — the pass's self-rated fidelity of the frame to the proposition; the downstream gate lever. */
   formalization_confidence: z.number().min(0).max(1),
   /** Formalization lifecycle (see NOTE above — distinct from EntityLinkStatus). */


### PR DESCRIPTION
Zod half of the signed Option-C design (e/145 §7 CLOSED; analyses/t3389-option-c/c-design.md). **Additive phase-1** port — mirrors the Python reference (#2078). The t/3391 corpus migration is blocked on all ports green.

## What (all additive)
- `lfTopicalCandidatesSchema` `{ validated, generator, golden_ref, blind_golden_precision, refs[] }` — the §2 object shape = the §3 in-data quality-marking gate (name+flag+provenance make the raw candidate layer P≈0.54 unmissable; clean-named field forbidden). refs use `lfTopicalCandidateRefSchema` with ref pattern EXACTLY `^(term:|ent-)` (ent HYPHENATED — SO e/145#14 d2; the doc's `ent:*` was a typo).
- `logicalFormSchema` gains `topical_candidates: …optional()` — existing frames without it still parse; `stripInvalidLogicalForm` (Rosetta) keeps a node carrying it (additive-first).
- **about[] UNCHANGED — stays `term:`-tolerant** (no `^ent-`). Co-located comment: tightening is PHASE-3, after the t/3391 migration (land-order load-bearing, c-design.md §6).

## Self-cert
Playbook-covered impl of a signed design, additive-only, single-scope, no deviation (review-routing.md). Mandatory schema-SO was obtained at design time (e/145). No further Main/SO pass.

## Verify
28/28 — full suite unchanged + t/3408 (topical_candidates parses/strip-safe; missing validated/precision fails; `^(term:|ent-)` enforced incl. the `ent:`-colon typo-guard; about[] `term:` tolerance arm with a phase-3-removal note). entities tsc 0, eslint 0.

Closes t/3408 (Zod port); unblocks t/3391 alongside the PS twin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)