### PR TITLE
test(t3389): Option-C PS<->Python parity fixture + Python arm (t/3409 item 4)

### DIFF
--- a/research/comp-linguist/analyses/t3389-option-c/optionc-parity-fixture.json
+++ b/research/comp-linguist/analyses/t3389-option-c/optionc-parity-fixture.json
@@ -1,0 +1,58 @@
+{
+  "_meta": {
+    "purpose": "Option C PS<->Python(<->TS) parity contract (t/3389 / t/3409 item 4, SO cond-3). Same input logical_form.about[] + ref allowlist, run through each port's split (PS ConvertTo-GroundedLogicalForm / Python formalize_node_lf.validate() / TS equivalent), MUST produce identical output.",
+    "parity_assertion": "For each case: identical about[] membership (ref + match_level, order-insensitive) AND identical topical_candidates.refs (ref + match_level) AND identical provenance parity-fields. topical_candidates ABSENT (not null) when expected_topical_candidates_refs is null.",
+    "provenance_parity_fields": ["validated", "golden_ref", "blind_golden_precision"],
+    "provenance_tolerated_fields": ["generator"],
+    "provenance_expected": { "validated": false, "golden_ref": "t/3381", "blind_golden_precision": 0.54 },
+    "generator_note": "The `generator` field is per-port identity (formalize_node_lf.py vs LogicalFormPass.ps1 vs the TS port) and is TOLERATED — parity ignores it. Every other field must match.",
+    "match_level_note": "match_level is enum-clamped on both sides so a concept's sort='universal' can never leak into match_level (t/3379). Concept (term:) refs land in topical_candidates with the register match_level ('exact'), NOT 'universal'.",
+    "modality_note": "modality/predicate/polarity are unaffected by the split; the fixture exercises only the about[]->about[]+topical_candidates routing.",
+    "camp": "acc", "category": "Beliefs"
+  },
+  "allowlist": {
+    "ent-034": { "sort": "agentive-physical-object", "match_level": "exact" },
+    "term:regulation_precautionary": { "sort": "universal", "match_level": "exact" },
+    "ent-x": { "sort": "perdurant", "match_level": "instance_of" }
+  },
+  "cases": [
+    {
+      "name": "concept_ref_routed_to_topical_candidates",
+      "note": "term: concept ref leaves about[]; match_level 'universal' clamped to authoritative 'exact'.",
+      "input_about": [{ "ref": "term:regulation_precautionary", "match_level": "universal" }],
+      "expected_about": [],
+      "expected_topical_candidates_refs": [{ "ref": "term:regulation_precautionary", "match_level": "exact" }]
+    },
+    {
+      "name": "entity_ref_stays_in_about_ent_only",
+      "note": "ent-* stays in about[] with the AUTHORITATIVE register match_level (model said 'exact', register says 'instance_of' -> register wins). No topical_candidates.",
+      "input_about": [{ "ref": "ent-x", "match_level": "exact" }],
+      "expected_about": [{ "ref": "ent-x", "match_level": "instance_of" }],
+      "expected_topical_candidates_refs": null
+    },
+    {
+      "name": "ungrounded_ref_dropped",
+      "note": "R6/t/2294 - a ref not in the node's own allowlist is never minted; dropped from about[], no topical_candidates.",
+      "input_about": [{ "ref": "ent-hallucinated", "match_level": "exact" }],
+      "expected_about": [],
+      "expected_topical_candidates_refs": null
+    },
+    {
+      "name": "split_mixed_ent_to_about_term_to_candidates",
+      "note": "The core split: ent-* -> about[], term: -> topical_candidates.refs, in one frame.",
+      "input_about": [
+        { "ref": "ent-034", "match_level": "exact" },
+        { "ref": "term:regulation_precautionary", "match_level": "universal" }
+      ],
+      "expected_about": [{ "ref": "ent-034", "match_level": "exact" }],
+      "expected_topical_candidates_refs": [{ "ref": "term:regulation_precautionary", "match_level": "exact" }]
+    },
+    {
+      "name": "empty_about_no_topical_candidates_key",
+      "note": "Empty about[] -> empty about[], topical_candidates ABSENT (not null).",
+      "input_about": [],
+      "expected_about": [],
+      "expected_topical_candidates_refs": null
+    }
+  ]
+}

