### PR TITLE
feat(debate-workspace): section-level error boundary for PLAN body render throws (t/3419)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/SectionErrorBoundary.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/SectionErrorBoundary.test.tsx
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3419 — a render throw in one section must degrade to an inline fallback
+// for that section only, and record the failure at `error` (not `fatal`) so
+// it's diagnosable without triggering the top-level crash/dump flow.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+const record = vi.fn();
+vi.mock('@lib/flight-recorder/index', () => ({
+  getGlobalRecorder: () => ({ record }),
+}));
+
+import { SectionErrorBoundary } from './SectionErrorBoundary';
+
+function Boom(): never {
+  throw new Error('boom');
+}
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+describe('SectionErrorBoundary (t/3419)', () => {
+  it('renders children normally when there is no error', () => {
+    render(
+      <SectionErrorBoundary section="Test Section">
+        <div data-testid="ok">fine</div>
+      </SectionErrorBoundary>
+    );
+    expect(screen.getByTestId('ok')).toBeInTheDocument();
+  });
+
+  it('catches a render throw and shows an inline fallback naming the section', () => {
+    // React logs the caught error to console.error by default — silence it for this test.
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <SectionErrorBoundary section="Anticipated Challenges">
+        <Boom />
+      </SectionErrorBoundary>
+    );
+    expect(screen.getByRole('alert').textContent).toContain('Anticipated Challenges');
+    consoleSpy.mockRestore();
+  });
+
+  it('does not unmount a sibling section when one section throws', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <>
+        <SectionErrorBoundary section="Broken"><Boom /></SectionErrorBoundary>
+        <SectionErrorBoundary section="Fine"><div data-testid="sibling">still here</div></SectionErrorBoundary>
+      </>
+    );
+    expect(screen.getByTestId('sibling')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    consoleSpy.mockRestore();
+  });
+
+  it('records the caught error at level "error" (not "fatal") with the section name', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <SectionErrorBoundary section="Anticipated Challenges">
+        <Boom />
+      </SectionErrorBoundary>
+    );
+    expect(record).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'system.error',
+      component: 'debate-workspace',
+      level: 'error',
+      data: expect.objectContaining({ section: 'Anticipated Challenges' }),
+    }));
+    consoleSpy.mockRestore();
+  });
+});

