### PR TITLE
feat(fol-eval): contradiction + paraphrase FN-rate (§8, make-or-break metric) — Increment 5 (t/3354)

### DIFF
--- a/scripts/fol-eval-contradict.ps1
+++ b/scripts/fol-eval-contradict.ps1
@@ -1,0 +1,266 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    FOL-on-debate eval — CONTRADICTION detection + the paraphrase FALSE-NEGATIVE RATE (design §8). Increment 5.
+.DESCRIPTION
+    The design's MAKE-OR-BREAK primary metric. Two things:
+
+    1. A structural contradiction/agreement detector over neo-Davidsonian logical forms (pure): two
+       clause logical forms stand in a relation on a SHARED predication when their (normalized) predicate
+       matches and their participant sets overlap — 'contradict' when polarities differ, 'agree' when they
+       match, else 'neutral'. Applied intra-debate cross-AGENT (different speakers) over the run's
+       formalized clauses (design §8 direction ii — shared-predicate contradictions confirmed on real data).
+
+    2. The paraphrase FALSE-NEGATIVE RATE (design §8, THE make-or-break metric). One underlying predicate
+       surfaces in ≥5 forms ("protects them" / "pull up the drawbridge" / "corporate moats" / …). WITHOUT
+       predicate+entity normalization, structural matching misses these (each has a different raw predicate)
+       — real disagreements go undetected (false negatives). Measure-ParaphraseFnRate scores a labeled
+       fixture WITH and WITHOUT the normalization pass so the normalization's value is ISOLATED (the gap).
+
+    Everything here is PURE (no AI, no I/O) and dot-source unit-tested. The detector emits raw contradictions
+    AND the labeled FN set; nothing anchors a conclusion until CL double-annotates (design §11, §12).
+.LINK
+    fol-eval-fol.ps1
+.LINK
+    run-fol-debate-eval.ps1
+#>
+
+Set-StrictMode -Version Latest
+
+function Get-NormalizedPredicate {
+    <#
+    .SYNOPSIS
+        Canonicalize a predicate: case-fold + apply the predicate normalization map. Pure.
+    .DESCRIPTION
+        The normalization map (from the FN fixture / a future synonym resource) maps a raw predicate to a
+        canonical predicate; an unmapped predicate normalizes to its lowercased self. This is the single
+        chokepoint the WITH/WITHOUT-normalization comparison toggles (pass an empty map for "without").
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [AllowNull()][AllowEmptyString()][string]$Predicate,
+        [hashtable]$NormalizationMap = @{}
+    )
+    Set-StrictMode -Version Latest
+    if ([string]::IsNullOrWhiteSpace($Predicate)) { return '' }
+    $p = $Predicate.Trim().ToLowerInvariant()
+    if ($NormalizationMap.ContainsKey($p)) { return [string]$NormalizationMap[$p] }
+    return $p
+}
+
+function Get-FolParticipantKeys {
+    <#
+    .SYNOPSIS
+        The normalized participant set of a logical form: arg refs (lit: stripped) ∪ about refs, lowercased. Pure.
+    .DESCRIPTION
+        Debate-clause args are all lit:"surface phrase" (no entity_refs), so participants are surface
+        tokens; about[] may carry ent ids. Used to require participant OVERLAP before calling two clauses
+        the "same predication" — predicate match alone over-fires.
+    #>
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param([Parameter(Mandatory)]$LogicalForm)
+    Set-StrictMode -Version Latest
+    $keys = [System.Collections.Generic.HashSet[string]]::new()
+    if ($LogicalForm.PSObject.Properties['args'] -and $LogicalForm.args) {
+        foreach ($a in @($LogicalForm.args)) {
+            if ($a.PSObject.Properties['ref'] -and $a.ref) {
+                $ref = [string]$a.ref
+                $ref = $ref -replace '^lit:', ''
+                $ref = $ref.Trim().Trim('"').ToLowerInvariant()
+                if (-not [string]::IsNullOrWhiteSpace($ref)) { [void]$keys.Add($ref) }
+            }
+        }
+    }
+    if ($LogicalForm.PSObject.Properties['about'] -and $LogicalForm.about) {
+        foreach ($ab in @($LogicalForm.about)) {
+            if ($ab.PSObject.Properties['ref'] -and $ab.ref) {
+                $r = [string]$ab.ref
+                $r = $r.Trim().Trim('"').ToLowerInvariant()
+                if (-not [string]::IsNullOrWhiteSpace($r)) { [void]$keys.Add($r) }
+            }
+        }
+    }
+    return @($keys)
+}
+
+function Get-FolPolarity {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param([Parameter(Mandatory)]$LogicalForm)
+    Set-StrictMode -Version Latest
+    if ($LogicalForm.PSObject.Properties['polarity'] -and $LogicalForm.polarity) { return ([string]$LogicalForm.polarity).Trim().ToLowerInvariant() }
+    return 'positive'
+}
+
+function Test-FolClausePair {
+    <#
+    .SYNOPSIS
+        Relation between two clause logical forms on a shared predication (design §8). Pure.
+    .OUTPUTS
+        'contradict' | 'agree' | 'neutral'.
+        contradict = same normalized predicate + overlapping participants + OPPOSITE polarity.
+        agree      = same normalized predicate + overlapping participants + SAME polarity.
+        neutral    = otherwise (different predicate, or disjoint participants).
+    .DESCRIPTION
+        Participant overlap is required unless BOTH forms are participant-less (a bare predication) — this
+        keeps predicate-only coincidences from firing as contradictions. Normalization is applied to the
+        predicate via -NormalizationMap; pass an empty map for the WITHOUT-normalization arm.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]$LfA,
+        [Parameter(Mandatory)]$LfB,
+        [hashtable]$NormalizationMap = @{}
+    )
+    Set-StrictMode -Version Latest
+    $predA = Get-NormalizedPredicate -Predicate ([string]$LfA.predicate) -NormalizationMap $NormalizationMap
+    $predB = Get-NormalizedPredicate -Predicate ([string]$LfB.predicate) -NormalizationMap $NormalizationMap
+    if ([string]::IsNullOrWhiteSpace($predA) -or $predA -ne $predB) { return 'neutral' }
+
+    $keysA = @(Get-FolParticipantKeys -LogicalForm $LfA)
+    $keysB = @(Get-FolParticipantKeys -LogicalForm $LfB)
+    $overlap = $false
+    if ($keysA.Count -eq 0 -and $keysB.Count -eq 0) { $overlap = $true }       # bare predication vs bare predication
+    else {
+        foreach ($k in $keysA) { if ($keysB -contains $k) { $overlap = $true; break } }
+    }
+    if (-not $overlap) { return 'neutral' }
+
+    if ((Get-FolPolarity -LogicalForm $LfA) -ne (Get-FolPolarity -LogicalForm $LfB)) { return 'contradict' }
+    return 'agree'
+}
+
+function Find-IntraDebateContradictions {
+    <#
+    .SYNOPSIS
+        Cross-AGENT contradiction/agreement pairs within each debate over the formalized clauses (§8 ii). Pure.
+    .DESCRIPTION
+        Considers only clauses with fol_status 'formalized' (a real logical_form). Pairs are within one
+        debate and between DIFFERENT speakers (cross-agent — a debater agreeing with themselves is not the
+        signal). SpeakerMap keys "<debate_id>|<turn_index>" -> speaker; a clause with no speaker mapping is
+        treated as speaker '' and still compared (never silently dropped) — but same-'' pairs are excluded
+        as not-provably-cross-agent. Returns the contradict + agree pairs (neutral omitted).
+    .PARAMETER Formalized
+        The formalized clauses (from ConvertTo-FolClauseFormalized).
+    .PARAMETER SpeakerMap
+        Hashtable "<debate_id>|<turn_index>" -> speaker.
+    .PARAMETER NormalizationMap
+        Predicate normalization map; empty = the WITHOUT-normalization arm.
+    #>
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Formalized,
+        [Parameter(Mandatory)][hashtable]$SpeakerMap,
+        [hashtable]$NormalizationMap = @{}
+    )
+    Set-StrictMode -Version Latest
+    $out = [System.Collections.Generic.List[object]]::new()
+    $withLf = @($Formalized | Where-Object { [string]$_.fol_status -eq 'formalized' -and $_.logical_form })
+
+    # Group by debate.
+    $byDebate = @{}
+    foreach ($c in $withLf) {
+        $d = [string]$c.debate_id
+        if (-not $byDebate.ContainsKey($d)) { $byDebate[$d] = [System.Collections.Generic.List[object]]::new() }
+        $byDebate[$d].Add($c)
+    }
+
+    foreach ($d in $byDebate.Keys) {
+        $clauses = @($byDebate[$d])
+        for ($i = 0; $i -lt $clauses.Count; $i++) {
+            for ($j = $i + 1; $j -lt $clauses.Count; $j++) {
+                $a = $clauses[$i]; $b = $clauses[$j]
+                $spkA = if ($SpeakerMap.ContainsKey("$d|$($a.turn_index)")) { [string]$SpeakerMap["$d|$($a.turn_index)"] } else { '' }
+                $spkB = if ($SpeakerMap.ContainsKey("$d|$($b.turn_index)")) { [string]$SpeakerMap["$d|$($b.turn_index)"] } else { '' }
+                # cross-agent only: distinct, non-empty speakers.
+                if ($spkA -eq '' -or $spkB -eq '' -or $spkA -eq $spkB) { continue }
+                $rel = Test-FolClausePair -LfA $a.logical_form -LfB $b.logical_form -NormalizationMap $NormalizationMap
+                if ($rel -eq 'neutral') { continue }
+                $out.Add([PSCustomObject]@{
+                        debate_id   = $d
+                        id_a        = [string]$a.id
+                        id_b        = [string]$b.id
+                        speaker_a   = $spkA
+                        speaker_b   = $spkB
+                        predicate_a = [string]$a.logical_form.predicate
+                        predicate_b = [string]$b.logical_form.predicate
+                        relation    = $rel
+                    })
+            }
+        }
+    }
+    return @($out)
+}
+
+function Measure-ParaphraseFnRate {
+    <#
+    .SYNOPSIS
+        The make-or-break metric (design §8): paraphrase false-negative rate WITH vs WITHOUT normalization. Pure.
+    .DESCRIPTION
+        For each fixture case, every surface form shares ONE canonical predicate (gold: all pairs SHOULD
+        match). A pair "matches" when the two forms' normalized raw_predicate are equal. WITHOUT normalization
+        uses an empty map (raw predicates differ -> misses -> false negatives); WITH normalization applies the
+        case's normalization_map (all -> canonical -> matches). The FN-rate is missed-gold-pairs / gold-pairs;
+        the WITHOUT−WITH gap isolates the normalization's value.
+    .PARAMETER Fixture
+        Parsed fixture: { cases: [ { canonical_predicate, surface_forms:[{text, raw_predicate}], normalization_map } ] }.
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param([Parameter(Mandatory)]$Fixture)
+    Set-StrictMode -Version Latest
+
+    $cases = @()
+    if ($Fixture.PSObject.Properties['cases'] -and $Fixture.cases) { $cases = @($Fixture.cases) }
+
+    $perCase = [System.Collections.Generic.List[object]]::new()
+    $totalPairs = 0; $rawMissed = 0; $normMissed = 0
+
+    foreach ($case in $cases) {
+        $forms = @($case.surface_forms)
+        # Build the case normalization map (PSCustomObject from JSON -> hashtable).
+        $map = @{}
+        if ($case.PSObject.Properties['normalization_map'] -and $case.normalization_map) {
+            foreach ($p in $case.normalization_map.PSObject.Properties) { $map[$p.Name.ToLowerInvariant()] = [string]$p.Value }
+        }
+        $casePairs = 0; $caseRawMissed = 0; $caseNormMissed = 0
+        for ($i = 0; $i -lt $forms.Count; $i++) {
+            for ($j = $i + 1; $j -lt $forms.Count; $j++) {
+                $casePairs++
+                $rawA = Get-NormalizedPredicate -Predicate ([string]$forms[$i].raw_predicate) -NormalizationMap @{}
+                $rawB = Get-NormalizedPredicate -Predicate ([string]$forms[$j].raw_predicate) -NormalizationMap @{}
+                if ($rawA -ne $rawB) { $caseRawMissed++ }    # gold says match; raw missed it -> false negative
+                $nA = Get-NormalizedPredicate -Predicate ([string]$forms[$i].raw_predicate) -NormalizationMap $map
+                $nB = Get-NormalizedPredicate -Predicate ([string]$forms[$j].raw_predicate) -NormalizationMap $map
+                if ($nA -ne $nB) { $caseNormMissed++ }
+            }
+        }
+        $perCase.Add([PSCustomObject]@{
+                canonical_predicate = [string]$case.canonical_predicate
+                surface_form_count  = $forms.Count
+                gold_pairs          = $casePairs
+                raw_missed          = $caseRawMissed
+                normalized_missed   = $caseNormMissed
+                raw_fn_rate         = if ($casePairs -gt 0) { [Math]::Round($caseRawMissed / [double]$casePairs, 4) } else { 0.0 }
+                normalized_fn_rate  = if ($casePairs -gt 0) { [Math]::Round($caseNormMissed / [double]$casePairs, 4) } else { 0.0 }
+            })
+        $totalPairs += $casePairs; $rawMissed += $caseRawMissed; $normMissed += $caseNormMissed
+    }
+
+    $rawRate = if ($totalPairs -gt 0) { [Math]::Round($rawMissed / [double]$totalPairs, 4) } else { 0.0 }
+    $normRate = if ($totalPairs -gt 0) { [Math]::Round($normMissed / [double]$totalPairs, 4) } else { 0.0 }
+    return [PSCustomObject]@{
+        cases                 = $cases.Count
+        gold_pairs            = $totalPairs
+        raw_fn_rate           = $rawRate
+        normalized_fn_rate    = $normRate
+        normalization_gap     = [Math]::Round($rawRate - $normRate, 4)
+        per_case              = @($perCase)
+    }
+}