--- a/research/comp-linguist/tools/test_optionc_parity.py
+++ b/research/comp-linguist/tools/test_optionc_parity.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Option C PS<->Python parity: assert formalize_node_lf.validate() produces the exact split the
+shared cross-port fixture specifies (analyses/t3389-option-c/optionc-parity-fixture.json). This is the
+Python arm of the t/3409 item-4 parity contract; PowerShell writes the mirror arm against the SAME
+fixture so both ports are proven identical (the `generator` provenance field is per-port and tolerated).
+Skips cleanly when the data repo is absent (formalize_node_lf loads entities.json at import)."""
+import importlib.util
+import json
+import os
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_FIXTURE = os.path.join(_HERE, "..", "analyses", "t3389-option-c", "optionc-parity-fixture.json")
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("flf", os.path.join(_HERE, "formalize_node_lf.py"))
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except (FileNotFoundError, OSError) as e:
+        pytest.skip(f"data repo not available for formalize_node_lf import: {e}")
+    return mod
+
+
+flf = _load_module()
+_FIX = json.load(open(_FIXTURE, encoding="utf-8"))
+_ALLOWED = {ref: (v["sort"], v["match_level"]) for ref, v in _FIX["allowlist"].items()}
+_PARITY = _FIX["_meta"]["provenance_parity_fields"]
+_PROV = _FIX["_meta"]["provenance_expected"]
+
+
+def _run(about):
+    lf = {"predicate": "x", "args": [], "about": about, "polarity": "positive",
+          "temporal": {"type": "unspecified", "value": None}, "formalization_confidence": 0.9}
+    return flf.validate(lf, dict(_ALLOWED), _FIX["_meta"]["camp"], _FIX["_meta"]["category"])
+
+
+@pytest.mark.parametrize("case", _FIX["cases"], ids=[c["name"] for c in _FIX["cases"]])
+def test_python_matches_parity_fixture(case):
+    lf = _run([dict(a) for a in case["input_about"]])
+
+    # about[] membership: ref + match_level, order-insensitive
+    got_about = sorted((a["ref"], a["match_level"]) for a in lf["about"])
+    exp_about = sorted((a["ref"], a["match_level"]) for a in case["expected_about"])
+    assert got_about == exp_about, f"{case['name']}: about[] mismatch"
+
+    exp_tc = case["expected_topical_candidates_refs"]
+    if exp_tc is None:
+        assert "topical_candidates" not in lf, f"{case['name']}: topical_candidates must be ABSENT (not null)"
+    else:
+        tc = lf["topical_candidates"]
+        got_refs = sorted((r["ref"], r["match_level"]) for r in tc["refs"])
+        assert got_refs == sorted((r["ref"], r["match_level"]) for r in exp_tc), f"{case['name']}: topical_candidates.refs mismatch"
+        # provenance parity fields (generator is tolerated/per-port, not asserted here)
+        for f in _PARITY:
+            assert tc[f] == _PROV[f], f"{case['name']}: provenance.{f} mismatch"
+
+
+def test_generator_field_is_python_identity():
+    """The one tolerated field: Python's generator identity (PS asserts its own)."""
+    tc = _run([{"ref": "term:regulation_precautionary", "match_level": "universal"}])["topical_candidates"]
+    assert tc["generator"] == "formalize_node_lf.py"


### PR DESCRIPTION
Shared cross-port parity contract for the about[]->about[]+topical_candidates split. Fixture (5 cases + allowlist + parity/tolerated-field contract) + the Python arm validating it against the landed #2078 validate() (6 passed). PowerShell writes the mirror arm against the same fixture. Test/fixture only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)