### PR TITLE
fix(aiHandlers): distinguish TimeoutError from generic errors in generate-text (t/3417)

### DIFF
--- a/taxonomy-editor/src/main/__tests__/aiHandlers.timeoutMessage.test.ts
+++ b/taxonomy-editor/src/main/__tests__/aiHandlers.timeoutMessage.test.ts
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3417 regression: AbortSignal.timeout() (the ai-client per-attempt fetch deadline)
+// fires with .name === 'TimeoutError', not 'AbortError' — it must NOT be treated as a
+// user-initiated cancel, and must surface a timeout-specific ActionableError instead of
+// the generic "check your API key / rate limits" message.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ipcMain } from 'electron';
+
+const mockGenerateText = vi.hoisted(() => vi.fn());
+
+vi.mock('../embeddings.js', () => ({
+  generateText: mockGenerateText,
+  generateChatStream: vi.fn(),
+  generateTextWithSearch: vi.fn(),
+  computeEmbeddings: vi.fn(),
+  computeQueryEmbedding: vi.fn(),
+  updateNodeEmbeddings: vi.fn(),
+  classifyNli: vi.fn(),
+  setDebateTemperature: vi.fn(),
+  getEmbeddingInfo: vi.fn(),
+}));
+
+vi.mock('../../../../lib/ai-client/index.js', () => ({
+  resolveBackend: vi.fn(() => 'gemini'),
+  DEFAULT_MODEL: 'gemini-2.0-flash',
+  DEFAULT_TEMPERATURE: 0.7,
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() },
+  app: { getPath: vi.fn(() => '/tmp'), getVersion: vi.fn(() => '1.0.0') },
+  safeStorage: { isEncryptionAvailable: vi.fn(() => false), encryptString: vi.fn(), decryptString: vi.fn() },
+}));
+
+vi.mock('../fileIO.js', () => ({
+  PROJECT_ROOT: '/fake/root',
+  getDataRootPath: vi.fn(() => '/fake/data'),
+  resolveDataPath: vi.fn((p: string) => `/fake/data/${p}`),
+}));
+
+vi.mock('../aiCallLog.js', () => ({ writeAICallLogEntry: vi.fn() }));
+vi.mock('../modelDiscovery.js', () => ({ refreshAIModels: vi.fn() }));
+vi.mock('../embeddingErrors.js', () => ({ buildEmbeddingFailureError: vi.fn() }));
+vi.mock('../../../../lib/debate/errors.js', () => ({
+  ActionableError: class ActionableError extends Error {
+    problem: string; goal: string; location: string; nextSteps: string[];
+    constructor(args: { goal: string; problem: string; location: string; nextSteps: string[]; innerError?: unknown }) {
+      super(args.problem);
+      this.name = 'ActionableError';
+      this.goal = args.goal; this.problem = args.problem; this.location = args.location; this.nextSteps = args.nextSteps;
+    }
+  },
+}));
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({ getGlobalRecorder: vi.fn(() => null) }));
+vi.mock('../../../../lib/debate/constants.js', () => ({ DEFAULT_RELEVANCE_THRESHOLD: 0.5 }));
+vi.mock('../../../../lib/url-fetch/fetchUrlForPrompt.js', () => ({ fetchUrlForPrompt: vi.fn() }));
+
+import { registerAiHandlers } from '../ipc/aiHandlers.js';
+import { ActionableError } from '../../../../lib/debate/errors.js';
+
+function getHandler(channel: string): (event: unknown, ...args: unknown[]) => Promise<unknown> {
+  const calls = (ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls;
+  const entry = calls.find((c: unknown[]) => c[0] === channel);
+  if (!entry) throw new Error(`${channel} handler not registered`);
+  return entry[1];
+}
+
+function makeSender() {
+  return { sender: { isDestroyed: () => false, send: vi.fn() } };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  registerAiHandlers();
+});
+
+describe('generate-text — TimeoutError surfaces a distinct, actionable message (t/3417)', () => {
+  it('wraps a TimeoutError with timeout-specific guidance, not the generic API-key message', async () => {
+    const timeoutErr = new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+    mockGenerateText.mockRejectedValue(timeoutErr);
+
+    const handler = getHandler('generate-text');
+    const { sender } = makeSender();
+    const err = await handler({ sender }, 'prompt', undefined, undefined, undefined, undefined).catch(e => e);
+
+    expect(err).toBeInstanceOf(ActionableError);
+    const ae = err as ActionableError;
+    expect(ae.problem).toContain('did not respond within the allotted timeout');
+    expect(ae.nextSteps.join(' ')).not.toContain('Verify your API key');
+    expect(ae.nextSteps.join(' ')).toContain('Retry');
+  });
+
+  it('a TimeoutError does NOT hit the user-cancel path (no requestId, no cancel)', async () => {
+    const timeoutErr = new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+    mockGenerateText.mockRejectedValue(timeoutErr);
+
+    const handler = getHandler('generate-text');
+    const { sender } = makeSender();
+    const err = await handler({ sender }, 'prompt', undefined, undefined, undefined, 'req-timeout-1').catch(e => e);
+
+    // A genuine cancel rethrows the raw error verbatim; a timeout must be wrapped.
+    expect(err).toBeInstanceOf(ActionableError);
+  });
+
+  it('a genuine AbortError (user cancel) is still rethrown raw, unaffected by this change', async () => {
+    const abortErr = new DOMException('The user aborted a request', 'AbortError');
+    mockGenerateText.mockRejectedValue(abortErr);
+
+    const handler = getHandler('generate-text');
+    const { sender } = makeSender();
+    const err = await handler({ sender }, 'prompt', undefined, undefined, undefined, 'req-cancel-1').catch(e => e);
+
+    expect(err).toBe(abortErr);
+    expect(err).not.toBeInstanceOf(ActionableError);
+  });
+});

