### PR TITLE
feat(fol-eval): summary-corpus direction (§8 i) + correlation (§9) — Increment 6, pipeline complete (t/3354)

### DIFF
--- a/scripts/fol-eval-correlate.ps1
+++ b/scripts/fol-eval-correlate.ps1
@@ -1,0 +1,156 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    FOL-on-debate eval — summary-corpus contradiction (design §8 i) + CORRELATION outputs (§9). Increment 6 (final).
+.DESCRIPTION
+    Closes the harness:
+
+    (i) SUMMARY-CORPUS direction (design §8 i): compare each formalized debate-clause logical form against
+        the EXISTING formalized POV summary corpus logical forms (the ones Invoke-LogicalFormPass attached),
+        using the identical structural detector (Test-FolClausePair, fol-eval-contradict.ps1). This is CL's
+        "link the assertoric claims back to the already-formalized summary corpus" — the summary FOL is the
+        entailment/contradiction target, not re-formalized dialogue.
+
+    §9 CORRELATION outputs (harness emits; CL analyzes): a per-debate, claim-level-provenance index that CL
+        can JOIN to crux_addressed_rate / convergence_score (target ii) to test the prediction that FOL
+        under-counts vs crux_addressed_rate because of paraphrase false-negatives. Target (iii) — the
+        conflict/QBAF corpus (Main-PS's seam, 15 verified PAIRS, exclude status=demoted) — is optional and
+        left as a follow-up (loop Main-PS for the field paths + demoted-excluding predicate).
+
+    All functions here are PURE (no AI, no I/O). The runner does the read-only summary-corpus load and feeds
+    parsed summaries in. Nothing anchors a conclusion until CL double-annotates (design §11/§12).
+.LINK
+    fol-eval-contradict.ps1
+.LINK
+    run-fol-debate-eval.ps1
+#>
+
+Set-StrictMode -Version Latest
+
+function Get-SummaryClaimLogicalForms {
+    <#
+    .SYNOPSIS
+        Extract the { source, camp, claim_ref, logical_form } entries from ONE parsed summary. Pure.
+    .DESCRIPTION
+        Walks pov_summaries.{accelerationist,safetyist,skeptic}.key_points[] (camp acc/saf/skp) and
+        top-level factual_claims[] (camp 'factual'), yielding only claims that carry a non-empty
+        logical_form. claim_ref is a stable "<source>|<camp>|<index>" provenance key.
+    #>
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory)]$Summary,
+        [Parameter(Mandatory)][string]$SourceId
+    )
+    Set-StrictMode -Version Latest
+    $out = [System.Collections.Generic.List[object]]::new()
+    $camps = @{ accelerationist = 'acc'; safetyist = 'saf'; skeptic = 'skp' }
+    if ($Summary.PSObject.Properties['pov_summaries'] -and $Summary.pov_summaries) {
+        foreach ($pov in @('accelerationist', 'safetyist', 'skeptic')) {
+            if (-not $Summary.pov_summaries.PSObject.Properties[$pov]) { continue }
+            $povData = $Summary.pov_summaries.$pov
+            if (-not $povData -or -not $povData.PSObject.Properties['key_points'] -or -not $povData.key_points) { continue }
+            $idx = -1
+            foreach ($kp in @($povData.key_points)) {
+                $idx++
+                if ($kp.PSObject.Properties['logical_form'] -and $kp.logical_form) {
+                    $out.Add([PSCustomObject]@{ source = $SourceId; camp = $camps[$pov]; claim_ref = "$SourceId|$($camps[$pov])|$idx"; logical_form = $kp.logical_form })
+                }
+            }
+        }
+    }
+    if ($Summary.PSObject.Properties['factual_claims'] -and $Summary.factual_claims) {
+        $idx = -1
+        foreach ($fc in @($Summary.factual_claims)) {
+            $idx++
+            if ($fc.PSObject.Properties['logical_form'] -and $fc.logical_form) {
+                $out.Add([PSCustomObject]@{ source = $SourceId; camp = 'factual'; claim_ref = "$SourceId|factual|$idx"; logical_form = $fc.logical_form })
+            }
+        }
+    }
+    return @($out)
+}
+
+function Find-SummaryCorpusContradictions {
+    <#
+    .SYNOPSIS
+        Contradiction/agreement of each formalized debate clause vs the summary-corpus logical forms (§8 i). Pure.
+    .DESCRIPTION
+        Structural detector (Test-FolClausePair) over debate-clause × summary-claim pairs; emits the
+        contradict + agree pairs (neutral omitted) with full provenance (debate clause id + summary claim_ref).
+        Requires fol-eval-contradict.ps1 dot-sourced (Test-FolClausePair). Only formalized debate clauses
+        (fol_status 'formalized') participate.
+    #>
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Formalized,
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$SummaryLfs,
+        [hashtable]$NormalizationMap = @{}
+    )
+    Set-StrictMode -Version Latest
+    $out = [System.Collections.Generic.List[object]]::new()
+    $debateLfs = @($Formalized | Where-Object { [string]$_.fol_status -eq 'formalized' -and $_.logical_form })
+    foreach ($dc in $debateLfs) {
+        foreach ($sc in $SummaryLfs) {
+            $rel = Test-FolClausePair -LfA $dc.logical_form -LfB $sc.logical_form -NormalizationMap $NormalizationMap
+            if ($rel -eq 'neutral') { continue }
+            $out.Add([PSCustomObject]@{
+                    debate_id      = [string]$dc.debate_id
+                    debate_clause  = [string]$dc.id
+                    turn_index     = $dc.turn_index
+                    summary_source = [string]$sc.source
+                    summary_camp   = [string]$sc.camp
+                    summary_claim  = [string]$sc.claim_ref
+                    relation       = $rel
+                })
+        }
+    }
+    return @($out)
+}
+
+function New-CorrelationIndex {
+    <#
+    .SYNOPSIS
+        The §9 correlation-ready index: per-debate joinable counts CL joins to the convergence metrics. Pure.
+    .DESCRIPTION
+        For each debate present in the formalized set, emits the claim-level-provenance keys + FOL-signal
+        counts (assertoric formalized, intra-debate cross-agent contradictions, summary-corpus contradictions).
+        CL joins debate_id -> crux_addressed_rate / convergence_score (target ii) to test the FOL-under-counts
+        prediction. The global paraphrase FN-rate summary is carried alongside so the normalization gap travels
+        with the correlation data. Target (iii) conflict-corpus is a follow-up (not joined here).
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Formalized,
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$IntraContradictions,
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$SummaryContradictions,
+        [Parameter(Mandatory)]$FnReport
+    )
+    Set-StrictMode -Version Latest
+
+    $debates = @($Formalized | ForEach-Object { [string]$_.debate_id } | Sort-Object -Unique)
+    $perDebate = [System.Collections.Generic.List[object]]::new()
+    foreach ($d in $debates) {
+        $formalizedN = @($Formalized | Where-Object { [string]$_.debate_id -eq $d -and [string]$_.fol_status -eq 'formalized' }).Count
+        $intraN = @($IntraContradictions | Where-Object { [string]$_.debate_id -eq $d -and $_.relation -eq 'contradict' }).Count
+        $summaryN = @($SummaryContradictions | Where-Object { [string]$_.debate_id -eq $d -and $_.relation -eq 'contradict' }).Count
+        $perDebate.Add([PSCustomObject]@{
+                debate_id                     = $d
+                assertoric_formalized         = $formalizedN
+                intra_debate_contradictions   = $intraN
+                summary_corpus_contradictions = $summaryN
+                join_key                      = "debate_id=$d -> crux_addressed_rate / convergence_score (CL, target ii)"
+            })
+    }
+
+    return [PSCustomObject]@{
+        _doc               = 'FOL-on-debate correlation index (t/3354 §9). Harness emits; CL joins debate_id -> crux_addressed_rate/convergence_score to test whether FOL contradictions under-count vs crux_addressed_rate (paraphrase FN gap). INSTRUMENT-PROVISIONAL — no number anchors a threshold until CL double-annotates (design §11/§12). Target (iii) conflict/QBAF corpus is a follow-up (loop Main-PS).'
+        debates            = $debates.Count
+        paraphrase_fn_rate = if ($null -ne $FnReport) { [PSCustomObject]@{ raw = $FnReport.raw_fn_rate; normalized = $FnReport.normalized_fn_rate; gap = $FnReport.normalization_gap; gold_pairs = $FnReport.gold_pairs } } else { $null }
+        per_debate         = @($perDebate)
+    }
+}

