### PR TITLE
feat(t3409): Option C phase-1 — LogicalFormPass accepts + emits topical_candidates + PS-Python parity

### DIFF
--- a/scripts/AITriad/Private/LogicalFormPass.ps1
+++ b/scripts/AITriad/Private/LogicalFormPass.ps1
@@ -28,6 +28,25 @@ $script:LogicalFormAttitudes     = @('belief', 'desire', 'intention')
 $script:LogicalFormPolarities    = @('positive', 'negative')
 $script:LogicalFormStatuses      = @('proposed', 'accepted', 'rejected')
 
+# ── Option C (t/3389; SO+TL signed e/145#13-#16) — topical_candidates ─────────────────────────────
+# The mixed-convention about[] missed the concept-anchored golden floor (0.636 < 0.80, t/3381), so
+# about[] reverts to ent-* only and term: concept refs move to `topical_candidates` — a quality-marked
+# layer whose provenance block makes the unvalidated status legible FROM THE DATA (a consumer sees
+# validated:false + the 0.54 blind-golden precision without reading the register). PHASE-1 is ADDITIVE:
+# the validator ACCEPTS the field and about[] stays term:-tolerant (the ^ent- tightening is phase-3,
+# post-migration — land-order is load-bearing, e/145#15/#16). Mirrors the Python reference (#2078).
+# Ref vocabulary is exactly ^(term:|ent-) (hyphenated ent-, the e/145#14 d2 spec-typo catch).
+$script:TopicalCandidateRefPattern = '^(term:|ent-)'
+# Provenance STAMPED BY THIS GENERATOR (e/145#14(c) lifecycle rule): a repaired generator (t/3390)
+# must UPDATE this block or revalidate-and-move the refs to about[] — never fresh refs under stale
+# 0.54 metadata. `generator` is this port's identity (distinct from the Python's formalize_node_lf.py).
+$script:TopicalCandidatesProvenance = [ordered]@{
+    validated              = $false
+    generator              = 'LogicalFormPass.ps1'
+    golden_ref             = 't/3381'
+    blind_golden_precision = 0.54
+}
+
 # Coercion map (t/3215#3, CL): full-DOLCE lit:/event sorts the model may still emit → the register's
 # 5-value DolceCategory. The prompt now enumerates the 5 (t/3126, 90ce0d3e), so this is a
 # defense-in-depth belt for RESIDUAL out-of-set lit:/event sorts — coerce to the nearest of the 5 and
@@ -164,8 +183,14 @@ function Get-LogicalFormRefTable {
         The claim's entity_refs[] (EntityLinkRef records). $null / empty tolerated.
     .PARAMETER DolceMap
         Output of Get-EntityDolceMap.
+    .PARAMETER ConceptRefs
+        The claim's concept_refs[] (term:* universals; t/3389 Option C). $null / empty tolerated. Each is
+        emitted as a grounding row with sort='universal' + match_level='exact' — the 6th arg-slot sort
+        (t/3251), mirroring the Python reference's `allowed[cid] = ("universal", "exact")` (#2078). These
+        are what the about[] split (ConvertTo-GroundedLogicalForm) routes into topical_candidates.
     .OUTPUTS
-        [pscustomobject[]] { ref; surface; match_level; sort } in the claim's entity_refs order.
+        [pscustomobject[]] { ref; surface; match_level; sort } — entity rows first (entity_refs order),
+        then concept rows (concept_refs order).
     #>
     [CmdletBinding()]
     [OutputType([System.Object[]])]
@@ -174,7 +199,10 @@ function Get-LogicalFormRefTable {
         $EntityRefs,
 
         [Parameter(Mandatory)]
-        [hashtable]$DolceMap
+        [hashtable]$DolceMap,
+
+        [AllowNull()]
+        $ConceptRefs
     )
     Set-StrictMode -Version Latest
 
@@ -187,6 +215,16 @@ function Get-LogicalFormRefTable {
         $surface = if ($r.PSObject.Properties['surface']) { [string]$r.surface } else { '' }
         $ml      = if ($r.PSObject.Properties['match_level']) { [string]$r.match_level } else { 'exact' }
         $rows.Add([pscustomobject]@{ ref = $ref; surface = $surface; match_level = $ml; sort = $DolceMap[$ref] })
+    }
+    # Concept refs (term:* universals, t/3389/t/3251): a concept is a UNIVERSAL (kind), sort='universal'
+    # (distinct from the 5 particular DolceCategory sorts), match_level='exact'. They ground the about[]
+    # split -> topical_candidates. Mirrors #2078. (Dormant on summaries today — 0 concept_refs there.)
+    foreach ($r in @($ConceptRefs)) {
+        if (-not $r -or -not $r.PSObject.Properties['ref']) { continue }
+        $ref = [string]$r.ref
+        if ([string]::IsNullOrWhiteSpace($ref)) { continue }
+        $surface = if ($r.PSObject.Properties['surface']) { [string]$r.surface } else { '' }
+        $rows.Add([pscustomobject]@{ ref = $ref; surface = $surface; match_level = 'exact'; sort = 'universal' })
     }
     return $rows.ToArray()
 }