--- a/taxonomy-editor/src/main/ipc/aiHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/aiHandlers.ts
@@ -36,6 +36,25 @@ function deriveCallLogStatus(err: unknown): string {
   return 'error';
 }
 
+// t/3417: AbortSignal.timeout() (the per-attempt fetch deadline, ai-client's
+// makeFetchSignal) fires with .name === 'TimeoutError', NOT 'AbortError' — it doesn't
+// match generate-text's cancel check, so without this it fell through to the generic
+// ActionableError, which tells the user to check their API key / rate limits —
+// misleading for a request that simply took too long to respond.
+function buildTimeoutError(err: unknown, elapsedMs: number): ActionableError {
+  return new ActionableError({
+    goal: 'Generate text via AI backend',
+    problem: `The AI backend did not respond within the allotted timeout for this request (${elapsedMs}ms elapsed).`,
+    location: 'ipcHandlers.generateText',
+    nextSteps: [
+      'Retry — a single slow response does not necessarily mean the backend is down',
+      'If this recurs, the prompt may be too large or complex for the current model — try a shorter prompt or a faster model',
+      'Try a different AI backend if the current one is consistently slow',
+    ],
+    innerError: err,
+  });
+}
+
 // ── Per-request AbortController map (t/2509) ──────────────────────────────
 
 const activeGenerations = new Map<string, AbortController>();
@@ -194,6 +213,16 @@ export function registerAiHandlers(): void {
         });
         writeAICallLogEntry({ scenario: 'Debate', promptId: '', promptStart: prompt, retryCount, status: deriveCallLogStatus(err) });
         throw err;
+      }
+      if ((err as Error).name === 'TimeoutError') {
+        const elapsedMs = Date.now() - t0;
+        getGlobalRecorder()?.record({
+          type: 'system.error', component: 'ipc-handlers', level: 'warn',
+          message: `generate-text timed out after ${elapsedMs}ms`,
+          error: { name: 'TimeoutError', message: String((err as Error).message ?? err) },
+        });
+        writeAICallLogEntry({ scenario: 'Debate', promptId: '', promptStart: prompt, retryCount, status: deriveCallLogStatus(err) });
+        throw buildTimeoutError(err, elapsedMs);
       }
       const problem = err instanceof ActionableError ? err.problem : (err instanceof Error ? err.message : String(err));
       getGlobalRecorder()?.record({


### PR DESCRIPTION
## Summary

Investigated per t/3417 (Diagnostics, TL ruling p/334#251 / t/3415#3 item 3). Full diagnosis posted at t/3417#1.

**Root cause:** `AbortSignal.timeout()` (the ai-client per-attempt fetch deadline, `makeFetchSignal`) fires with `.name === 'TimeoutError'`, not `'AbortError'`. `generate-text`'s cancel check only matched `'AbortError'`, so a genuine 120s backend timeout fell through to the generic ActionableError branch — telling the user to check their API key / rate limits, which is misleading for a request that simply took too long.

**Fix:** a distinct `TimeoutError` branch (extracted into `buildTimeoutError` to keep complexity down) with timeout-specific guidance: retry, shorten the prompt, or try a different backend. Genuine user-cancel (`AbortError` / `controller.aborted`) is unaffected. `deriveCallLogStatus` already classified `TimeoutError` correctly as `'timeout'` in the call log — no change needed there.

**Left open** (documented on the ticket): whether `withRetry`'s retry-on-timeout is actually firing in practice for this path (it should, per its `isRetryable` set including `'timed out'`), and the exact FR/log timestamp correlation with t/3415's observed window-reload — both need a live dump I don't have access to in this session.

## Test plan

- [x] `aiHandlers.timeoutMessage.test.ts` (new) — TimeoutError wraps with timeout-specific guidance (not API-key text); a genuine AbortError user-cancel still rethrows raw, unaffected.
- [x] `aiHandlers.cancelGenerate.test.ts`, `aiHandlers.callLog.test.ts` — still pass, unaffected.
- [x] `tsc -p tsconfig.main.json` — no new errors.
- [x] `eslint` — 0 errors (1 pre-existing-pattern complexity warning, consistent with dozens of others already in this codebase, non-blocking).

Closes t/3417.

🤖 Generated with [Claude Code](https://claude.com/claude-code)