--- a/scripts/run-fol-debate-eval.ps1
+++ b/scripts/run-fol-debate-eval.ps1
@@ -20,10 +20,13 @@
     FOL (§7, fol-eval-fol.ps1 — neo-Davidsonian formalization of the resolved usable subset, REUSING the
     LogicalFormPass core via module session state, no fork, so it is shape-identical to the summary FOL corpus),
     CONTRADICTION + FN-rate (§8, fol-eval-contradict.ps1 — structural intra-debate cross-agent contradiction
-    detection + the make-or-break paraphrase false-negative rate, scored WITH vs WITHOUT normalization).
-    Classifier + coref are INSTRUMENT-PROVISIONAL (§5/t/3342); the §8 numbers are measurement reports, not
-    gates — no number anchors a conclusion until CL double-annotates (§11/§12).
-    The summary-corpus direction (§8 i) + §9 correlation outputs are NOT implemented yet and throw (honest failure).
+    detection + the make-or-break paraphrase false-negative rate, scored WITH vs WITHOUT normalization),
+    SUMMARY-LINK (§8 i, fol-eval-correlate.ps1 — debate clauses vs the read-only formalized POV summary
+    corpus) and CORRELATE (§9 — the per-debate claim-level-provenance index CL joins to the convergence
+    metrics). The pipeline now runs END-TO-END and returns a final summary object.
+    Classifier + coref + §8/§9 numbers are INSTRUMENT-PROVISIONAL (§5/t/3342) — measurement reports, not
+    gates; no number anchors a conclusion until CL double-annotates (§11/§12). Target (iii) conflict-corpus
+    correlation is a follow-up (loop Main-PS).
     Runnable paths without a model call: -DryRun (plan+manifest) and -SkipClassify (segment only).
 
     READ-ONLY (design §1, TL tightening e/141#8): the harness writes NOTHING under the data
@@ -101,6 +104,10 @@ param(
     [string]$FnFixturePath,
 
     [Parameter()]
+    [ValidateRange(0, 100000)]
+    [int]$MaxSummaryClaims = 3000,
+
+    [Parameter()]
     [switch]$DryRun
 )
 
@@ -111,12 +118,13 @@ Import-Module (Join-Path $PSScriptRoot 'AITriad' 'AITriad.psd1') -Force -ErrorAc
 $Mod = Get-Module AITriad
 if (-not $Mod) { throw 'AITriad module failed to load; cannot resolve data-root helpers.' }
 
-# Clause segmenter (§4) + classifier (§3) + coref (§6) + FOL (§7) — pure, dot-sourceable libraries.
+# Clause segmenter (§4) + classifier (§3) + coref (§6) + FOL (§7) + contradiction (§8) + correlate (§8i/§9).
 . (Join-Path $PSScriptRoot 'fol-eval-segment.ps1')
 . (Join-Path $PSScriptRoot 'fol-eval-classify.ps1')
 . (Join-Path $PSScriptRoot 'fol-eval-coref.ps1')
 . (Join-Path $PSScriptRoot 'fol-eval-fol.ps1')
 . (Join-Path $PSScriptRoot 'fol-eval-contradict.ps1')
+. (Join-Path $PSScriptRoot 'fol-eval-correlate.ps1')
 
 # Get-Prompt is a module-PRIVATE helper (Import-Module does not expose it), so the classifier/coref
 # Get-Prompt calls would fail with 'not recognized'. Dot-source it + set $script:ModuleRoot so its
@@ -126,6 +134,7 @@ $script:ModuleRoot = Join-Path $PSScriptRoot 'AITriad'
 
 # ── Module-session-state wrappers for Private helpers (see .DESCRIPTION note) ──────
 function Resolve-DebatesDir { & $Mod { Get-DebatesDir } }
+function Resolve-SummariesDir { & $Mod { Get-SummariesDir } }
 function Test-OutputUnderDataRoot { param([string]$Path) & $Mod { param($p) Test-IsUnderDataRoot -Path $p } $Path }
 function New-EvalError {
     param([string]$Goal, [string]$Problem, [string]$NextSteps)
@@ -214,8 +223,9 @@ $manifest = [ordered]@{
     coref_batch_size       = $CorefBatchSize
     max_context_turns      = $MaxContextTurns
     fn_fixture             = $FnFixturePath
-    stages_implemented     = @('load', 'run-bound', 'manifest', 'segment', 'classify', 'coref', 'fol', 'contradiction', 'fn-rate')
-    stages_pending_pairing = @('summary-corpus-direction', 'correlate')
+    max_summary_claims     = $MaxSummaryClaims
+    stages_implemented     = @('load', 'run-bound', 'manifest', 'segment', 'classify', 'coref', 'fol', 'contradiction', 'fn-rate', 'summary-link', 'correlate')
+    stages_pending_pairing = @()
 }
 
 Write-Host ''
@@ -415,8 +425,58 @@ if ($null -ne $fnFixture) {
     Write-Host '  (INSTRUMENT-PROVISIONAL — illustrative single-annotator fixture; no number anchors a threshold until CL double-annotates, design §11/§12.)' -ForegroundColor DarkGray
 }
 
-# ── DIRECTION (i) vs summary corpus + CORRELATION outputs (design §8 i / §9) — next increment ──
-throw (New-EvalError `
-    'Run the full FOL-on-debate eval pipeline' `
-    "SEGMENT + CLASSIFY + COREF + FOL + CONTRADICTION/FN-rate ran (contradictions.jsonl + fn-rate-report.json emitted; intra-debate contradict normalized=$normContraN) but the summary-corpus direction (i) and the §9 correlation outputs are not yet implemented." `
-    'Inspect contradictions.jsonl + fn-rate-report.json now. Direction (i) — contradiction vs the formalized POV summary corpus — plus the §9 correlation join (CL convergence metrics; optional conflict corpus) is the final increment.')
+# ── SUMMARY-LINK stage (design §8 i) — Increment 6. Read-only over the summary corpus ───────
+# Compare each formalized debate-clause logical form against the EXISTING formalized POV summary corpus
+# logical forms (read-only), using the identical structural detector. The summary FOL is the contradiction
+# target (CL's design), never re-formalized dialogue. Bounded by -MaxSummaryClaims (over-cap logged).
+Write-Host ''
+Write-Host '=== SUMMARY-LINK stage (design §8 i) — debate clauses vs the formalized summary corpus (read-only, structural) ===' -ForegroundColor Cyan
+$summaryLfs = [System.Collections.Generic.List[object]]::new()
+$summariesDir = Resolve-SummariesDir
+$summaryFilesScanned = 0
+if (Test-Path -LiteralPath $summariesDir) {
+    foreach ($sf in @(Get-ChildItem -LiteralPath $summariesDir -Filter '*.json' -File | Sort-Object Name)) {
+        if ($summaryLfs.Count -ge $MaxSummaryClaims) { break }
+        $summaryFilesScanned++
+        try { $sdoc = Get-Content -Raw -LiteralPath $sf.FullName | ConvertFrom-Json } catch { continue }
+        foreach ($e in @(Get-SummaryClaimLogicalForms -Summary $sdoc -SourceId ([System.IO.Path]::GetFileNameWithoutExtension($sf.Name)))) {
+            if ($summaryLfs.Count -ge $MaxSummaryClaims) { break }
+            $summaryLfs.Add($e)
+        }
+    }
+}
+else {
+    Write-Warning "SUMMARY-LINK: summaries dir not found ($summariesDir) — direction (i) skipped (0 summary logical forms)."
+}
+$summaryCapped = ($summaryLfs.Count -ge $MaxSummaryClaims)
+$summaryContra = @(Find-SummaryCorpusContradictions -Formalized $formalized -SummaryLfs @($summaryLfs) -NormalizationMap $normMap)
+$summaryContraPath = Join-Path $resolvedOut 'summary-contradictions.jsonl'
+Set-Content -LiteralPath $summaryContraPath -Value @($summaryContra | ForEach-Object { $_ | ConvertTo-Json -Depth 4 -Compress }) -Encoding utf8
+$summContraN = @($summaryContra | Where-Object { $_.relation -eq 'contradict' }).Count
+Write-Host "  Summary corpus: $($summaryLfs.Count) formalized claims from $summaryFilesScanned file(s)$(if ($summaryCapped) { " (capped at -MaxSummaryClaims $MaxSummaryClaims — over-cap NOT scanned)" })" -ForegroundColor White
+Write-Host "  Debate-clause vs summary-corpus: contradict=$summContraN, agree=$(@($summaryContra | Where-Object { $_.relation -eq 'agree' }).Count) -> $summaryContraPath" -ForegroundColor White
+
+# ── CORRELATE stage (design §9) — emit the claim-level-provenance index CL joins to the metrics ──
+Write-Host ''
+Write-Host '=== CORRELATE stage (design §9) — per-debate correlation index (harness emits; CL joins) ===' -ForegroundColor Cyan
+$fnReport = if ($null -ne $fnFixture) { $fn } else { $null }
+$corrIndex = New-CorrelationIndex -Formalized $formalized -IntraContradictions $contraNorm `
+    -SummaryContradictions $summaryContra -FnReport $fnReport
+$corrPath = Join-Path $resolvedOut 'correlation-index.json'
+$corrIndex | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $corrPath -Encoding utf8
+Write-Host "  Correlation index: $($corrIndex.debates) debate(s) -> $corrPath  (join debate_id -> crux_addressed_rate/convergence_score; target iii conflict-corpus is a follow-up)" -ForegroundColor White
+
+# ── PIPELINE COMPLETE — all steps-1–2 stages ran. Return the final summary. ──────────────────
+Write-Host ''
+Write-Host 'FOL-on-debate eval COMPLETE — all §2 stages ran. Artifacts in the output dir; numbers are INSTRUMENT-PROVISIONAL until CL double-annotates (§11/§12).' -ForegroundColor Green
+Write-Host ''
+return [PSCustomObject]@{
+    manifest                      = [PSCustomObject]$manifest
+    output_dir                    = $resolvedOut
+    clauses                       = $allClauses.Count
+    assertoric_formalized         = $folStats.formalized_count
+    intra_debate_contradictions   = $normContraN
+    summary_corpus_contradictions = $summContraN
+    paraphrase_fn_rate            = $fnReport
+    artifacts                     = @('run-manifest.json', 'clauses.jsonl', 'classified-clauses.jsonl', 'resolved-clauses.jsonl', 'formalized-clauses.jsonl', 'contradictions.jsonl', 'fn-rate-report.json', 'summary-contradictions.jsonl', 'correlation-index.json')
+}

--- a/tests/DataWriteSinkGuard.Tests.ps1
+++ b/tests/DataWriteSinkGuard.Tests.ps1
@@ -59,7 +59,7 @@ BeforeAll {
         'scripts/AITriad/Public/New-SyntheticCorpus.ps1'   = 'append-checkpoint + fresh corpus generation + NEW metadata (not a whole-file data rewrite)'
         'scripts/AITriad/Public/Test-DebatePersistence.ps1' = 'writes a random persist-probe .tmp (test probe, non-data)'
         'scripts/AITriad/Private/AICallLog.ps1'            = 'append-only AI call-log JSONL (Add-Content); references Get-DataRoot only to locate the log file — never read-mutate-rewrites a data-of-record file (t/3241)'
-        'scripts/run-fol-debate-eval.ps1'                  = 'read-only FOL-on-debate eval harness (t/3354); Set-Content writes only run-manifest.json + clauses.jsonl + classified-clauses.jsonl + resolved-clauses.jsonl + formalized-clauses.jsonl + contradictions.jsonl + fn-rate-report.json to -OutputDir, which is fail-closed asserted OUTSIDE the data root via Test-IsUnderDataRoot (design §1) — references data tokens (debates/summaries/conflicts) as read-only inputs, never writes ../ai-triad-data'
+        'scripts/run-fol-debate-eval.ps1'                  = 'read-only FOL-on-debate eval harness (t/3354); Set-Content writes only run-manifest.json + clauses.jsonl + classified-clauses.jsonl + resolved-clauses.jsonl + formalized-clauses.jsonl + contradictions.jsonl + fn-rate-report.json + summary-contradictions.jsonl + correlation-index.json to -OutputDir, which is fail-closed asserted OUTSIDE the data root via Test-IsUnderDataRoot (design §1) — references data tokens (debates/summaries/conflicts) as read-only inputs, never writes ../ai-triad-data'
     }
 
     # A data-of-record path token (basename or data-dir accessor). Kept specific so

--- a/tests/FolDebateCorrelate.Tests.ps1
+++ b/tests/FolDebateCorrelate.Tests.ps1
@@ -1,0 +1,84 @@
+# Tag: qbaf (t/3354 — FOL-on-debate eval summary-corpus direction + correlation, design §8 i / §9)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Tests for the FOL-on-debate correlation PURE transforms (scripts/fol-eval-correlate.ps1, §8 i / §9).
+.DESCRIPTION
+    Get-SummaryClaimLogicalForms, Find-SummaryCorpusContradictions, and New-CorrelationIndex are pure
+    (no AI, no I/O). Find-SummaryCorpusContradictions needs Test-FolClausePair, so the detector library is
+    dot-sourced too. The runner's read-only summary-corpus load is covered by the degraded no-key run.
+#>
+
+BeforeAll {
+    . "$PSScriptRoot/../scripts/fol-eval-contradict.ps1"
+    . "$PSScriptRoot/../scripts/fol-eval-correlate.ps1"
+    function New-Lf { param($pred, $arg, $pol = 'positive')
+        [pscustomobject]@{ predicate = $pred; args = @([pscustomobject]@{ role = 'patient'; ref = $arg }); polarity = $pol; about = @() }
+    }
+}
+
+Describe 'Get-SummaryClaimLogicalForms — extract claims carrying a logical_form' -Tag 'qbaf' {
+    It 'pulls BDI key_points (camp acc/saf/skp) + factual_claims, skipping claims without a logical_form' {
+        $summary = [pscustomobject]@{
+            pov_summaries  = [pscustomobject]@{
+                accelerationist = [pscustomobject]@{ key_points = @(
+                        [pscustomobject]@{ logical_form = (New-Lf 'protect' 'lit:"incumbents"') }
+                        [pscustomobject]@{ point = 'no logical form here' }
+                    ) }
+                safetyist       = [pscustomobject]@{ key_points = @([pscustomobject]@{ logical_form = (New-Lf 'ban' 'lit:"asi"') }) }
+            }
+            factual_claims = @([pscustomobject]@{ logical_form = (New-Lf 'consume' 'lit:"415 twh"') })
+        }
+        $lfs = @(Get-SummaryClaimLogicalForms -Summary $summary -SourceId 'doc1')
+        $lfs.Count | Should -Be 3           # acc[0], saf[0], factual[0] — acc[1] skipped
+        ($lfs | Where-Object { $_.camp -eq 'acc' }).claim_ref | Should -Be 'doc1|acc|0'
+        ($lfs | Where-Object { $_.camp -eq 'factual' }).claim_ref | Should -Be 'doc1|factual|0'
+    }
+    It 'tolerates a summary with no logical forms' {
+        @(Get-SummaryClaimLogicalForms -Summary ([pscustomobject]@{ factual_claims = @() }) -SourceId 'd').Count | Should -Be 0
+    }
+}
+
+Describe 'Find-SummaryCorpusContradictions — debate clause vs summary corpus' -Tag 'qbaf' {
+    It 'emits contradict pairs with full provenance (debate clause + summary claim_ref)' {
+        $formalized = @(
+            [pscustomobject]@{ id = 'd:t0:c0'; debate_id = 'd'; turn_index = 0; fol_status = 'formalized'; logical_form = (New-Lf 'protect' 'lit:"incumbents"' 'positive') }
+            [pscustomobject]@{ id = 'd:t1:c0'; debate_id = 'd'; turn_index = 1; fol_status = 'skipped-unresolved'; logical_form = $null }
+        )
+        $summaryLfs = @(
+            [pscustomobject]@{ source = 'doc1'; camp = 'saf'; claim_ref = 'doc1|saf|0'; logical_form = (New-Lf 'protect' 'lit:"incumbents"' 'negative') }
+        )
+        $r = @(Find-SummaryCorpusContradictions -Formalized $formalized -SummaryLfs $summaryLfs)
+        $r.Count | Should -Be 1
+        $r[0].relation | Should -Be 'contradict'
+        $r[0].debate_clause | Should -Be 'd:t0:c0'
+        $r[0].summary_claim | Should -Be 'doc1|saf|0'
+    }
+    It 'tolerates empty inputs' {
+        @(Find-SummaryCorpusContradictions -Formalized @() -SummaryLfs @()).Count | Should -Be 0
+    }
+}
+
+Describe 'New-CorrelationIndex — §9 per-debate joinable counts' -Tag 'qbaf' {
+    It 'aggregates formalized + intra + summary contradictions per debate and carries the FN-rate' {
+        $formalized = @(
+            [pscustomobject]@{ debate_id = 'd'; fol_status = 'formalized' }
+            [pscustomobject]@{ debate_id = 'd'; fol_status = 'formalized' }
+            [pscustomobject]@{ debate_id = 'e'; fol_status = 'skipped-unresolved' }
+        )
+        $intra = @([pscustomobject]@{ debate_id = 'd'; relation = 'contradict' })
+        $summary = @([pscustomobject]@{ debate_id = 'd'; relation = 'contradict' }, [pscustomobject]@{ debate_id = 'd'; relation = 'agree' })
+        $fn = [pscustomobject]@{ raw_fn_rate = 1.0; normalized_fn_rate = 0.0; normalization_gap = 1.0; gold_pairs = 10 }
+        $idx = New-CorrelationIndex -Formalized $formalized -IntraContradictions $intra -SummaryContradictions $summary -FnReport $fn
+        $idx.debates | Should -Be 2
+        $d = $idx.per_debate | Where-Object { $_.debate_id -eq 'd' }
+        $d.assertoric_formalized | Should -Be 2
+        $d.intra_debate_contradictions | Should -Be 1
+        $d.summary_corpus_contradictions | Should -Be 1      # the 'agree' is not counted
+        $idx.paraphrase_fn_rate.gap | Should -Be 1.0
+    }
+}


### PR DESCRIPTION
## Increment 6 (final) — summary-corpus direction (§8 i) + correlation outputs (§9)

Closes the offline FOL-on-debate eval harness (t/3354) — the pipeline now runs **end-to-end**. After foundation (#2045), segmenter (#2081), classifier (#2086), coref (#2088), FOL (#2089), contradiction+FN-rate (#2099).

### What lands
- **`scripts/fol-eval-correlate.ps1`** — PURE transforms:
  - `Get-SummaryClaimLogicalForms` — extract `{source, camp, claim_ref, logical_form}` from a parsed summary (only claims carrying a `logical_form`).
  - `Find-SummaryCorpusContradictions` — debate clause vs the **existing formalized POV summary corpus** via the identical detector (`Test-FolClausePair`); the summary FOL is the contradiction target (CL's design), never re-formalized dialogue.
  - `New-CorrelationIndex` — the §9 per-debate claim-level-provenance index (assertoric formalized, intra-debate + summary-corpus contradictions, the paraphrase FN-rate) that CL joins to `crux_addressed_rate`/`convergence_score` (target ii).
- **`run-fol-debate-eval.ps1`** — SUMMARY-LINK stage (read-only load of the summary corpus via module session state, bounded by `-MaxSummaryClaims`, over-cap logged) + CORRELATE stage emit `summary-contradictions.jsonl` + `correlation-index.json`. The runner now **COMPLETES and returns a final summary object** (no more honest-throw). Target (iii) conflict-corpus correlation is a follow-up (loop Main-PS).
- Tests: **`FolDebateCorrelate.Tests.ps1`** (5 pure-transform cases); `DataWriteSinkGuard.Tests.ps1` exemption updated.

### Verification
- **47/47 Pester** green.
- Degraded **no-key END-TO-END** run COMPLETES (no throw), loads **45 formalized summary claims read-only from 775 files**, emits **all 9 artifacts** (manifest `stages_pending` now empty), and returns the final summary.

### Scope / gates
Read-only over `../ai-triad-data` (§1 — summary corpus read only); structural (no model call). No new prompt/usage → **no promptCatalog coupling**; no `ai-models.json`/schema change → no Second Opinion (t/3361). Numbers are measurement reports, not gates — nothing anchors a conclusion until CL double-annotates (§11/§12).

**Harness steps 1–2 are now feature-complete.** Remaining AC items are the write-up / go-no-go (§12, gated on CL's double-annotation of the classifier gold set + FN fixture) and the optional target-(iii) conflict-corpus correlation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)