### PR TITLE
fix(debate): drop situation min-floor backfill when topic is out-of-coverage (t/3412)

### DIFF
--- a/lib/debate/debateEngine/taxonomyContext.ts
+++ b/lib/debate/debateEngine/taxonomyContext.ts
@@ -347,6 +347,12 @@ export async function getRelevantTaxonomyContext(engine: DebateEngineInternals, 
   }
 
   let filteredSit = selectRelevantSituationNodes(ctx.situationNodes, sitScores, { ...relevanceOpts, maxTotal: undefined }, 3, 8);
+  // Fallback-Path Logging (t/3412): when min-floor backfill is skipped (out-of-coverage topic),
+  // log the top score so out-of-coverage debates are diagnosable.
+  if (filteredSit.length === 0 && ctx.situationNodes.length > 0) {
+    const topSitScore = sitScores.size > 0 ? Math.max(...sitScores.values()) : 0;
+    getGlobalRecorder()?.record({ type: 'system.error', component: 'debate-engine', level: 'warn', debate_id: engine.session?.id, message: `situation injection: top score ${topSitScore.toFixed(3)} far below threshold — skipping min-floor backfill, 0 situations injected (out-of-coverage topic)` });
+  }
 
   // Situation exclusion filter (t/490): skip situations whose exclusion zone matches the round focus
   let situationExclusionSkipped: { node_id: string; similarity_exclusion: number }[] = [];

--- a/lib/debate/taxonomyRelevance.test.ts
+++ b/lib/debate/taxonomyRelevance.test.ts
@@ -349,6 +349,30 @@ describe('selectRelevantSituationNodes — divergence penalty', () => {
   });
 });
 
+// ── selectRelevantSituationNodes — out-of-coverage guard (t/3412) ──────
+
+describe('selectRelevantSituationNodes — out-of-coverage guard', () => {
+  function makeSit(id: string): SituationNode {
+    return { id, label: `Sit ${id}`, description: `Desc ${id}`, interpretations: { accelerationist: 'i', safetyist: 'i', skeptic: 'i' }, linked_nodes: [], conflict_ids: [] };
+  }
+
+  it('injects 0 situations when top score is far below threshold (out-of-coverage)', () => {
+    // threshold=0.48, margin=0.15 → fires when top < 0.33
+    const nodes = [makeSit('sit-001'), makeSit('sit-002'), makeSit('sit-003')];
+    const scores = new Map([['sit-001', 0.20], ['sit-002', 0.18], ['sit-003', 0.15]]);
+    const result = selectRelevantSituationNodes(nodes, scores, 0.48, 3, 15);
+    expect(result).toHaveLength(0);
+  });
+
+  it('still backfills to min when scores are within margin of threshold', () => {
+    // top=0.40, threshold=0.48, margin=0.15 → 0.40 >= 0.33 → backfill applies
+    const nodes = [makeSit('sit-001'), makeSit('sit-002'), makeSit('sit-003')];
+    const scores = new Map([['sit-001', 0.40], ['sit-002', 0.38], ['sit-003', 0.35]]);
+    const result = selectRelevantSituationNodes(nodes, scores, 0.48, 3, 15);
+    expect(result).toHaveLength(3);
+  });
+});
+
 // ── filterByTopicConstraints — discipline boost ─────────────────
 
 describe('filterByTopicConstraints — discipline boost', () => {

--- a/lib/debate/taxonomyRelevance.ts
+++ b/lib/debate/taxonomyRelevance.ts
@@ -435,6 +435,11 @@ export function buildSituationRootLookup(
   return rootCache;
 }
 
+/** Gap below threshold that signals out-of-coverage topics (t/3412).
+ *  When top situation score < threshold − NO_SIT_COVERAGE_MARGIN, the min-floor
+ *  backfill is skipped and 0 situations are injected to avoid misleading grounding. */
+export const NO_SIT_COVERAGE_MARGIN = 0.15;
+
 /**
  * Select relevant situation nodes based on similarity threshold.
  * When situationBranchBoost is configured and nodes have parent_id, scores
@@ -541,7 +546,11 @@ export function selectRelevantSituationNodes(
     .sort((a, b) => b.score - a.score || a.node.id.localeCompare(b.node.id));
 
   const aboveThreshold = scored.filter(s => s.score >= threshold);
-  const selected = aboveThreshold.length >= min
+  const topScore = scored[0]?.score ?? 0;
+  // t/3412: when top score is far below threshold the topic has no taxonomy coverage —
+  // skip min-floor backfill to avoid injecting misleading situations.
+  const outOfCoverage = topScore < threshold - NO_SIT_COVERAGE_MARGIN;
+  const selected = outOfCoverage || aboveThreshold.length >= min
     ? aboveThreshold
     : scored.slice(0, Math.max(min, aboveThreshold.length));
 


### PR DESCRIPTION
Fixes irrelevant situation injection on out-of-coverage topics (t/3412). Observed: debate 14ae53bc (OpenAI/Hugging Face hack topic) injected sit-451 "Hardware Sensor Stack Governance in Connected AI Toys" via superficial security-vocabulary embedding overlap despite `situation_activation=0` from topic critique.

## Root cause
`selectRelevantSituationNodes` guaranteed `min=3` situations via unconditional backfill from raw cosine top-N, even when all scores were far below threshold.

## Fix
- **`lib/debate/taxonomyRelevance.ts`**: export `NO_SIT_COVERAGE_MARGIN = 0.15`; guard the backfill — when `topScore < threshold − 0.15`, return empty instead of raw top-3. Normal near-threshold backfill (top within margin) is unchanged.
- **`lib/debate/debateEngine/taxonomyContext.ts`**: WARN log when 0 situations injected with situations available (Fallback-Path Logging rule).
- **`lib/debate/taxonomyRelevance.test.ts`**: 2 new tests — out-of-coverage returns 0; within-margin still backfills. 69/69 pass.

Self-certifying under /trivial-change: 3 files in lib/debate/, exported constant only, no interface changes.

Closes t/3412
