### PR TITLE
fix(debate): per-id save/load mutex + fix misleading AV self-lock error (t/3415)

### DIFF
--- a/lib/debate/__tests__/persistenceRetryBudget.test.ts
+++ b/lib/debate/__tests__/persistenceRetryBudget.test.ts
@@ -227,7 +227,14 @@ describe('renameSyncWithRetry — onLockExhausted callback (t/2544)', () => {
 
     afterEach(() => { vi.restoreAllMocks(); });
 
-    it('names the lock holder process in problem when callback returns a description', () => {
+    // Both-arms coverage (t/3415): the branch is self-lock vs external-lock, decided by
+    // whether the detected process name matches /^electron/i — NOT "is it named after AV".
+    // This arm uses MsMpEng.exe (Windows Defender), a genuinely-external, genuinely-AV
+    // process, so asserting 'antivirus' in nextSteps here is accurate for THIS process —
+    // it is not a blanket "external == antivirus" assumption. The self-lock arm below is
+    // the actual regression coverage that the AV-only framing doesn't leak onto our own
+    // process's lock.
+    it('external-lock arm: names the lock holder process in problem when callback returns a description', () => {
       setupEpermRenames();
       const target = tmpPath('lock-holder-named.json');
       const onLockExhausted = vi.fn().mockReturnValue('MsMpEng.exe (pid 1234)');
@@ -241,7 +248,7 @@ describe('renameSyncWithRetry — onLockExhausted callback (t/2544)', () => {
       cleanup(target);
     });
 
-    it('emits self-lock guidance when lock holder is electron.exe', () => {
+    it('self-lock arm: emits self-lock guidance when lock holder is electron.exe', () => {
       setupEpermRenames();
       const target = tmpPath('self-lock.json');
       const onLockExhausted = vi.fn().mockReturnValue('electron.exe (pid 52308)');

--- a/lib/debate/persistence.ts
+++ b/lib/debate/persistence.ts
@@ -41,8 +41,10 @@ export function safeSerialize(value: unknown, indent: number = 2): { json: strin
 
 /**
  * Rename with exponential-backoff retry for transient Windows file locks.
- * EPERM / EACCES on rename are almost always caused by antivirus, search
- * indexer, or another process briefly holding the target file open.
+ * EPERM / EACCES on rename can be caused by antivirus, a search indexer,
+ * another process briefly holding the target file open — or, on Windows, a
+ * same-process read handle this app itself still has open on the target
+ * (t/3415; see the lock-holder-driven self-lock vs external-lock split below).
  *
  * When maxWallClockMs is provided (large payloads >200KB), retries continue
  * until the wall-clock cap is hit rather than a fixed attempt count — AV scan
@@ -160,8 +162,9 @@ export function atomicWriteSync(
       try { fs.unlinkSync(tmpPath); } catch { /* best-effort cleanup */ }
       throw renameErr;
     }
-    // Sustained rename EPERM/EACCES: a Windows AV/indexer held an exclusive
-    // handle on the target longer than the bounded retry budget. The atomic
+    // Sustained rename EPERM/EACCES: some process held an exclusive handle on
+    // the target longer than the bounded retry budget — an external process
+    // (AV/indexer/other), or this app's own process (t/3415 self-lock). The atomic
     // directory-entry swap is unavailable, but tmpPath still holds the COMPLETE
     // new content. Fallback: write to .tmp2, then rename atomically.
     // This avoids writing directly to the (possibly locked) target — the old

--- a/lib/flight-recorder/types.ts
+++ b/lib/flight-recorder/types.ts
@@ -114,6 +114,7 @@ export type EventType =
   | 'io.data-loss'    // t/1627: atomicWriteSync could not persist; new content preserved at tmpPath
   | 'io.lock-holder'  // t/2544: lock holder identified on EPERM exhaustion (handle.exe / unavailable fallback)
   | 'io.tmp-orphan'   // t/2555: stranded .tmp/.tmp2 file detected at startup sweep (recovered or preserved)
+  | 'io.contention'   // t/3415: a same-id save/load op waited for an in-flight op on the same id
   // Lock instrumentation
   | 'lock.acquire_attempt'
   | 'lock.acquired'

--- a/taxonomy-editor/src/main/__tests__/debateIO.idMutex.test.ts
+++ b/taxonomy-editor/src/main/__tests__/debateIO.idMutex.test.ts
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3415 regression: save-debate-session EPERM is a same-process self-lock (a
+// concurrent read holding an open handle on the target when the save's rename fires),
+// not antivirus. Two things are covered here:
+//   1. A per-id async mutex serializes save vs load/list for the SAME id, closing the
+//      race — an interleaved save+load on the same id must not let the write proceed
+//      while a read is still in flight.
+//   2. The outer save-failure error reuses the inner self-lock-aware diagnosis
+//      (persistence.ts) instead of overwriting it with a hardcoded "Windows
+//      antivirus/indexer" message — self-lock text vs external-lock text, both arms.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ActionableError } from '../../../../lib/debate/errors.js';
+
+const mockAtomicWriteSync = vi.hoisted(() => vi.fn());
+const mockExistsSync = vi.hoisted(() => vi.fn(() => true));
+const mockStatSync = vi.hoisted(() => vi.fn(() => ({ mtimeMs: 1 })));
+const mockMkdirSync = vi.hoisted(() => vi.fn());
+const mockWriteFileSync = vi.hoisted(() => vi.fn());
+const mockReadFileSync = vi.hoisted(() => vi.fn(() => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }); }));
+
+// A controllable deferred readFile so a "read in flight" can be held open across the
+// moment a same-id save is issued — proving the mutex actually serializes them.
+const readFileDeferred = vi.hoisted(() => {
+  let resolve!: (v: string) => void;
+  const promise = new Promise<string>((r) => { resolve = r; });
+  return { promise, resolve };
+});
+
+const events: string[] = [];
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  const mockReadFileProm = vi.fn(() => {
+    events.push('read:start');
+    return readFileDeferred.promise.then((v) => { events.push('read:resolve'); return v; });
+  });
+  const mockPromises = { ...actual.promises, readFile: mockReadFileProm };
+  const overrides = {
+    existsSync: mockExistsSync, statSync: mockStatSync, mkdirSync: mockMkdirSync,
+    writeFileSync: mockWriteFileSync, readFileSync: mockReadFileSync, promises: mockPromises,
+  };
+  return { ...actual, ...overrides, default: { ...actual, ...overrides } };
+});
+
+vi.mock('../fileIO.js', () => ({
+  resolveDataPath: vi.fn(() => '/fake/debates'),
+  PROJECT_ROOT: '/fake/root',
+}));
+
+vi.mock('../../../../lib/debate/calibrationLogger.js', () => ({
+  extractCalibrationData: vi.fn(),
+  appendCalibrationLog: vi.fn(),
+}));
+
+vi.mock('../../../../lib/debate/harvestOnSave.js', () => ({
+  harvestDebateTestedForSession: vi.fn(),
+}));
+
+vi.mock('../../../../lib/debate/persistence.js', () => ({
+  safeSerialize: vi.fn((v: unknown) => ({ json: JSON.stringify(v), hadError: false })),
+  atomicWriteSync: (...args: unknown[]) => {
+    events.push('write:atomic');
+    return mockAtomicWriteSync(...args);
+  },
+  renameSyncWithRetry: vi.fn(),
+}));
+
+vi.mock('../../../../lib/debate/lockHolder.js', () => ({ recordLockHolder: vi.fn() }));
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({ getGlobalRecorder: vi.fn(() => null) }));
+
+import { loadDebateSession, saveDebateSession } from '../debateIO.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  events.length = 0;
+  mockAtomicWriteSync.mockReset();
+  mockAtomicWriteSync.mockImplementation(() => undefined);
+});
+
+// withIdLock chains through several microtask hops (Promise.resolve().catch().then())
+// before fn() actually runs, so a single `await Promise.resolve()` doesn't reliably
+// observe the read having started. Flush via a macrotask, which only runs once the
+// microtask queue is fully drained.
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('debateIO — per-id read/write serialization (t/3415)', () => {
+  it('a save for the SAME id waits for an in-flight read to finish before writing', async () => {
+    const loadPromise = loadDebateSession('same-id');
+    await flushMicrotasks();
+    expect(events).toEqual(['read:start']);
+
+    const savePromise = saveDebateSession({ id: 'same-id', transcript: [] }, 'test');
+    // The read is still in flight — the save must not have written yet.
+    await flushMicrotasks();
+    expect(events).toEqual(['read:start']);
+
+    readFileDeferred.resolve('{"id":"same-id"}');
+    await loadPromise;
+    await savePromise;
+
+    expect(events).toEqual(['read:start', 'read:resolve', 'write:atomic']);
+  });
+});
+
+describe('debateIO — save error reuses inner self-lock diagnosis, not hardcoded AV (t/3415)', () => {
+  it('self-lock: outer error names the Electron process, not antivirus', async () => {
+    mockAtomicWriteSync.mockImplementation(() => {
+      throw new ActionableError({
+        goal: 'Persist bytes to debate file',
+        problem: 'Atomic rename and .tmp2 rename fallback were both denied (rename EPERM, fallback EPERM) — the target is held by electron.exe (pid 52308) longer than the retry budget allows.',
+        location: 'lib/debate/persistence.ts atomicWriteSync',
+        nextSteps: [
+          'The new content is preserved at the .tmp and was NOT deleted.',
+          'Retry the save once the lock clears.',
+          'The locker is the Electron process itself (electron.exe (pid 52308)) — check for overlapping write operations or an unclosed read handle in the same process.',
+        ],
+      });
+    });
+
+    const err = await saveDebateSession({ id: 'x', transcript: [] }, 'test').catch(e => e);
+    expect(err).toBeInstanceOf(ActionableError);
+    const ae = err as ActionableError;
+    expect(ae.problem).toContain('electron.exe (pid 52308)');
+    expect(ae.nextSteps.join(' ')).toContain('Electron process itself');
+    expect(ae.nextSteps.join(' ')).not.toContain('antivirus');
+  });
+
+  it('external-lock: outer error keeps the antivirus/indexer guidance for a genuine external lock', async () => {
+    mockAtomicWriteSync.mockImplementation(() => {
+      throw new ActionableError({
+        goal: 'Persist bytes to debate file',
+        problem: 'Atomic rename and .tmp2 rename fallback were both denied (rename EPERM, fallback EPERM) — the target is held by MsMpEng.exe (pid 1234) longer than the retry budget allows.',
+        location: 'lib/debate/persistence.ts atomicWriteSync',
+        nextSteps: [
+          'The new content is preserved at the .tmp and was NOT deleted.',
+          'Retry the save once the lock clears.',
+          'If saves keep failing, exclude the debates directory from antivirus/search-indexer scanning.',
+        ],
+      });
+    });
+
+    const err = await saveDebateSession({ id: 'y', transcript: [] }, 'test').catch(e => e);
+    expect(err).toBeInstanceOf(ActionableError);
+    const ae = err as ActionableError;
+    expect(ae.problem).toContain('MsMpEng.exe (pid 1234)');
+    expect(ae.nextSteps.join(' ')).toContain('antivirus');
+  });
+});

--- a/taxonomy-editor/src/main/__tests__/debateIO.safeId.test.ts
+++ b/taxonomy-editor/src/main/__tests__/debateIO.safeId.test.ts
@@ -71,12 +71,12 @@ describe('debateIO — assertSafeId traversal guards', () => {
     await expect(loadDebateSession('abc-123')).resolves.toBeDefined();
   });
 
-  it.each(TRAVERSAL_IDS)('saveDebateSession rejects traversal in session.id "%s"', (id) => {
-    expect(() => saveDebateSession({ id, transcript: [] }, 'test')).toThrow();
+  it.each(TRAVERSAL_IDS)('saveDebateSession rejects traversal in session.id "%s"', async (id) => {
+    await expect(saveDebateSession({ id, transcript: [] }, 'test')).rejects.toThrow();
   });
 
-  it('saveDebateSession accepts valid id', () => {
-    expect(() => saveDebateSession({ id: 'abc-123', transcript: [] }, 'test')).not.toThrow();
+  it('saveDebateSession accepts valid id', async () => {
+    await expect(saveDebateSession({ id: 'abc-123', transcript: [] }, 'test')).resolves.not.toThrow();
   });
 
   it.each(TRAVERSAL_IDS)('deleteDebateSession rejects "%s"', (id) => {

--- a/taxonomy-editor/src/main/__tests__/debateIO.saveEnrich.test.ts
+++ b/taxonomy-editor/src/main/__tests__/debateIO.saveEnrich.test.ts
@@ -49,7 +49,7 @@ beforeEach(() => { h.failWith = null; });
 afterAll(() => { if (h.debatesRoot) fs.rmSync(h.debatesRoot, { recursive: true, force: true }); });
 
 describe('saveDebateSession enriches total-loss ActionableError (t/1638)', () => {
-  it('re-throws with debate id, run_id, turn_count, and the preserved .tmp path', () => {
+  it('re-throws with debate id, run_id, turn_count, and the preserved .tmp path', async () => {
     // Simulate the exact contract atomicWriteSync throws on total loss (t/1627).
     h.failWith = new ActionableError({
       goal: 'Persist bytes to debate file',
@@ -66,7 +66,7 @@ describe('saveDebateSession enriches total-loss ActionableError (t/1638)', () =>
     };
 
     let caught: unknown;
-    try { saveDebateSession(session, 'test'); } catch (e) { caught = e; }
+    try { await saveDebateSession(session, 'test'); } catch (e) { caught = e; }
 
     expect(caught).toBeInstanceOf(ActionableError);
     const ae = caught as ActionableError;
@@ -92,7 +92,7 @@ describe('saveDebateSession enriches total-loss ActionableError (t/1638)', () =>
     expect(ae.innerError).toBe(h.failWith);
   });
 
-  it('defaults run_id to "unknown" and turn_count to 0 when the session lacks them', () => {
+  it('defaults run_id to "unknown" and turn_count to 0 when the session lacks them', async () => {
     // Non-lock rename errors rethrow the RAW error (not an ActionableError);
     // the wrapper must still enrich it into an ActionableError.
     h.failWith = new Error('EXDEV: cross-device link not permitted');
@@ -100,7 +100,7 @@ describe('saveDebateSession enriches total-loss ActionableError (t/1638)', () =>
     const session = { id: 'deb-min' }; // no run_id, no transcript
 
     let caught: unknown;
-    try { saveDebateSession(session, 'test'); } catch (e) { caught = e; }
+    try { await saveDebateSession(session, 'test'); } catch (e) { caught = e; }
 
     expect(caught).toBeInstanceOf(ActionableError);
     const ae = caught as ActionableError;

--- a/taxonomy-editor/src/main/debateIO.ts
+++ b/taxonomy-editor/src/main/debateIO.ts
@@ -16,6 +16,41 @@ import { getGlobalRecorder } from '../../../lib/flight-recorder/index.js';
 const DEBATES_DIR = resolveDataPath('debates');
 const INDEX_PATH = path.join(DEBATES_DIR, '.debate-index.json');
 
+// ── Per-id read/write serialization (t/3415) ────────────────────────────
+// Same-process self-lock: an in-flight async read (loadDebateSession, or a
+// listDebateSessions per-file read) can still hold an open OS handle on a
+// debate's .json file — via the libuv threadpool — at the exact moment a
+// separate, later IPC call's saveDebateSession fires its rename-replace.
+// Windows denies the rename (EPERM) unless the open handle carries
+// FILE_SHARE_DELETE, which Node's fs paths don't set. Chaining a per-id
+// promise queue here closes that window at the single choke point every
+// renderer save/load call funnels through — this module. Different ids
+// never block each other; contention (an op actually waiting on a prior one
+// for the SAME id) is flight-recorded so the window's frequency stays
+// observable rather than silently absorbed.
+const idLocks = new Map<string, Promise<unknown>>();
+
+function withIdLock<T>(id: string, op: 'read' | 'write', fn: () => Promise<T>): Promise<T> {
+  const prior = idLocks.get(id);
+  const contended = prior !== undefined;
+  const run: Promise<T> = (prior ?? Promise.resolve()).catch(() => undefined).then(() => {
+    if (contended) {
+      getGlobalRecorder()?.record({
+        type: 'io.contention', component: 'debateIO', level: 'info',
+        message: `debate ${id}: ${op} waited for an in-flight operation on the same id`,
+        data: { debate_id: id, op },
+      });
+    }
+    return fn();
+  });
+  const tracked = run.catch(() => undefined);
+  idLocks.set(id, tracked);
+  tracked.finally(() => {
+    if (idLocks.get(id) === tracked) idLocks.delete(id);
+  });
+  return run;
+}
+
 export interface DebateSessionSummary {
   id: string;
   title: string;
@@ -175,9 +210,12 @@ export async function listDebateSessions(): Promise<DebateSessionSummary[]> {
     indexDirty = true;
   }
 
-  // Read changed/new files async (non-blocking)
-  const reads = readQueue.map(({ filename, filePath }) =>
-    fs.promises.readFile(filePath, 'utf-8').then(raw => {
+  // Read changed/new files async (non-blocking). Each read is serialized against a
+  // concurrent save for the SAME id via withIdLock (t/3415) — different ids read in
+  // parallel as before.
+  const reads = readQueue.map(({ filename, filePath }) => {
+    const id = filename.replace(/^debate-/, '').replace(/\.json$/, '');
+    return withIdLock(id, 'read', () => fs.promises.readFile(filePath, 'utf-8')).then(raw => {
       const data = JSON.parse(raw) as Record<string, unknown>;
       const summary = extractSummary(data);
       const stat = fs.statSync(filePath);
@@ -191,8 +229,8 @@ export async function listDebateSessions(): Promise<DebateSessionSummary[]> {
         message: `Skipping corrupt debate file: ${filename}`,
         error: { name: (err as Error).name ?? 'Error', message: String(err) },
       });
-    })
-  );
+    });
+  });
   await Promise.all(reads);
 
   if (indexDirty) saveIndex(nextIndex);
@@ -202,12 +240,14 @@ export async function listDebateSessions(): Promise<DebateSessionSummary[]> {
 }
 
 export async function loadDebateSession(id: string): Promise<unknown> {
-  const filePath = debateFilePath(id);
-  if (!fs.existsSync(filePath)) {
-    throw new Error(`Debate session not found: ${id}`);
-  }
-  const raw = await fs.promises.readFile(filePath, 'utf-8');
-  return JSON.parse(raw);
+  const filePath = debateFilePath(id); // validates id — throws before touching the lock map
+  return withIdLock(id, 'read', async () => {
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`Debate session not found: ${id}`);
+    }
+    const raw = await fs.promises.readFile(filePath, 'utf-8');
+    return JSON.parse(raw);
+  });
 }
 
 /** For a completed debate (has a concluding turn) that lacks a calibration_log, extract +
@@ -225,84 +265,95 @@ function embedCalibrationIfCompleted(session: unknown): void {
   } catch { /* telemetry — silent by design;  calibration logging never blocks save */ }
 }
 
-export function saveDebateSession(session: unknown, caller: string): void {
+export async function saveDebateSession(session: unknown, caller: string): Promise<void> {
   ensureDebatesDir();
   const data = session as { id: string };
   if (!data.id || typeof data.id !== 'string') {
     throw new Error('Cannot save debate session: missing or invalid ID');
   }
+  const filePath = debateFilePath(data.id); // validates id — throws before touching the lock map
 
-  // Embed calibration data for completed debates before saving (best-effort).
-  embedCalibrationIfCompleted(session);
+  return withIdLock(data.id, 'write', async () => {
+    // Embed calibration data for completed debates before saving (best-effort).
+    embedCalibrationIfCompleted(session);
 
-  const filePath = debateFilePath(data.id);
-  // Crash-safe persistence (t/1140): safe-serialize (circular/non-serializable fields fall
-  // back to a sanitizing replacer and are logged) + atomic temp+rename so a crash mid-write
-  // can't leave a truncated session file.
-  const { json, hadError, errorMessage } = safeSerialize(session, 2);
-  if (hadError) {
-    getGlobalRecorder()?.record({
-      type: 'system.error', component: 'debateIO', level: 'warn',
-      message: `Debate session ${data.id} saved via sanitizing fallback (non-serializable fields stripped): ${errorMessage}`,
-      error: { name: 'SerializationFallback', message: errorMessage ?? 'unknown' },
-    });
-  }
-  try {
-    atomicWriteSync(filePath, json + '\n', recordLockHolder);
-  } catch (err) {
-    // t/1638: atomicWriteSync (t/1627) throws on a total-loss save naming only
-    // filePath/tmpPath; re-throw enriched with the debate-specific state (id, run_id,
-    // turn_count + preserved .tmp). record() + throw stay here (ADR-003 in-catch rule).
-    const { runId, turnCount, tmpPath } = computeSaveLossContext(session, filePath);
-    getGlobalRecorder()?.record({
-      type: 'system.error', component: 'debateIO', level: 'error',
-      message: `Debate save failed for ${data.id} (run ${runId}, ${turnCount} turns) — payload preserved at ${tmpPath}`,
-      data: { debateId: data.id, runId, turnCount, tmpPath },
-      error: { name: (err as Error).name ?? 'Error', message: String((err as Error).message ?? err), stack: (err as Error).stack },
-    });
-    throw new ActionableError({
-      goal: `Save debate ${data.id} (run ${runId}, ${turnCount} turns) to ${filePath}`,
-      problem: `The atomic write to ${filePath} failed after exhausting the rename-retry budget and the in-place copy fallback — the target is held by another process (Windows antivirus/indexer). Debate ${data.id}, run ${runId}: ${turnCount} turns are at risk of being lost.`,
-      location: 'taxonomy-editor/src/main/debateIO.ts saveDebateSession',
-      nextSteps: [
-        `The full session snapshot for debate ${data.id} (run ${runId}, ${turnCount} turns) is preserved at ${tmpPath} and was NOT deleted — it is the only durable copy. Do not remove it.`,
-        `Retry the save once the file lock clears; the next successful save re-persists all ${turnCount} turns and replaces ${filePath}, after which ${tmpPath} may be removed.`,
-        `If saves keep failing, exclude the debates directory from antivirus/search-indexer scanning.`,
-      ],
-      innerError: err,
-    });
-  }
-
-  // Update metadata index so next list call skips re-reading this file
-  try {
-    const index = loadIndex();
-    updateIndexEntry(index, data.id, session as Record<string, unknown>);
-    saveIndex(index);
-  } catch (err) {
-    getGlobalRecorder()?.record({ type: 'system.error', component: 'debateIO', level: 'warn', message: 'Debate index update after save failed', error: { name: (err as Error).name ?? 'Error', message: String(err) } });
-  }
-
-  getGlobalRecorder()?.record({
-    type: 'state.save', component: 'debateIO', level: 'info',
-    message: 'Debate saved',
-    data: { debate_id: data.id, caller, save_mode: 'electron-main' },
-  });
-
-  // Harvest debate_tested tier increments after save (t/3330). Deferred so harvest never
-  // blocks save latency. Flag default-OFF until coordinated corpus reconcile (t/3330#2).
-  const _session = session;
-  const _id = data.id;
-  setImmediate(() => {
-    if (process.env.HARVEST_DEBATE_TESTED_ON_SAVE !== '1') return;
-    try {
-      harvestDebateTestedForSession(_session as HarvestableSession, PROJECT_ROOT);
-    } catch (err) {
+    // Crash-safe persistence (t/1140): safe-serialize (circular/non-serializable fields fall
+    // back to a sanitizing replacer and are logged) + atomic temp+rename so a crash mid-write
+    // can't leave a truncated session file.
+    const { json, hadError, errorMessage } = safeSerialize(session, 2);
+    if (hadError) {
       getGlobalRecorder()?.record({
         type: 'system.error', component: 'debateIO', level: 'warn',
-        message: `debate_tested auto-harvest failed for ${_id}`,
-        error: { name: (err as Error).name ?? 'Error', message: String(err) },
+        message: `Debate session ${data.id} saved via sanitizing fallback (non-serializable fields stripped): ${errorMessage}`,
+        error: { name: 'SerializationFallback', message: errorMessage ?? 'unknown' },
       });
     }
+    try {
+      atomicWriteSync(filePath, json + '\n', recordLockHolder);
+    } catch (err) {
+      // t/1638: atomicWriteSync (t/1627) throws on a total-loss save naming only
+      // filePath/tmpPath; re-throw enriched with the debate-specific state (id, run_id,
+      // turn_count + preserved .tmp). record() + throw stay here (ADR-003 in-catch rule).
+      const { runId, turnCount, tmpPath } = computeSaveLossContext(session, filePath);
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'debateIO', level: 'error',
+        message: `Debate save failed for ${data.id} (run ${runId}, ${turnCount} turns) — payload preserved at ${tmpPath}`,
+        data: { debateId: data.id, runId, turnCount, tmpPath },
+        error: { name: (err as Error).name ?? 'Error', message: String((err as Error).message ?? err), stack: (err as Error).stack },
+      });
+      // t/3415: when the inner failure is persistence.ts's own ActionableError, it has
+      // already computed the ACTUAL lock holder and correctly distinguished self-lock
+      // ("the Electron process itself") from an external lock — reuse that diagnosis
+      // instead of overwriting it with a hardcoded "Windows antivirus/indexer" guess,
+      // which misdirects a same-process self-lock user straight to a useless AV exclusion.
+      const inner = err instanceof ActionableError ? err : undefined;
+      const problem = inner
+        ? `${inner.problem} Debate ${data.id}, run ${runId}: ${turnCount} turns are at risk of being lost.`
+        : `The atomic write to ${filePath} failed after exhausting the rename-retry budget and the in-place copy fallback. Debate ${data.id}, run ${runId}: ${turnCount} turns are at risk of being lost.`;
+      throw new ActionableError({
+        goal: `Save debate ${data.id} (run ${runId}, ${turnCount} turns) to ${filePath}`,
+        problem,
+        location: 'taxonomy-editor/src/main/debateIO.ts saveDebateSession',
+        nextSteps: [
+          `The full session snapshot for debate ${data.id} (run ${runId}, ${turnCount} turns) is preserved at ${tmpPath} and was NOT deleted — it is the only durable copy. Do not remove it.`,
+          `Retry the save once the file lock clears; the next successful save re-persists all ${turnCount} turns and replaces ${filePath}, after which ${tmpPath} may be removed.`,
+          inner?.nextSteps[2] ?? `If saves keep failing, exclude the debates directory from antivirus/search-indexer scanning.`,
+        ],
+        innerError: err,
+      });
+    }
+
+    // Update metadata index so next list call skips re-reading this file
+    try {
+      const index = loadIndex();
+      updateIndexEntry(index, data.id, session as Record<string, unknown>);
+      saveIndex(index);
+    } catch (err) {
+      getGlobalRecorder()?.record({ type: 'system.error', component: 'debateIO', level: 'warn', message: 'Debate index update after save failed', error: { name: (err as Error).name ?? 'Error', message: String(err) } });
+    }
+
+    getGlobalRecorder()?.record({
+      type: 'state.save', component: 'debateIO', level: 'info',
+      message: 'Debate saved',
+      data: { debate_id: data.id, caller, save_mode: 'electron-main' },
+    });
+
+    // Harvest debate_tested tier increments after save (t/3330). Deferred so harvest never
+    // blocks save latency. Flag default-OFF until coordinated corpus reconcile (t/3330#2).
+    const _session = session;
+    const _id = data.id;
+    setImmediate(() => {
+      if (process.env.HARVEST_DEBATE_TESTED_ON_SAVE !== '1') return;
+      try {
+        harvestDebateTestedForSession(_session as HarvestableSession, PROJECT_ROOT);
+      } catch (err) {
+        getGlobalRecorder()?.record({
+          type: 'system.error', component: 'debateIO', level: 'warn',
+          message: `debate_tested auto-harvest failed for ${_id}`,
+          error: { name: (err as Error).name ?? 'Error', message: String(err) },
+        });
+      }
+    });
   });
 }
 

--- a/taxonomy-editor/src/main/debateIO.ts
+++ b/taxonomy-editor/src/main/debateIO.ts
@@ -45,7 +45,7 @@ function withIdLock<T>(id: string, op: 'read' | 'write', fn: () => Promise<T>): 
   });
   const tracked = run.catch(() => undefined);
   idLocks.set(id, tracked);
-  tracked.finally(() => {
+  void tracked.finally(() => {
     if (idLocks.get(id) === tracked) idLocks.delete(id);
   });
   return run;

--- a/taxonomy-editor/src/main/ipc/debateHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/debateHandlers.ts
@@ -45,8 +45,8 @@ export function registerDebateHandlers(): void {
     return loadDebateSession(id);
   });
 
-  ipcMain.handle('save-debate-session', (_event, session: unknown, caller: string) => {
-    saveDebateSession(session, caller);
+  ipcMain.handle('save-debate-session', async (_event, session: unknown, caller: string) => {
+    await saveDebateSession(session, caller);
   });
 
   ipcMain.handle('delete-debate-session', (_event, id: string) => {

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/sessionSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/sessionSlice.ts
@@ -330,7 +330,7 @@ function computeSaveErrorState(err: unknown, activeDebate: DebateSession): { isD
   if (isAuthQuotaFailure) {
     debateError = `Save failed: the server rejected this save (HTTP ${httpStatus}). ${atRiskTurns} ${atRiskTurns === 1 ? 'turn is' : 'turns are'} at risk of being lost. Check your API key and account status in Settings.`;
   } else if (isDiskLoss) {
-    debateError = `Save failed: this debate couldn't be written to disk — a file lock (often antivirus or a file indexer) is holding the file. ${atRiskTurns} ${atRiskTurns === 1 ? 'turn is' : 'turns are'} at risk. A recovery copy was preserved on disk; retry the save once the lock clears, and don't close the app before it succeeds.`;
+    debateError = `Save failed: this debate couldn't be written to disk — another process (the app itself, antivirus, or a file indexer) is holding the file open. ${atRiskTurns} ${atRiskTurns === 1 ? 'turn is' : 'turns are'} at risk. A recovery copy was preserved on disk; retry the save once the lock clears, and don't close the app before it succeeds.`;
   } else if (isBreakerBlocked) {
     debateError = `Saving is paused while the server recovers. ${atRiskTurns} ${atRiskTurns === 1 ? 'turn is' : 'turns are'} not yet saved — this will retry automatically. Keep the app open.`;
   } else {


### PR DESCRIPTION
## Summary

Diagnosed by Diagnostics; TL decomposition + spec at t/3415#1, scope amendment at p/577#34.

**Root cause:** `save-debate-session` EPERM on Windows is a same-process self-lock, not antivirus. A concurrent async read (`loadDebateSession` or a `listDebateSessions` per-file read) can still hold an open OS handle on a debate's `.json` file — via the libuv threadpool — at the exact moment a later, separate IPC call's save fires its rename-replace. Windows denies the rename unless the open handle carries `FILE_SHARE_DELETE`, which Node's fs paths don't set.

**Fix:**
- Per-id async mutex (`withIdLock`) in `debateIO.ts` serializing `saveDebateSession` against `loadDebateSession`/`listDebateSessions` for the SAME id. Different ids stay fully concurrent. `saveDebateSession` is now async; `debateHandlers.ts` awaits it so IPC error propagation to the renderer is unchanged.
- The outer save-failure error now reuses `persistence.ts`'s own self-lock-aware diagnosis (problem + nextSteps) instead of overwriting it with a hardcoded "Windows antivirus/indexer" message that misdirected a self-lock user to a useless AV exclusion.
- Contention observability: a new `io.contention` flight-recorder event fires only when an op genuinely waits on a same-id op already in flight (added to `lib/flight-recorder/types.ts`'s `EventType` union).
- Regression test `debateIO.idMutex.test.ts`: interleaved save+load on the same id serializes with no EPERM; both-arms error-message coverage (self-lock text vs external-lock text).

**Scope amendment (p/577#34):** also fixed the same AV-framing bug at three more sites Diagnostics found (all trivial, <5 lines, text-only):
- `sessionSlice.ts:333` — user-facing save-error toast no longer assumes AV.
- `persistence.ts` comments — broadened to acknowledge same-process self-lock as a cause.
- `persistenceRetryBudget.test.ts` — both-arms test titles + a clarifying comment noting the external-lock arm's `antivirus` assertion is accurate for that specific test process (MsMpEng.exe, genuine AV), not a blanket external-lock assumption.

## Test plan

- [x] `debateIO.idMutex.test.ts` (new) — interleaved save+load ordering, self-lock vs external-lock error-message arms.
- [x] `debateIO.safeId.test.ts`, `debateIO.saveEnrich.test.ts` — updated to the new async `saveDebateSession` contract, still pass.
- [x] `persistenceRetryBudget.test.ts` — 15/15 pass, no behavior change.
- [x] Full `src/main/__tests__/` suite — 300/301 pass; the 1 failure (`validateDataRoot.test.ts`, Windows path separator) and 1 pre-existing suite load failure (`communityReviewIO.test.ts`, missing optional npm package) are both baseline/environment issues unrelated to this change, confirmed via `tsc` baseline scan before starting.
- [x] `tsc -p tsconfig.main.json` — no new errors.

Closes t/3415.

🤖 Generated with [Claude Code](https://claude.com/claude-code)