### PR TITLE
feat(debate): surface steelman_vulnerability in plan-stage context (t/3405)

### DIFF
--- a/lib/debate/taxonomyContext.ts
+++ b/lib/debate/taxonomyContext.ts
@@ -310,6 +310,11 @@ export function formatTaxonomyContext(ctx: TaxonomyContext, pov: string, maxNode
         const weightLabel = nodeWeightLabel(n, cat);
         lines.push(`${prefix}[${n.id}]${weightLabel}`);
         lines.push(`  "${n.label}" — ${stripExcludes(cfg.syntheticPhraseOverrides?.get(n.id) ?? n.description)}`);
+        const sv = n.graph_attributes?.steelman_vulnerability;
+        if (sv) {
+          const svText = typeof sv === 'string' ? sv : Object.values(sv).filter(Boolean).join(' | ');
+          if (svText) lines.push(`  Vulnerability: ${svText}`);
+        }
         // t/3269: classifications are always AI-generated — drop by default until
         // a classification-level verified signal exists.
       } else {


### PR DESCRIPTION
Surfaces `steelman_vulnerability` in the plan-stage context so the debater can ground ATTACK-type `anticipated_challenges` in pre-computed per-node vulnerabilities rather than free-generating them.

## Change
`lib/debate/taxonomyContext.ts`: add `Vulnerability:` line for primary nodes in `formatTaxonomyContext` (inside `isPrimary` block, after description). Handles both `string` (legacy, pre-Phase-6c) and per-POV object shapes. Non-primary nodes unchanged.

## What was missing
`generateNodeGuidance()` and `formatNodeAttributes()` both render `steelman_vulnerability`, but neither is called by `formatTaxonomyContext`. The FIELD-AWARE STRATEGY envelope block also omits the field. This PR wires the field into the context; CL's follow-up adds the prompt instruction.

## Test
18/18 taxonomyContext tests pass. 3 failures in full run are pre-existing live-AI network flakes (rate limits), unrelated to this change.

Self-certifying under /trivial-change: 5 lines, single file, no new API, no interface changes.

Closes t/3405 (DebateTool half)