--- a/taxonomy-editor/src/renderer/components/debate-workspace/SectionErrorBoundary.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/SectionErrorBoundary.tsx
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3419: the top-level react-error-boundary (lib/electron-shared) is correctly
+// wired for a genuinely fatal crash, but using it for a single render-field throw
+// (t/3418) unmounts the entire debate workspace — the wrong blast radius for a
+// contained, recoverable render failure in one panel. This boundary catches at
+// section granularity and degrades to an inline fallback instead, logging at
+// `error` (not `fatal`) so the caught failure is diagnosable without triggering
+// the top-level crash/dump flow.
+
+import { Component, type ReactNode, type ErrorInfo } from 'react';
+import { getGlobalRecorder } from '@lib/flight-recorder/index';
+
+interface Props {
+  children: ReactNode;
+  /** Human-readable section label — surfaced in the fallback UI and the FR record. */
+  section: string;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class SectionErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    getGlobalRecorder()?.record({
+      type: 'system.error',
+      component: 'debate-workspace',
+      level: 'error',
+      message: `Section render failed: ${this.props.section}`,
+      error: { name: error.name, message: error.message, stack: error.stack },
+      data: { section: this.props.section, component_stack: info.componentStack?.slice(0, 1000) },
+    });
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        <div className="taxrefs-section-error" role="alert">
+          Couldn&rsquo;t render {this.props.section}.
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/taxonomy-editor/src/renderer/components/debate-workspace/TaxonomyRefs.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/TaxonomyRefs.css
@@ -1,3 +1,15 @@
+/* t/3419: inline fallback for a section-level render throw — replaces the
+   crashed section without unmounting the surrounding PLAN body. */
+.taxrefs-section-error {
+  padding: 4px 8px;
+  margin: 4px 0;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--danger);
+  color: var(--danger);
+  font-size: var(--text-xs);
+  font-style: italic;
+}
+
 /* ─── Debate Taxonomy Pills ───────────────────────────── */
 
 .debate-taxonomy-refs {

--- a/taxonomy-editor/src/renderer/components/debate-workspace/TaxonomyRefs.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/TaxonomyRefs.tsx
@@ -16,6 +16,7 @@ import type { PolicyRefEntry } from './utils';
 import { useTaxonomyStore } from '../../hooks/useTaxonomyStore';
 import { TaxonomyRefDetail, type TaxRefNode } from '../taxonomy/TaxonomyRefDetail';
 import { TheoryLink } from '../shared/TheoryLink';
+import { SectionErrorBoundary } from './SectionErrorBoundary';
 import './TaxonomyRefs.css';
 
 // Prevents a TheoryLink click inside a <summary> from toggling its parent <details>
@@ -341,15 +342,24 @@ function PlanBody({ planStage, selectedPlanNodeId, setSelectedPlanNodeId }: {
   }
   return (
     <>
-      <DirectiveBox wp={wp} />
-      <StrategicGoalBox wp={wp} />
-      <CoreThesisBox wp={wp} />
-      <FramingBox wp={wp} />
-      <PlannedMovesBox wp={wp} />
-      <ArgumentStructureBox wp={wp} selectedPlanNodeId={selectedPlanNodeId} setSelectedPlanNodeId={setSelectedPlanNodeId} />
-      <ArgumentSketchBox wp={wp} />
-      <AnticipatedBox wp={wp} field="anticipated_responses" title="Anticipated Responses" />
-      <AnticipatedBox wp={wp} field="anticipated_challenges" title="Anticipated Challenges" />
+      {/* t/3419: each Box wrapped independently — a render throw in one field
+          (e.g. a legacy-shaped work_product value) degrades to an inline
+          fallback for that section instead of unmounting the whole PLAN body. */}
+      <SectionErrorBoundary section="Directive"><DirectiveBox wp={wp} /></SectionErrorBoundary>
+      <SectionErrorBoundary section="Strategic Goal"><StrategicGoalBox wp={wp} /></SectionErrorBoundary>
+      <SectionErrorBoundary section="Core Thesis"><CoreThesisBox wp={wp} /></SectionErrorBoundary>
+      <SectionErrorBoundary section="Framing"><FramingBox wp={wp} /></SectionErrorBoundary>
+      <SectionErrorBoundary section="Planned Moves"><PlannedMovesBox wp={wp} /></SectionErrorBoundary>
+      <SectionErrorBoundary section="Argument Structure">
+        <ArgumentStructureBox wp={wp} selectedPlanNodeId={selectedPlanNodeId} setSelectedPlanNodeId={setSelectedPlanNodeId} />
+      </SectionErrorBoundary>
+      <SectionErrorBoundary section="Argument Sketch"><ArgumentSketchBox wp={wp} /></SectionErrorBoundary>
+      <SectionErrorBoundary section="Anticipated Responses">
+        <AnticipatedBox wp={wp} field="anticipated_responses" title="Anticipated Responses" />
+      </SectionErrorBoundary>
+      <SectionErrorBoundary section="Anticipated Challenges">
+        <AnticipatedBox wp={wp} field="anticipated_challenges" title="Anticipated Challenges" />
+      </SectionErrorBoundary>
       {/* Inline POV detail for the clicked argument-structure anchor (t/1724). */}
       {selectedPlanNodeId && <TaxNodeDetail nodeId={selectedPlanNodeId} onClose={() => setSelectedPlanNodeId(null)} />}
     </>


### PR DESCRIPTION
## Summary
- Fixes t/3419 (blast-radius reduction, sibling of t/3418): the top-level `react-error-boundary` unmounted the *entire* debate workspace when a single `work_product` field threw during render. This adds a finer-grained boundary so one panel's throw degrades to an inline fallback instead.
- New `SectionErrorBoundary` component: catches render errors in a subtree, shows a small inline "Couldn't render {section}." fallback, and records the catch to the flight recorder at `error` level (component: `debate-workspace`, section name, stack) — independent of the top-level `fatal`/dump-triggering hook used by the app-wide boundary, per the ticket's ask.
- Wraps each `Box` in `TaxonomyRefs.tsx`'s `PlanBody` individually (Directive, Strategic Goal, Core Thesis, Framing, Planned Moves, Argument Structure, Argument Sketch, Anticipated Responses/Challenges) — matching the ticket's suggested granularity and covering the exact site of the t/3418 incident plus its sibling fields.

## Design note
The existing shared `lib/electron-shared/components/ErrorBoundary` is wired to a global `__onErrorBoundaryCatch` hook hardcoded to `level: 'fatal'` plus a full state-snapshot dump — correct for a genuinely fatal top-level crash, but firing that flow for every recoverable section-level catch would misrepresent severity and spam dumps. Rather than modify the shared component (out of my scope, and its dump-flow semantics are intentional for the top level), `SectionErrorBoundary` is a small local component with its own direct `error`-level flight-recorder call, sized to the ticket's ask.

## Test plan
- [x] New `SectionErrorBoundary.test.tsx`: no-error passthrough, catches a throw + shows fallback naming the section, sibling boundary stays mounted when one throws, records at `error` level with the section name
- [x] `npx vitest run src/renderer/components/debate-workspace/` — 276/276 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
