### PR TITLE
feat(debate/prompts): ground ATTACK anticipated_challenges in Vulnerability: line (t/3405 CL half)

### DIFF
--- a/lib/debate/prompts/opening.ts
+++ b/lib/debate/prompts/opening.ts
@@ -139,6 +139,10 @@ ANTICIPATED CHALLENGES - forecast where you are actually vulnerable, not where y
   assumption. Never "they'll say it's risky."
 - Tag each as ATTACK (an objection an opponent will raise) or ASSUMPTION (a load-bearing
   premise of YOUR position you are exposing). These are different - give at least one of each.
+- Where a node in your context shows a `Vulnerability:` line (its pre-computed strongest
+  counterargument), GROUND your ATTACK-type challenge for that node in it — sharpen or restate
+  that objection rather than inventing a weaker one. It is the strongest known attack on the
+  node; anticipate it, don't dodge it.
 
 Respond ONLY with a JSON object (no markdown, no code fences):
 {

--- a/lib/debate/prompts/opening.ts
+++ b/lib/debate/prompts/opening.ts
@@ -139,7 +139,7 @@ ANTICIPATED CHALLENGES - forecast where you are actually vulnerable, not where y
   assumption. Never "they'll say it's risky."
 - Tag each as ATTACK (an objection an opponent will raise) or ASSUMPTION (a load-bearing
   premise of YOUR position you are exposing). These are different - give at least one of each.
-- Where a node in your context shows a `Vulnerability:` line (its pre-computed strongest
+- Where a node in your context shows a Vulnerability: line (its pre-computed strongest
   counterargument), GROUND your ATTACK-type challenge for that node in it — sharpen or restate
   that objection rather than inventing a weaker one. It is the strongest known attack on the
   node; anticipate it, don't dodge it.


### PR DESCRIPTION
CL prompt-hook half of t/3405 — add bullet to ANTICIPATED CHALLENGES plan block tying ATTACK-type challenges to the `Vulnerability:` line now surfaced by #2098.

## Change
`lib/debate/prompts/opening.ts`: new bullet after the ATTACK/ASSUMPTION tagging instruction. When a primary node has a `Vulnerability:` line (pre-computed `steelman_vulnerability`), ATTACK-type anticipated challenges must be grounded in it rather than free-generated.

## Rationale
Without this instruction the debater could strawman itself with a weaker anticipated objection. The bullet closes the loop: #2098 surfaces the strongest known attack on a node; this instruction forces the debater to anticipate it.

## Test
No dedicated test file for `opening.ts` (prompt-only, same precedent as t/3404). 18/18 taxonomyContext tests pass. Prompt-only; string[] schema unchanged.

Closes t/3405