--- a/scripts/fol-eval-fn-fixture.json
+++ b/scripts/fol-eval-fn-fixture.json
@@ -1,0 +1,24 @@
+{
+  "_doc": "Canonical paraphrase false-negative fixture for the FOL-on-debate eval (t/3354 design §8, the make-or-break primary metric). ONE underlying predicate surfaces in five forms; without predicate+entity normalization, structural FOL matching misses them (each has a different raw predicate) = false negatives. Measure-ParaphraseFnRate scores this WITHOUT vs WITH the normalization_map so the normalization's value is isolated. Single-annotator, ILLUSTRATIVE — the surface forms are the co-signed design's example set; CL replaces raw_predicate labels + the map with the authoritative double-annotated set (design §11). No number here anchors a threshold.",
+  "_provenance": "surface forms: design §8 (fol-eval-design.md); raw_predicate labels: single-annotator first-pass by PowerShell 2, pending CL.",
+  "cases": [
+    {
+      "canonical_predicate": "protect-incumbents",
+      "note": "The accelerationist/skeptic 'caps entrench incumbents' claim, five surface forms across the sample turns.",
+      "surface_forms": [
+        { "text": "the caps protect them", "raw_predicate": "protect" },
+        { "text": "they pull up the drawbridge", "raw_predicate": "pull-up-drawbridge" },
+        { "text": "it builds corporate moats", "raw_predicate": "build-moat" },
+        { "text": "an exclusive federal licensing club", "raw_predicate": "license-exclude" },
+        { "text": "an incumbent compliance cartel", "raw_predicate": "cartelize" }
+      ],
+      "normalization_map": {
+        "protect": "protect-incumbents",
+        "pull-up-drawbridge": "protect-incumbents",
+        "build-moat": "protect-incumbents",
+        "license-exclude": "protect-incumbents",
+        "cartelize": "protect-incumbents"
+      }
+    }
+  ]
+}

