### PR TITLE
fix(debate-workspace): normalize legacy {challenge,type} objects in AnticipatedBox (t/3418)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/TaxonomyRefs.planDetail.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/TaxonomyRefs.planDetail.test.tsx
@@ -108,6 +108,44 @@ describe('TaxonomyRefsSection — PLAN anchor → inline POV detail (t/1724)', (
   });
 });
 
+describe('AnticipatedBox — legacy object-shape items (t/3418, React #31 regression)', () => {
+  beforeEach(() => { vi.clearAllMocks(); usePreferencesStore.setState({ viewMode: 'advanced' }); });
+
+  it('renders without throwing when anticipated_challenges/responses are legacy {challenge, type} objects', () => {
+    const stageDiagnostics = [
+      {
+        stage: 'plan',
+        raw_response: '',
+        work_product: {
+          strategic_goal: 'Win the point',
+          anticipated_challenges: [{ challenge: 'They will cite cost.', type: 'economic' }],
+          anticipated_responses: [{ challenge: 'Point to long-run savings.' }],
+        },
+      },
+    ];
+    expect(() =>
+      render(<TaxonomyRefsSection refs={[]} stageDiagnostics={stageDiagnostics} forceExpanded />)
+    ).not.toThrow();
+    expect(screen.getByText('economic: They will cite cost.')).toBeInTheDocument();
+    expect(screen.getByText('Point to long-run savings.')).toBeInTheDocument();
+  });
+
+  it('still renders plain tagged-string items (new schema) unchanged', () => {
+    const stageDiagnostics = [
+      {
+        stage: 'plan',
+        raw_response: '',
+        work_product: {
+          strategic_goal: 'Win the point',
+          anticipated_challenges: ['economic: They will cite cost.'],
+        },
+      },
+    ];
+    render(<TaxonomyRefsSection refs={[]} stageDiagnostics={stageDiagnostics} forceExpanded />);
+    expect(screen.getByText('economic: They will cite cost.')).toBeInTheDocument();
+  });
+});
+
 describe('TheoryLink help icons — mounts f + g (t/2347)', () => {
   it('renders the artifact-guide icon on BRIEF + PLAN and the citation-diagnostics icon in the statement footer, with distinct aria-labels', () => {
     const stageDiagnostics = [

--- a/taxonomy-editor/src/renderer/components/debate-workspace/TaxonomyRefs.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/TaxonomyRefs.tsx
@@ -316,14 +316,26 @@ function ArgumentSketchBox({ wp }: { wp: Record<string, unknown> }) {
   );
 }
 
+// t/3418: anticipated_challenges/anticipated_responses migrated object → tagged-string
+// (t/3404, PR #2093), but debates persisted under the old schema still have
+// {challenge, type} objects — rendering one directly is React error #31.
+function normalizeAnticipatedItem(r: unknown): string {
+  if (typeof r === 'string') return r;
+  if (r && typeof r === 'object' && 'challenge' in r) {
+    const { challenge, type } = r as { challenge: unknown; type?: unknown };
+    return `${type ? `${String(type)}: ` : ''}${String(challenge)}`;
+  }
+  return String(r);
+}
+
 function AnticipatedBox({ wp, field, title }: { wp: Record<string, unknown>; field: string; title: string }) {
   const items = wp[field];
-  if (!Array.isArray(items) || (items as string[]).length === 0) return null;
+  if (!Array.isArray(items) || items.length === 0) return null;
   return (
     <details className="taxrefs-details"><summary className="taxrefs-summary">{title}</summary>
       <ul className="taxrefs-anticipated-list">
-        {(items as string[]).map((r, i) => (
-          <li key={i}>{r}</li>
+        {items.map((r, i) => (
+          <li key={i}>{normalizeAnticipatedItem(r)}</li>
         ))}
       </ul>
     </details>


### PR DESCRIPTION
## Summary
- Fixes t/3418 (high-priority, FR-triage escalation p/334): opening a persisted community debate crashed the entire workspace with React error #31 (fatal, via the error boundary) when `AnticipatedBox` rendered a `{challenge, type}` object directly as a React child.
- Root cause: `anticipated_challenges`/`anticipated_responses` migrated object → tagged-string (t/3404, PR #2093), but debates persisted under the old schema still carry the legacy object shape. The reader assumed the new shape and rendered items unchecked.
- Fix: `normalizeAnticipatedItem()` accepts `string | {challenge, type?} | other`, rendering `"type: challenge"` for the legacy shape (matching the new tagged-string convention) and falling back to `String(r)` for anything else. Covers both `anticipated_challenges` and `anticipated_responses` — they share one renderer.
- Per the ticket's sibling-field sweep: the other `work_product` array renderers (`framing_choices`, `planned_moves`, `argument_structure`) render named subfields, so shape drift there degrades to `undefined` cells rather than a #31 crash — no fix needed there.

## Test plan
- [x] New regression test: legacy `{challenge, type}` objects in both fields render without throwing, producing `"type: challenge"` text
- [x] New test: new-schema tagged-string items still render unchanged
- [x] `npx vitest run src/renderer/components/debate-workspace/` — 274/274 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