@@ -339,17 +377,39 @@ function ConvertTo-GroundedLogicalForm {
         }
     }
 
-    # ── about[]: projection of already-resolved entity_refs (ent-* only, no lits, no new resolution) ──
+    # ── about[] / topical_candidates: Option C split (t/3389, e/145#13-#16; mirrors #2078) ────────────
+    # Grounded refs only (in the claim's entity_refs/concept_refs = $byRef) — R6/t/2294, never mint.
+    # ent-* -> about[]; term:* concept refs -> topical_candidates.refs (about[] reverts to ent-only for
+    # NEW generations; concept refs carry the topical signal under a quality-marked provenance block).
+    # match_level is copied authoritatively from the register (enum-clamped so a concept's universal sort
+    # can never leak into match_level, t/3379) — never the model's guess.
     $groundedAbout = [System.Collections.Generic.List[object]]::new()
+    $candidateRefs = [System.Collections.Generic.List[object]]::new()
     if ($Raw.PSObject.Properties['about'] -and $Raw.about) {
         foreach ($ab in @($Raw.about)) {
             if (-not $ab -or -not $ab.PSObject.Properties['ref']) { continue }
             $ref = [string]$ab.ref
-            if (-not ($ref -like 'ent-*') -or -not $byRef.ContainsKey($ref)) {
-                Write-Verbose "LogicalForm: dropped about ref '$ref' — about[] projects the claim's entity_refs only."
+            if (-not $byRef.ContainsKey($ref)) {
+                Write-Verbose "LogicalForm: dropped about ref '$ref' — not grounded in the claim's refs (R6)."
                 continue
             }
-            $groundedAbout.Add([ordered]@{ ref = $ref; match_level = [string]$byRef[$ref].match_level })
+            $ml = [string]$byRef[$ref].match_level
+            if ($ml -notin $script:LogicalFormMatchLevels) { $ml = 'exact' }
+            $entry = [ordered]@{ ref = $ref; match_level = $ml }
+            if ($ref -like 'ent-*') { $groundedAbout.Add($entry) }
+            else { $candidateRefs.Add($entry) }   # term:* concept ref -> topical_candidates
+        }
+    }
+    # topical_candidates present ONLY when concept refs exist (absent != null, t/2943). Provenance is
+    # stamped FRESH by this generator each call (e/145#14(c) lifecycle rule — never a shared/stale ref).
+    $topicalCandidates = $null
+    if ($candidateRefs.Count -gt 0) {
+        $topicalCandidates = [ordered]@{
+            validated              = $script:TopicalCandidatesProvenance.validated
+            generator              = $script:TopicalCandidatesProvenance.generator
+            golden_ref             = $script:TopicalCandidatesProvenance.golden_ref
+            blind_golden_precision = $script:TopicalCandidatesProvenance.blind_golden_precision
+            refs                   = $candidateRefs.ToArray()
         }
     }
 
@@ -391,17 +451,20 @@ function ConvertTo-GroundedLogicalForm {
         try { $conf = [double]$Raw.formalization_confidence } catch { $conf = 0.0 }
     }
 
-    return [pscustomobject][ordered]@{
-        predicate                = $predicate
-        event_ref                = $eventRef
-        args                     = $groundedArgs.ToArray()
-        polarity                 = $polarity
-        modality                 = $modality
-        temporal                 = [ordered]@{ type = $tempType; value = $tempValue }
-        about                    = $groundedAbout.ToArray()
-        formalization_confidence = $conf
-        status                   = $status
+    $result = [ordered]@{
+        predicate = $predicate
+        event_ref = $eventRef
+        args      = $groundedArgs.ToArray()
+        polarity  = $polarity
+        modality  = $modality
+        temporal  = [ordered]@{ type = $tempType; value = $tempValue }
+        about     = $groundedAbout.ToArray()
     }
+    # topical_candidates sits after about[] when concept refs exist (absent != null, t/2943 — never a null key).
+    if ($null -ne $topicalCandidates) { $result['topical_candidates'] = $topicalCandidates }
+    $result['formalization_confidence'] = $conf
+    $result['status'] = $status
+    return [pscustomobject]$result
 }
 
 function Test-LogicalFormStructure {
@@ -457,9 +520,43 @@ function Test-LogicalFormStructure {
         if ([string]$a.match_level -notin $script:LogicalFormMatchLevels) { return [pscustomobject]@{ Ok = $false; Reason = "arg match_level '$($a.match_level)' invalid" } }
     }
 
+    # about[] stays TOLERANT of term: refs in phase-1 — NO ^ent- tightening here (Option C, t/3389).
+    # Tightening about[].ref to ent-* only is PHASE-3, after the t/3391 corpus migration: enforcing
+    # ^ent- before the 1560 term: refs migrate would red the corpus (e/145#15/#16, land-order is
+    # load-bearing). Remove this note + add the ^ent- check together in phase-3.
     foreach ($ab in @($lf.about)) {
         if ([string]::IsNullOrWhiteSpace([string]$ab.ref)) { return [pscustomobject]@{ Ok = $false; Reason = 'about missing ref' } }
         if ([string]$ab.match_level -notin $script:LogicalFormMatchLevels) { return [pscustomobject]@{ Ok = $false; Reason = "about match_level '$($ab.match_level)' invalid" } }
+    }
+
+    # topical_candidates (Option C phase-1, t/3389): OPTIONAL. Absent is valid (absent != null, t/2943);
+    # present must be a well-formed quality-marked block. This is the migration front-edge — all four
+    # validator ports ACCEPT the field before any data moves (e/145#13/#16). Handles both a generator-
+    # produced ordered-dict and a JSON-parsed PSObject (dual-type accessor below).
+    if ($lf.PSObject.Properties['topical_candidates'] -and $null -ne $lf.topical_candidates) {
+        $getp = {
+            param($o, $n)
+            if ($null -eq $o) { return $null }
+            if ($o -is [System.Collections.IDictionary]) { if ($o.Contains($n)) { return $o[$n] } return $null }
+            $p = $o.PSObject.Properties[$n]; if ($p) { return $p.Value } return $null
+        }
+        $tc = $lf.topical_candidates
+        if (($tc -isnot [System.Collections.IDictionary]) -and ($tc -isnot [psobject])) {
+            return [pscustomobject]@{ Ok = $false; Reason = 'topical_candidates must be an object' }
+        }
+        if ((& $getp $tc 'validated') -isnot [bool]) { return [pscustomobject]@{ Ok = $false; Reason = 'topical_candidates.validated must be a boolean' } }
+        if ([string]::IsNullOrWhiteSpace([string](& $getp $tc 'generator')))  { return [pscustomobject]@{ Ok = $false; Reason = 'topical_candidates.generator empty' } }
+        if ([string]::IsNullOrWhiteSpace([string](& $getp $tc 'golden_ref'))) { return [pscustomobject]@{ Ok = $false; Reason = 'topical_candidates.golden_ref empty' } }
+        $prec = (& $getp $tc 'blind_golden_precision')
+        $precD = 0.0
+        $precOk = ($null -ne $prec) -and [double]::TryParse([string]$prec, [ref]$precD)
+        if (-not $precOk -or $precD -lt 0.0 -or $precD -gt 1.0) { return [pscustomobject]@{ Ok = $false; Reason = 'topical_candidates.blind_golden_precision not in [0,1]' } }
+        foreach ($r in @(& $getp $tc 'refs')) {
+            $rref = [string](& $getp $r 'ref')
+            if ($rref -notmatch $script:TopicalCandidateRefPattern) { return [pscustomobject]@{ Ok = $false; Reason = "topical_candidates ref '$rref' must match $($script:TopicalCandidateRefPattern)" } }
+            $rml = [string](& $getp $r 'match_level')
+            if ($rml -notin $script:LogicalFormMatchLevels) { return [pscustomobject]@{ Ok = $false; Reason = "topical_candidates ref '$rref' match_level '$rml' invalid" } }
+        }
     }
 
     if ($isFactual) {

--- a/scripts/AITriad/Public/Invoke-LogicalFormPass.ps1
+++ b/scripts/AITriad/Public/Invoke-LogicalFormPass.ps1
@@ -196,6 +196,12 @@ function Invoke-LogicalFormPass {
                 $skipped++
                 continue   # not in the grounded set
             }
+            # concept_refs[] (term:* universals, t/3389 Option C): grounds the about[]->topical_candidates
+            # split. Optional/empty on summary claims today (0 present), so this is dormant-but-correct;
+            # the grounded-set gate above stays keyed on entity_refs only (a claim with only concept_refs
+            # is not part of the D3b-stratifiable grounded set).
+            $conceptRefs = @()
+            if ($claim.PSObject.Properties['concept_refs'] -and $claim.concept_refs) { $conceptRefs = @($claim.concept_refs) }
 
             $proposition = Get-ClaimProposition -Claim $claim -IsFactual:$entry.IsFactual
             if ([string]::IsNullOrWhiteSpace($proposition)) {
@@ -203,7 +209,7 @@ function Invoke-LogicalFormPass {
                 continue   # nothing to formalize
             }
 
-            $refTable = Get-LogicalFormRefTable -EntityRefs $refs -DolceMap $dolceMap
+            $refTable = Get-LogicalFormRefTable -EntityRefs $refs -DolceMap $dolceMap -ConceptRefs $conceptRefs
             $refsJson = ConvertTo-EntityRefsPromptJson -RefTable $refTable
             $claimCategory = if ($entry.IsFactual) { 'factual' } else { $entry.Category }
 

--- a/tests/Invoke-LogicalFormPass.OptionCParity.Tests.ps1
+++ b/tests/Invoke-LogicalFormPass.OptionCParity.Tests.ps1
@@ -1,0 +1,120 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+# Option C PS<->Python parity (t/3389 / t/3409 item 4, SO cond-3). Shared cross-language contract
+# (CL #2097): research/comp-linguist/analyses/t3389-option-c/optionc-parity-fixture.json. The PS split
+# (ConvertTo-GroundedLogicalForm) MUST match the Python validate() (#2078); `generator` is per-port
+# identity and TOLERATED. Python arm: test_optionc_parity.py.
+#
+# #2669 avoidance (learned empirically co-running with the InModuleScope sibling suite): NO helper
+# functions defined in BeforeAll and called from It, NO `foreach` statement, NO `Should` inside a
+# helper or a loop, NO -ForEach/BeforeDiscovery. Everything inline per It; InModuleScope returns only
+# $lf and all Should run in the It body. Expectations are READ from the fixture (drift-catching); each
+# fixture case has <=1 ref in about[]/topical_candidates.refs, so indexed compares suffice (no sort helper).
+
+Describe 'Option C PS-to-Python parity fixture (t/3389/t/3409)' -Tag 'unit', 'fol' {
+    BeforeAll {
+        Import-Module (Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1') -Force -WarningAction SilentlyContinue
+        $fixturePath = Join-Path $PSScriptRoot '..' 'research' 'comp-linguist' 'analyses' 't3389-option-c' 'optionc-parity-fixture.json'
+        $script:Fx   = Get-Content -Raw -LiteralPath $fixturePath | ConvertFrom-Json
+        $script:Prov = $script:Fx._meta.provenance_expected
+        # RefTable literal from the fixture's 3-entry allowlist (no loop in BeforeAll — a #2669 risk).
+        # Kept in sync with the fixture by the drift-guard It below.
+        $script:Allow = @(
+            [pscustomobject]@{ ref = 'ent-034'; surface = ''; match_level = 'exact';       sort = 'agentive-physical-object' }
+            [pscustomobject]@{ ref = 'term:regulation_precautionary'; surface = ''; match_level = 'exact'; sort = 'universal' }
+            [pscustomobject]@{ ref = 'ent-x';   surface = ''; match_level = 'instance_of'; sort = 'perdurant' }
+        )
+    }
+
+    It 'The parity fixture is present and its allowlist matches the test RefTable (drift guard)' {
+        @($script:Fx.cases).Count | Should -Be 5
+        $script:Fx._meta.provenance_expected.golden_ref | Should -Be 't/3381'
+        # allowlist drift guard — the 3 refs + their register (sort, match_level) must match $script:Allow.
+        $al = $script:Fx.allowlist
+        @($al.PSObject.Properties).Count | Should -Be 3
+        $al.'ent-034'.sort | Should -Be 'agentive-physical-object'
+        $al.'term:regulation_precautionary'.sort | Should -Be 'universal'
+        $al.'ent-x'.match_level | Should -Be 'instance_of'
+    }
+
+    It 'case: concept_ref_routed_to_topical_candidates (term: -> topical_candidates; universal clamped to exact)' {
+        $case = $script:Fx.cases | Where-Object { $_.name -eq 'concept_ref_routed_to_topical_candidates' } | Select-Object -First 1
+        $lf = InModuleScope AITriad -Parameters @{ InAbout = @($case.input_about); Allow = $script:Allow; Cat = $script:Fx._meta.category; Camp = $script:Fx._meta.camp } {
+            param($InAbout, $Allow, $Cat, $Camp)
+            $raw = [pscustomobject]@{ predicate = 'hold'; event_ref = 'e1'; args = @(); polarity = 'positive'
+                modality = [pscustomobject]@{ holder = 'camp:acc'; attitude = 'belief' }
+                temporal = [pscustomobject]@{ type = 'unspecified'; value = $null }
+                about = @($InAbout); formalization_confidence = 0.7; status = 'proposed' }
+            ConvertTo-GroundedLogicalForm -Raw $raw -RefTable $Allow -Category $Cat -Camp $Camp
+        }
+        @($lf.about).Count | Should -Be 0
+        $lf.topical_candidates | Should -Not -BeNullOrEmpty
+        @($lf.topical_candidates.refs).Count | Should -Be 1
+        $lf.topical_candidates.refs[0].ref | Should -Be $case.expected_topical_candidates_refs[0].ref
+        $lf.topical_candidates.refs[0].match_level | Should -Be $case.expected_topical_candidates_refs[0].match_level
+        $lf.topical_candidates.validated | Should -Be $script:Prov.validated
+        "$($lf.topical_candidates.golden_ref)" | Should -Be "$($script:Prov.golden_ref)"
+        [double]$lf.topical_candidates.blind_golden_precision | Should -Be ([double]$script:Prov.blind_golden_precision)
+    }
+
+    It 'case: entity_ref_stays_in_about_ent_only (authoritative register match_level; no topical_candidates)' {
+        $case = $script:Fx.cases | Where-Object { $_.name -eq 'entity_ref_stays_in_about_ent_only' } | Select-Object -First 1
+        $lf = InModuleScope AITriad -Parameters @{ InAbout = @($case.input_about); Allow = $script:Allow; Cat = $script:Fx._meta.category; Camp = $script:Fx._meta.camp } {
+            param($InAbout, $Allow, $Cat, $Camp)
+            $raw = [pscustomobject]@{ predicate = 'hold'; event_ref = 'e1'; args = @(); polarity = 'positive'
+                modality = [pscustomobject]@{ holder = 'camp:acc'; attitude = 'belief' }
+                temporal = [pscustomobject]@{ type = 'unspecified'; value = $null }
+                about = @($InAbout); formalization_confidence = 0.7; status = 'proposed' }
+            ConvertTo-GroundedLogicalForm -Raw $raw -RefTable $Allow -Category $Cat -Camp $Camp
+        }
+        @($lf.about).Count | Should -Be 1
+        $lf.about[0].ref | Should -Be $case.expected_about[0].ref
+        $lf.about[0].match_level | Should -Be $case.expected_about[0].match_level   # register 'instance_of', not model 'exact'
+        $lf.PSObject.Properties['topical_candidates'] | Should -BeNullOrEmpty
+    }
+
+    It 'case: ungrounded_ref_dropped (R6 no-mint; no topical_candidates)' {
+        $case = $script:Fx.cases | Where-Object { $_.name -eq 'ungrounded_ref_dropped' } | Select-Object -First 1
+        $lf = InModuleScope AITriad -Parameters @{ InAbout = @($case.input_about); Allow = $script:Allow; Cat = $script:Fx._meta.category; Camp = $script:Fx._meta.camp } {
+            param($InAbout, $Allow, $Cat, $Camp)
+            $raw = [pscustomobject]@{ predicate = 'hold'; event_ref = 'e1'; args = @(); polarity = 'positive'
+                modality = [pscustomobject]@{ holder = 'camp:acc'; attitude = 'belief' }
+                temporal = [pscustomobject]@{ type = 'unspecified'; value = $null }
+                about = @($InAbout); formalization_confidence = 0.7; status = 'proposed' }
+            ConvertTo-GroundedLogicalForm -Raw $raw -RefTable $Allow -Category $Cat -Camp $Camp
+        }
+        @($lf.about).Count | Should -Be 0
+        $lf.PSObject.Properties['topical_candidates'] | Should -BeNullOrEmpty
+    }
+
+    It 'case: split_mixed_ent_to_about_term_to_candidates (core split in one frame)' {
+        $case = $script:Fx.cases | Where-Object { $_.name -eq 'split_mixed_ent_to_about_term_to_candidates' } | Select-Object -First 1
+        $lf = InModuleScope AITriad -Parameters @{ InAbout = @($case.input_about); Allow = $script:Allow; Cat = $script:Fx._meta.category; Camp = $script:Fx._meta.camp } {
+            param($InAbout, $Allow, $Cat, $Camp)
+            $raw = [pscustomobject]@{ predicate = 'hold'; event_ref = 'e1'; args = @(); polarity = 'positive'
+                modality = [pscustomobject]@{ holder = 'camp:acc'; attitude = 'belief' }
+                temporal = [pscustomobject]@{ type = 'unspecified'; value = $null }
+                about = @($InAbout); formalization_confidence = 0.7; status = 'proposed' }
+            ConvertTo-GroundedLogicalForm -Raw $raw -RefTable $Allow -Category $Cat -Camp $Camp
+        }
+        @($lf.about).Count | Should -Be 1
+        $lf.about[0].ref | Should -Be $case.expected_about[0].ref                       # ent-034 stays
+        @($lf.topical_candidates.refs).Count | Should -Be 1
+        $lf.topical_candidates.refs[0].ref | Should -Be $case.expected_topical_candidates_refs[0].ref   # term: -> candidates
+    }
+
+    It 'case: empty_about_no_topical_candidates_key (absent, not null)' {
+        $case = $script:Fx.cases | Where-Object { $_.name -eq 'empty_about_no_topical_candidates_key' } | Select-Object -First 1
+        $lf = InModuleScope AITriad -Parameters @{ InAbout = @($case.input_about); Allow = $script:Allow; Cat = $script:Fx._meta.category; Camp = $script:Fx._meta.camp } {
+            param($InAbout, $Allow, $Cat, $Camp)
+            $raw = [pscustomobject]@{ predicate = 'hold'; event_ref = 'e1'; args = @(); polarity = 'positive'
+                modality = [pscustomobject]@{ holder = 'camp:acc'; attitude = 'belief' }
+                temporal = [pscustomobject]@{ type = 'unspecified'; value = $null }
+                about = @($InAbout); formalization_confidence = 0.7; status = 'proposed' }
+            ConvertTo-GroundedLogicalForm -Raw $raw -RefTable $Allow -Category $Cat -Camp $Camp
+        }
+        @($lf.about).Count | Should -Be 0
+        $lf.PSObject.Properties['topical_candidates'] | Should -BeNullOrEmpty
+    }
+}

--- a/tests/Invoke-LogicalFormPass.Tests.ps1
+++ b/tests/Invoke-LogicalFormPass.Tests.ps1
@@ -338,3 +338,120 @@ Describe 'Invoke-LogicalFormPass — orchestrator (t/3215)' -Tag 'unit', 'fol' {
         Should -Invoke -CommandName Invoke-AIByUsage -ModuleName AITriad -Times 2 -Exactly
     }
 }
+
+Describe 'Invoke-LogicalFormPass — Option C topical_candidates (t/3389/t/3409)' -Tag 'unit', 'fol' {
+    # Phase-1 ADDITIVE port of the SO+TL-signed Option C design (e/145#13-#16; reference impl #2078):
+    # about[] splits ent-* (stays) from term: concept refs (-> topical_candidates); the validator ACCEPTS
+    # the field; about[] stays term:-tolerant (^ent- tightening is phase-3). Both-arms per gate discipline.
+    BeforeAll {
+        Import-Module (Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1') -Force -WarningAction SilentlyContinue
+    }
+
+    It 'Get-LogicalFormRefTable emits concept_refs as term: rows (sort=universal, match_level=exact)' {
+        InModuleScope AITriad {
+            $map  = @{ 'ent-055' = 'non-agentive-functional-artifact' }
+            $ents = @([pscustomobject]@{ ref = 'ent-055'; surface = 'GPT-5'; match_level = 'exact' })
+            $cons = @([pscustomobject]@{ ref = 'term:cf-alignment'; surface = 'alignment' })
+            $table = @(Get-LogicalFormRefTable -EntityRefs $ents -DolceMap $map -ConceptRefs $cons)
+            $table.Count | Should -Be 2
+            $term = $table | Where-Object { $_.ref -eq 'term:cf-alignment' }
+            $term.sort        | Should -Be 'universal'
+            $term.match_level | Should -Be 'exact'
+        }
+    }
+
+    It 'ConvertTo-GroundedLogicalForm splits about[]: ent-* stays, term:* -> topical_candidates.refs; provenance stamped' {
+        InModuleScope AITriad {
+            $table = @(
+                [pscustomobject]@{ ref = 'ent-055'; surface = 'GPT-5'; match_level = 'exact'; sort = 'non-agentive-functional-artifact' }
+                [pscustomobject]@{ ref = 'term:cf-alignment'; surface = 'alignment'; match_level = 'exact'; sort = 'universal' }
+            )
+            $raw = [pscustomobject]@{
+                predicate = 'x'; event_ref = 'e1'; args = @()
+                polarity = 'positive'; modality = $null
+                temporal = [pscustomobject]@{ type = 'unspecified'; value = $null }
+                about = @(
+                    [pscustomobject]@{ ref = 'ent-055'; match_level = 'exact' }
+                    [pscustomobject]@{ ref = 'term:cf-alignment'; match_level = 'related' }  # ml overwritten from register -> exact
+                    [pscustomobject]@{ ref = 'ent-999'; match_level = 'exact' }              # ungrounded -> dropped (R6)
+                )
+                formalization_confidence = 0.7; status = 'proposed'
+            }
+            $lf = ConvertTo-GroundedLogicalForm -Raw $raw -RefTable $table -Category 'factual' -Camp ''
+            @($lf.about).Count | Should -Be 1
+            $lf.about[0].ref   | Should -Be 'ent-055'
+            $tc = $lf.topical_candidates
+            $tc                        | Should -Not -BeNullOrEmpty
+            $tc.validated              | Should -BeFalse
+            $tc.generator              | Should -Be 'LogicalFormPass.ps1'   # THIS generator's identity (e/145#14c)
+            $tc.golden_ref             | Should -Be 't/3381'
+            $tc.blind_golden_precision | Should -Be 0.54
+            @($tc.refs).Count          | Should -Be 1
+            $tc.refs[0].ref            | Should -Be 'term:cf-alignment'
+            $tc.refs[0].match_level    | Should -Be 'exact'                 # authoritative from register, not model's 'related'
+            (Test-LogicalFormStructure -LogicalForm $lf -Category 'factual').Ok | Should -BeTrue
+        }
+    }
+
+    It 'topical_candidates is ABSENT (not a null key) when there are no concept refs (absent != null, t/2943)' {
+        InModuleScope AITriad {
+            $table = @([pscustomobject]@{ ref = 'ent-055'; surface = 'x'; match_level = 'exact'; sort = 'non-agentive-functional-artifact' })
+            $raw = [pscustomobject]@{ predicate = 'x'; event_ref = 'e1'; args = @(); polarity = 'positive'; modality = $null
+                temporal = [pscustomobject]@{ type = 'unspecified'; value = $null }
+                about = @([pscustomobject]@{ ref = 'ent-055'; match_level = 'exact' }); formalization_confidence = 0.5; status = 'proposed' }
+            $lf = ConvertTo-GroundedLogicalForm -Raw $raw -RefTable $table -Category 'factual' -Camp ''
+            $lf.PSObject.Properties['topical_candidates'] | Should -BeNullOrEmpty
+        }
+    }
+
+    It 'Test-LogicalFormStructure ACCEPTS a well-formed topical_candidates (JSON-parsed migrated shape; hyphenated ent-)' {
+        InModuleScope AITriad {
+            $json = '{"predicate":"x","event_ref":"e1","args":[],"polarity":"positive","modality":null,' +
+                    '"temporal":{"type":"unspecified","value":null},"about":[],' +
+                    '"topical_candidates":{"validated":false,"generator":"formalize_node_lf.py","golden_ref":"t/3381",' +
+                    '"blind_golden_precision":0.54,"refs":[{"ref":"term:cf-alignment","match_level":"exact"},{"ref":"ent-360","match_level":"exact"}]},' +
+                    '"formalization_confidence":0.5,"status":"proposed"}'
+            $lf = $json | ConvertFrom-Json
+            (Test-LogicalFormStructure -LogicalForm $lf -Category 'factual').Ok | Should -BeTrue
+        }
+    }
+
+    It 'Test-LogicalFormStructure REJECTS a topical_candidates ref outside ^(term:|ent-)' {
+        InModuleScope AITriad {
+            $json = '{"predicate":"x","event_ref":"e1","args":[],"polarity":"positive","modality":null,' +
+                    '"temporal":{"type":"unspecified","value":null},"about":[],' +
+                    '"topical_candidates":{"validated":false,"generator":"g","golden_ref":"t/3381","blind_golden_precision":0.54,' +
+                    '"refs":[{"ref":"concept:oops","match_level":"exact"}]},"formalization_confidence":0.5,"status":"proposed"}'
+            $r = Test-LogicalFormStructure -LogicalForm ($json | ConvertFrom-Json) -Category 'factual'
+            $r.Ok     | Should -BeFalse
+            $r.Reason | Should -BeLike '*term:*'
+        }
+    }
+
+    It 'Test-LogicalFormStructure REJECTS non-bool validated and out-of-range precision' {
+        InModuleScope AITriad {
+            $nonBool = '{"predicate":"x","event_ref":"e1","args":[],"polarity":"positive","modality":null,' +
+                       '"temporal":{"type":"unspecified","value":null},"about":[],' +
+                       '"topical_candidates":{"validated":"false","generator":"g","golden_ref":"t/3381","blind_golden_precision":0.54,"refs":[]},' +
+                       '"formalization_confidence":0.5,"status":"proposed"}'
+            (Test-LogicalFormStructure -LogicalForm ($nonBool | ConvertFrom-Json) -Category 'factual').Ok | Should -BeFalse
+
+            $badPrec = '{"predicate":"x","event_ref":"e1","args":[],"polarity":"positive","modality":null,' +
+                       '"temporal":{"type":"unspecified","value":null},"about":[],' +
+                       '"topical_candidates":{"validated":false,"generator":"g","golden_ref":"t/3381","blind_golden_precision":1.5,"refs":[]},' +
+                       '"formalization_confidence":0.5,"status":"proposed"}'
+            (Test-LogicalFormStructure -LogicalForm ($badPrec | ConvertFrom-Json) -Category 'factual').Ok | Should -BeFalse
+        }
+    }
+
+    It 'about[] stays TOLERANT of term: refs in phase-1 (no ^ent- tightening — that is phase-3)' {
+        InModuleScope AITriad {
+            $json = '{"predicate":"x","event_ref":"e1","args":[],"polarity":"positive","modality":null,' +
+                    '"temporal":{"type":"unspecified","value":null},' +
+                    '"about":[{"ref":"term:cf-legacy","match_level":"exact"}],' +
+                    '"formalization_confidence":0.5,"status":"proposed"}'
+            # TOLERANCE ARM — marked for phase-3 removal (when about[].ref tightens to ^ent-, this flips to Should -BeFalse).
+            (Test-LogicalFormStructure -LogicalForm ($json | ConvertFrom-Json) -Category 'factual').Ok | Should -BeTrue
+        }
+    }
+}


### PR DESCRIPTION
Phase-1 ADDITIVE port of the SO+TL-signed Option C design (e/145#13-#16; design doc analyses/t3389-option-c/c-design.md). Reference impl: Python #2078. Zod twin: #2096. Parity fixture: #2097. This is the 4th/last of the four validator ports; unblocks the t/3391 corpus migration.

**Self-cert:** playbook-covered impl of a signed design (/add-test + /trivial-change) — no further TL/SO pass per t/3409. Design + scope on t/3409#1.

## Changes (scripts/AITriad/)
- **Validator** (`Test-LogicalFormStructure`): accepts OPTIONAL `topical_candidates` `{validated, generator, golden_ref, blind_golden_precision, refs[]}`; ref pattern `^(term:|ent-)` (hyphenated ent-, e/145#14 d2); match_level enum-clamped; absent≠null (t/2943).
- **about[] stays term:-tolerant** — no `^ent-` tightening (phase-3, post-migration; land-order load-bearing). Co-located comment.
- **Generator** (`ConvertTo-GroundedLogicalForm` + `Get-LogicalFormRefTable` + orchestrator): concept_refs plumbed as term: universals; about[] split ent-*→about[], term:→topical_candidates.refs; fresh per-generator provenance (generator=LogicalFormPass.ps1); emitted only when concept refs exist.
- args[] unchanged (out of phase-1 scope).

## Tests
- Both-arms Pester (validator accept/reject, split, absent≠null, tolerance) — Invoke-LogicalFormPass.Tests.ps1.
- **PS-Python parity fixture arm** (item 4 / SO cond-3) against the shared #2097 fixture — 5 cases, generator tolerated. 30/30 green co-run; manifest passes.

Note: local full-suite gate has env-only DevOps live-integration failures (Azure blob/analytics) unrelated to this change; CI runs the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)