--- a/scripts/run-fol-debate-eval.ps1
+++ b/scripts/run-fol-debate-eval.ps1
@@ -18,10 +18,12 @@
     CLASSIFY (§3, AI clause classifier, fol-eval-classify.ps1), COREF (§6, the hard prerequisite,
     fol-eval-coref.ps1 — resolves cross-turn deps on the assertoric subset + reports coverage loss),
     FOL (§7, fol-eval-fol.ps1 — neo-Davidsonian formalization of the resolved usable subset, REUSING the
-    LogicalFormPass core via module session state, no fork, so it is shape-identical to the summary FOL corpus).
-    Classifier + coref are INSTRUMENT-PROVISIONAL (§5/t/3342): the §3.3 distribution and §6 coverage are
-    measurement reports, not gates — nothing anchors a conclusion until CL scores the blind gold set.
-    The contradiction/FN-rate/correlation stages are NOT implemented yet and throw (honest failure).
+    LogicalFormPass core via module session state, no fork, so it is shape-identical to the summary FOL corpus),
+    CONTRADICTION + FN-rate (§8, fol-eval-contradict.ps1 — structural intra-debate cross-agent contradiction
+    detection + the make-or-break paraphrase false-negative rate, scored WITH vs WITHOUT normalization).
+    Classifier + coref are INSTRUMENT-PROVISIONAL (§5/t/3342); the §8 numbers are measurement reports, not
+    gates — no number anchors a conclusion until CL double-annotates (§11/§12).
+    The summary-corpus direction (§8 i) + §9 correlation outputs are NOT implemented yet and throw (honest failure).
     Runnable paths without a model call: -DryRun (plan+manifest) and -SkipClassify (segment only).
 
     READ-ONLY (design §1, TL tightening e/141#8): the harness writes NOTHING under the data
@@ -96,6 +98,9 @@ param(
     [int]$MaxContextTurns = 12,
 
     [Parameter()]
+    [string]$FnFixturePath,
+
+    [Parameter()]
     [switch]$DryRun
 )
 
@@ -111,6 +116,7 @@ if (-not $Mod) { throw 'AITriad module failed to load; cannot resolve data-root 
 . (Join-Path $PSScriptRoot 'fol-eval-classify.ps1')
 . (Join-Path $PSScriptRoot 'fol-eval-coref.ps1')
 . (Join-Path $PSScriptRoot 'fol-eval-fol.ps1')
+. (Join-Path $PSScriptRoot 'fol-eval-contradict.ps1')
 
 # Get-Prompt is a module-PRIVATE helper (Import-Module does not expose it), so the classifier/coref
 # Get-Prompt calls would fail with 'not recognized'. Dot-source it + set $script:ModuleRoot so its
@@ -164,7 +170,8 @@ foreach ($f in $allFiles) {
             $turnIndex++
             if ($turn.PSObject.Properties['type'] -and $turn.type -eq 'statement' -and
                 $turn.PSObject.Properties['content'] -and $turn.content) {
-                $statements.Add([PSCustomObject]@{ turn_index = $turnIndex; content = [string]$turn.content })
+                $speaker = if ($turn.PSObject.Properties['speaker'] -and $turn.speaker) { [string]$turn.speaker } else { '' }
+                $statements.Add([PSCustomObject]@{ turn_index = $turnIndex; content = [string]$turn.content; speaker = $speaker })
             }
         }
     }
@@ -206,8 +213,9 @@ $manifest = [ordered]@{
     classify_batch_size    = $ClassifyBatchSize
     coref_batch_size       = $CorefBatchSize
     max_context_turns      = $MaxContextTurns
-    stages_implemented     = @('load', 'run-bound', 'manifest', 'segment', 'classify', 'coref', 'fol')
-    stages_pending_pairing = @('contradiction', 'fn-rate', 'correlate')
+    fn_fixture             = $FnFixturePath
+    stages_implemented     = @('load', 'run-bound', 'manifest', 'segment', 'classify', 'coref', 'fol', 'contradiction', 'fn-rate')
+    stages_pending_pairing = @('summary-corpus-direction', 'correlate')
 }
 
 Write-Host ''
@@ -353,8 +361,62 @@ if ($folStats.attempted -gt 0 -and $folStats.formalized_count -eq 0) {
     Write-Warning 'FOL: no clause formalized — the backend returned nothing (missing key / model?). formalized-clauses.jsonl was still emitted so the run is inspectable; no logical_form is present.'
 }
 
-# ── CONTRADICTION + paraphrase FN-rate (design §8) — later increment, NOT implemented ────────
+# ── CONTRADICTION + paraphrase FN-rate stage (design §8) — Increment 5, the MAKE-OR-BREAK metric ──
+# (a) Intra-debate cross-AGENT contradiction/agreement over the formalized clauses (direction ii), run
+#     BOTH raw (no normalization) and normalized so the normalization delta is visible on real data.
+# (b) The paraphrase FALSE-NEGATIVE RATE against the canonical fixture (one predicate / five surface forms),
+#     scored WITH and WITHOUT the predicate normalization pass so its value is isolated (the design's
+#     make-or-break metric). All pure/structural — no model call. Direction (i) vs the summary corpus and
+#     the §9 correlation outputs are the next increment.
+Write-Host ''
+Write-Host '=== CONTRADICTION + FN-rate stage (design §8) — structural, no model call ===' -ForegroundColor Cyan
+
+# Speaker map (debate_id|turn_index -> speaker) for the cross-agent constraint.
+$speakerMap = @{}
+foreach ($deb in $selected) {
+    foreach ($st in $deb.Statements) {
+        $sp = if ($st.PSObject.Properties['speaker']) { [string]$st.speaker } else { '' }
+        $speakerMap["$($deb.DebateId)|$($st.turn_index)"] = $sp
+    }
+}
+
+# Load the FN fixture (read-only; code-repo file, not the data root) + derive the run-level normalization map.
+if (-not $FnFixturePath) { $FnFixturePath = Join-Path $PSScriptRoot 'fol-eval-fn-fixture.json' }
+$normMap = @{}
+$fnFixture = $null
+if (Test-Path -LiteralPath $FnFixturePath) {
+    $fnFixture = Get-Content -Raw -LiteralPath $FnFixturePath | ConvertFrom-Json
+    foreach ($case in @($fnFixture.cases)) {
+        if ($case.PSObject.Properties['normalization_map'] -and $case.normalization_map) {
+            foreach ($p in $case.normalization_map.PSObject.Properties) { $normMap[$p.Name.ToLowerInvariant()] = [string]$p.Value }
+        }
+    }
+}
+else {
+    Write-Warning "CONTRADICTION: FN fixture not found ($FnFixturePath) — FN-rate report skipped; contradiction detection still runs with an empty normalization map."
+}
+
+# (a) Intra-debate cross-agent contradictions — raw vs normalized.
+$contraRaw = @(Find-IntraDebateContradictions -Formalized $formalized -SpeakerMap $speakerMap -NormalizationMap @{})
+$contraNorm = @(Find-IntraDebateContradictions -Formalized $formalized -SpeakerMap $speakerMap -NormalizationMap $normMap)
+$contraPath = Join-Path $resolvedOut 'contradictions.jsonl'
+Set-Content -LiteralPath $contraPath -Value @($contraNorm | ForEach-Object { $_ | ConvertTo-Json -Depth 4 -Compress }) -Encoding utf8
+$rawContraN = @($contraRaw | Where-Object { $_.relation -eq 'contradict' }).Count
+$normContraN = @($contraNorm | Where-Object { $_.relation -eq 'contradict' }).Count
+$normAgreeN = @($contraNorm | Where-Object { $_.relation -eq 'agree' }).Count
+Write-Host "  Intra-debate cross-agent pairs (formalized): contradict raw=$rawContraN normalized=$normContraN; agree normalized=$normAgreeN -> $contraPath" -ForegroundColor White
+
+# (b) Paraphrase FN-rate — the make-or-break metric.
+if ($null -ne $fnFixture) {
+    $fn = Measure-ParaphraseFnRate -Fixture $fnFixture
+    $fnPath = Join-Path $resolvedOut 'fn-rate-report.json'
+    $fn | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $fnPath -Encoding utf8
+    Write-Host "  Paraphrase FN-rate (fixture, $($fn.gold_pairs) gold pairs): WITHOUT normalization $($fn.raw_fn_rate)  ->  WITH normalization $($fn.normalized_fn_rate)  (gap $($fn.normalization_gap)) -> $fnPath" -ForegroundColor White
+    Write-Host '  (INSTRUMENT-PROVISIONAL — illustrative single-annotator fixture; no number anchors a threshold until CL double-annotates, design §11/§12.)' -ForegroundColor DarkGray
+}
+
+# ── DIRECTION (i) vs summary corpus + CORRELATION outputs (design §8 i / §9) — next increment ──
 throw (New-EvalError `
     'Run the full FOL-on-debate eval pipeline' `
-    "SEGMENT + CLASSIFY + COREF + FOL ran (formalized-clauses.jsonl emitted; $($folStats.formalized_count) logical forms of $($folStats.attempted) attempted) but the contradiction/FN-rate/correlation stages are not yet implemented." `
-    'Inspect formalized-clauses.jsonl now (or use -DryRun / -SkipClassify). Contradiction + paraphrase FN-rate (design §8, the make-or-break primary metric) is the next increment; correlation outputs (§9) follow.')
+    "SEGMENT + CLASSIFY + COREF + FOL + CONTRADICTION/FN-rate ran (contradictions.jsonl + fn-rate-report.json emitted; intra-debate contradict normalized=$normContraN) but the summary-corpus direction (i) and the §9 correlation outputs are not yet implemented." `
+    'Inspect contradictions.jsonl + fn-rate-report.json now. Direction (i) — contradiction vs the formalized POV summary corpus — plus the §9 correlation join (CL convergence metrics; optional conflict corpus) is the final increment.')

--- a/tests/DataWriteSinkGuard.Tests.ps1
+++ b/tests/DataWriteSinkGuard.Tests.ps1
@@ -59,7 +59,7 @@ BeforeAll {
         'scripts/AITriad/Public/New-SyntheticCorpus.ps1'   = 'append-checkpoint + fresh corpus generation + NEW metadata (not a whole-file data rewrite)'
         'scripts/AITriad/Public/Test-DebatePersistence.ps1' = 'writes a random persist-probe .tmp (test probe, non-data)'
         'scripts/AITriad/Private/AICallLog.ps1'            = 'append-only AI call-log JSONL (Add-Content); references Get-DataRoot only to locate the log file — never read-mutate-rewrites a data-of-record file (t/3241)'
-        'scripts/run-fol-debate-eval.ps1'                  = 'read-only FOL-on-debate eval harness (t/3354); Set-Content writes only run-manifest.json + clauses.jsonl + classified-clauses.jsonl + resolved-clauses.jsonl + formalized-clauses.jsonl to -OutputDir, which is fail-closed asserted OUTSIDE the data root via Test-IsUnderDataRoot (design §1) — references data tokens (debates/summaries/conflicts) as read-only inputs, never writes ../ai-triad-data'
+        'scripts/run-fol-debate-eval.ps1'                  = 'read-only FOL-on-debate eval harness (t/3354); Set-Content writes only run-manifest.json + clauses.jsonl + classified-clauses.jsonl + resolved-clauses.jsonl + formalized-clauses.jsonl + contradictions.jsonl + fn-rate-report.json to -OutputDir, which is fail-closed asserted OUTSIDE the data root via Test-IsUnderDataRoot (design §1) — references data tokens (debates/summaries/conflicts) as read-only inputs, never writes ../ai-triad-data'
     }
 
     # A data-of-record path token (basename or data-dir accessor). Kept specific so

--- a/tests/FolDebateContradict.Tests.ps1
+++ b/tests/FolDebateContradict.Tests.ps1
@@ -1,0 +1,108 @@
+# Tag: qbaf (t/3354 — FOL-on-debate eval contradiction + paraphrase FN-rate, design §8)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Tests for the FOL-on-debate contradiction + FN-rate PURE transforms (scripts/fol-eval-contradict.ps1, §8).
+.DESCRIPTION
+    Everything in this stage is pure (no AI, no I/O): the structural detector (Test-FolClausePair /
+    Find-IntraDebateContradictions) and the make-or-break paraphrase FN-rate (Measure-ParaphraseFnRate).
+    The tests dot-source the library and exercise them directly, including the WITH/WITHOUT-normalization
+    delta that is the design's headline (§8).
+#>
+
+BeforeAll {
+    . "$PSScriptRoot/../scripts/fol-eval-contradict.ps1"
+    function New-Lf { param($pred, $args_, $pol = 'positive')
+        [pscustomobject]@{ predicate = $pred; args = @($args_ | ForEach-Object { [pscustomobject]@{ role = 'patient'; ref = $_ } }); polarity = $pol; about = @() }
+    }
+}
+
+Describe 'Get-NormalizedPredicate' -Tag 'qbaf' {
+    It 'case-folds and applies the map; unmapped -> lowercased self' {
+        Get-NormalizedPredicate -Predicate 'Protect' -NormalizationMap @{ protect = 'P' } | Should -Be 'P'
+        Get-NormalizedPredicate -Predicate 'Cartelize' -NormalizationMap @{} | Should -Be 'cartelize'
+        Get-NormalizedPredicate -Predicate '' | Should -Be ''
+    }
+}
+
+Describe 'Test-FolClausePair — structural relation' -Tag 'qbaf' {
+    It 'contradict = same predicate + overlapping participants + opposite polarity' {
+        $a = New-Lf 'protect' @('lit:"incumbents"') 'positive'
+        $b = New-Lf 'protect' @('lit:"incumbents"') 'negative'
+        Test-FolClausePair -LfA $a -LfB $b | Should -Be 'contradict'
+    }
+    It 'agree = same predicate + overlapping participants + same polarity' {
+        $a = New-Lf 'protect' @('lit:"incumbents"') 'positive'
+        $b = New-Lf 'protect' @('lit:"consumers"', 'lit:"incumbents"') 'positive'
+        Test-FolClausePair -LfA $a -LfB $b | Should -Be 'agree'
+    }
+    It 'neutral = disjoint participants (predicate coincidence does not fire)' {
+        $a = New-Lf 'protect' @('lit:"incumbents"') 'positive'
+        $b = New-Lf 'protect' @('lit:"consumers"') 'negative'
+        Test-FolClausePair -LfA $a -LfB $b | Should -Be 'neutral'
+    }
+    It 'normalization can turn a raw-neutral (different predicate) pair into a contradiction' {
+        $a = New-Lf 'protect' @('lit:"incumbents"') 'positive'
+        $b = New-Lf 'cartelize' @('lit:"incumbents"') 'negative'
+        Test-FolClausePair -LfA $a -LfB $b -NormalizationMap @{} | Should -Be 'neutral'
+        Test-FolClausePair -LfA $a -LfB $b -NormalizationMap @{ protect = 'P'; cartelize = 'P' } | Should -Be 'contradict'
+    }
+}
+
+Describe 'Find-IntraDebateContradictions — cross-agent only, formalized only' -Tag 'qbaf' {
+    BeforeAll {
+        $script:formalized = @(
+            [pscustomobject]@{ id = 'd:t0:c0'; debate_id = 'd'; turn_index = 0; fol_status = 'formalized'; logical_form = (New-Lf 'protect' @('lit:"incumbents"') 'positive') }
+            [pscustomobject]@{ id = 'd:t1:c0'; debate_id = 'd'; turn_index = 1; fol_status = 'formalized'; logical_form = (New-Lf 'protect' @('lit:"incumbents"') 'negative') }
+            # same speaker as t0 (should NOT pair with t0)
+            [pscustomobject]@{ id = 'd:t2:c0'; debate_id = 'd'; turn_index = 2; fol_status = 'formalized'; logical_form = (New-Lf 'protect' @('lit:"incumbents"') 'negative') }
+            # not formalized -> excluded
+            [pscustomobject]@{ id = 'd:t3:c0'; debate_id = 'd'; turn_index = 3; fol_status = 'skipped-unresolved'; logical_form = $null }
+        )
+        $script:speakers = @{ 'd|0' = 'Accelerationist'; 'd|1' = 'Safetyist'; 'd|2' = 'Accelerationist'; 'd|3' = 'Skeptic' }
+    }
+
+    It 'finds the cross-agent contradiction (t0 acc vs t1 saf), not the same-agent pair (t0 vs t2)' {
+        $r = @(Find-IntraDebateContradictions -Formalized $formalized -SpeakerMap $speakers)
+        $contra = @($r | Where-Object { $_.relation -eq 'contradict' })
+        $contra.Count | Should -Be 1
+        $contra[0].id_a | Should -Be 'd:t0:c0'
+        $contra[0].id_b | Should -Be 'd:t1:c0'
+        $contra[0].speaker_a | Should -Be 'Accelerationist'
+        $contra[0].speaker_b | Should -Be 'Safetyist'
+    }
+    It 'excludes non-formalized clauses' {
+        $r = @(Find-IntraDebateContradictions -Formalized $formalized -SpeakerMap $speakers)
+        @($r | Where-Object { $_.id_a -eq 'd:t3:c0' -or $_.id_b -eq 'd:t3:c0' }).Count | Should -Be 0
+    }
+}
+
+Describe 'Measure-ParaphraseFnRate — the make-or-break metric' -Tag 'qbaf' {
+    It 'raw FN-rate 1.0 (all different predicates) drops to 0.0 with normalization' {
+        $fixture = [pscustomobject]@{ cases = @(
+                [pscustomobject]@{
+                    canonical_predicate = 'protect-incumbents'
+                    surface_forms       = @(
+                        [pscustomobject]@{ text = 'a'; raw_predicate = 'protect' }
+                        [pscustomobject]@{ text = 'b'; raw_predicate = 'cartelize' }
+                        [pscustomobject]@{ text = 'c'; raw_predicate = 'build-moat' }
+                    )
+                    normalization_map   = [pscustomobject]@{ protect = 'protect-incumbents'; cartelize = 'protect-incumbents'; 'build-moat' = 'protect-incumbents' }
+                }
+            ) }
+        $fn = Measure-ParaphraseFnRate -Fixture $fixture
+        $fn.gold_pairs | Should -Be 3          # C(3,2)
+        $fn.raw_fn_rate | Should -Be 1.0       # every pair missed without normalization
+        $fn.normalized_fn_rate | Should -Be 0.0
+        $fn.normalization_gap | Should -Be 1.0
+    }
+    It 'handles an empty fixture' {
+        $fn = Measure-ParaphraseFnRate -Fixture ([pscustomobject]@{ cases = @() })
+        $fn.gold_pairs | Should -Be 0
+        $fn.raw_fn_rate | Should -Be 0.0
+    }
+}


### PR DESCRIPTION
## Increment 5 — contradiction + paraphrase FN-rate (design §8, the make-or-break primary metric)

Sixth build increment of the offline FOL-on-debate eval harness (t/3354), after foundation (#2045), segmenter (#2081), classifier (#2086), coref (#2088), FOL (#2089). Implements the design's **make-or-break primary metric** — the paraphrase false-negative rate — plus structural intra-debate cross-agent contradiction detection (§8 direction ii).

### What lands
- **`scripts/fol-eval-contradict.ps1`** — PURE structural detector + FN-rate (no AI, no I/O):
  - `Test-FolClausePair` — relation on a shared predication: **contradict** = same normalized predicate + overlapping participants + opposite polarity; **agree** = same polarity; else **neutral**. Participant overlap required (predicate-only coincidences don't fire).
  - `Find-IntraDebateContradictions` — cross-**agent** pairs (distinct speakers) within a debate over the formalized clauses, run **raw and normalized**.
  - `Measure-ParaphraseFnRate` — the make-or-break metric: score a labeled fixture (one predicate / five surface forms) **WITHOUT vs WITH** the predicate normalization pass; the gap isolates normalization's value.
- **`scripts/fol-eval-fn-fixture.json`** — the canonical fixture (design §8 five surface forms). **Illustrative, single-annotator**, from the co-signed design examples; CL replaces with the authoritative double-annotated set (§11). No number anchors a threshold.
- **`run-fol-debate-eval.ps1`** — CONTRADICTION+FN-rate stage emits `contradictions.jsonl` + `fn-rate-report.json`, prints the WITHOUT→WITH FN-rate + gap, then throws at the pending summary-corpus direction (§8 i) + §9 correlation. Loader now carries `speaker` (the cross-agent constraint). New `-FnFixturePath`.
- Tests: **`FolDebateContradict.Tests.ps1`** (9 pure-transform cases incl. the raw-1.0 → normalized-0.0 delta); `DataWriteSinkGuard.Tests.ps1` exemption reason updated.

### Verification
- **42/42 Pester** green.
- Degraded **no-key** full run emits all seven artifacts and the FN-rate report: **raw 1.0 → normalized 0.0, gap 1.0** over 10 gold pairs — the make-or-break demonstration — then throws at summary-corpus/correlation.

### Scope / gates
Read-only over `../ai-triad-data` (§1); structural (no model call). No new prompt/usage → **no promptCatalog coupling**; no `ai-models.json`/schema change → no Second Opinion (t/3361). Numbers are measurement reports, not gates — nothing anchors a conclusion until CL double-annotates (§11/§12). **Next (final): summary-corpus direction (§8 i) + §9 correlation outputs**, which makes the pipeline run end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)