### PR TITLE
fix(dwellTracker): stop idle tail from bleeding into engaged_ms (t/3420)

### DIFF
--- a/taxonomy-editor/src/renderer/lib/clientConfig.ts
+++ b/taxonomy-editor/src/renderer/lib/clientConfig.ts
@@ -37,6 +37,8 @@ export interface ClientConfig {
     ENGAGED_MIN_MS: number;
     MIN_VISIT_MS: number;
     PULSE_THROTTLE_MS: number;
+    /** t/3420: grace window after the last pulse that still counts as engaged on an idle-close. */
+    IDLE_GRACE_MS: number;
   };
   healthProbe: {
     intervalMs: number;
@@ -96,6 +98,7 @@ const DEFAULTS: ClientConfig = {
     ENGAGED_MIN_MS: 8_000,
     MIN_VISIT_MS: 1_000,
     PULSE_THROTTLE_MS: 5_000,
+    IDLE_GRACE_MS: 10_000,
   },
   healthProbe: {
     intervalMs: 30_000,

--- a/taxonomy-editor/src/renderer/lib/dwellTracker.test.ts
+++ b/taxonomy-editor/src/renderer/lib/dwellTracker.test.ts
@@ -21,6 +21,7 @@ const THRESHOLDS: EngagementThresholds = {
   ENGAGED_MIN_MS: 8_000,
   MIN_VISIT_MS: 1_000,
   PULSE_THROTTLE_MS: 5_000,
+  IDLE_GRACE_MS: 10_000,
 };
 
 function makeTracker(thresholds: EngagementThresholds = THRESHOLDS): DwellTracker {
@@ -167,8 +168,58 @@ describe('DwellTracker — emitted engaged_ms excludes hidden + idle spans (AC a
     tracker.onIdleTimeout(70_000);             // no pulse since 10s; idle fires at 70s (>60s after last pulse)
     expect(emitted).toHaveLength(1);
     expect(emitted[0].close_reason).toBe('idle');
-    expect(emitted[0].engaged_ms).toBe(70_000); // engaged span 0→70s (last-pulse-within-idle window), not truncated silently
+    // t/3420: the engaged span stops at lastPulseTime (10s) + IDLE_GRACE_MS (10s) = 20s,
+    // NOT at the full 70s idle-timer-fire moment — the idle tail no longer bleeds into engaged_ms.
+    expect(emitted[0].engaged_ms).toBe(20_000);
     expect(emitted[0].engaged).toBe(true);
+  });
+
+  it('t/3420: idle-closed visit books engaged time only through last-pulse + IDLE_GRACE_MS', () => {
+    const emitted: DwellDetail[] = [];
+    const tracker = new DwellTracker(() => THRESHOLDS, (_c, detail) => emitted.push(detail));
+    const nodeA: Subject = { subject_type: 'node', subject_id: 'skp-bel-002', pov: 'skp', cat: 'bel', tab: 'skeptic' };
+    tracker.onSubjectChange(nodeA, 0);
+    tracker.onPulse(0);
+    tracker.onPulse(5_000); // lastPulseTime = 5_000
+    // No more pulses; idle timer fires well past IDLE_TIMEOUT_MS after the last pulse.
+    tracker.onIdleTimeout(65_000);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].close_reason).toBe('idle');
+    // Grace window: 5_000 + IDLE_GRACE_MS (10_000) = 15_000, far short of the 65_000 wall gap.
+    expect(emitted[0].engaged_ms).toBe(15_000);
+    expect(emitted[0].wall_ms).toBe(65_000);
+  });
+
+  it('t/3420: a visit with continuous pulses through close is unaffected by the idle-grace change', () => {
+    const emitted: DwellDetail[] = [];
+    const tracker = new DwellTracker(() => THRESHOLDS, (_c, detail) => emitted.push(detail));
+    const nodeA: Subject = { subject_type: 'node', subject_id: 'skp-bel-002', pov: 'skp', cat: 'bel', tab: 'skeptic' };
+    tracker.onSubjectChange(nodeA, 0);
+    tracker.onPulse(0);
+    tracker.onPulse(20_000);
+    tracker.onPulse(40_000);
+    // Closed via subject_change (never idle), so onIdleTimeout's pause logic never runs.
+    tracker.onSubjectChange({ ...nodeA, subject_id: 'skp-bel-003' }, 60_000);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].close_reason).toBe('subject_change');
+    expect(emitted[0].engaged_ms).toBe(60_000);
+    expect(emitted[0].wall_ms).toBe(60_000);
+  });
+
+  it('t/3420: initiallyEngaged visit with zero pulses books ~0 engaged_ms on idle-close (deltaMs<=0 guard)', () => {
+    const emitted: DwellDetail[] = [];
+    const tracker = new DwellTracker(() => THRESHOLDS, (_c, detail) => emitted.push(detail));
+    const nodeA: Subject = { subject_type: 'node', subject_id: 'skp-bel-002', pov: 'skp', cat: 'bel', tab: 'skeptic' };
+    // Subject change opens the visit as initiallyEngaged=true (see DwellVisit ctor), but no
+    // onPulse ever fires — lastPulseTime stays at its initial 0, same as the visit start.
+    tracker.onSubjectChange(nodeA, 0);
+    tracker.onIdleTimeout(70_000);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].close_reason).toBe('idle');
+    // pause() clamps to lastPulseTime (0) + IDLE_GRACE_MS, i.e. effectively no engaged span opened
+    // beyond the grace window from t=0 — EngagementAccumulator.accrue's deltaMs<=0 guard means this
+    // books at most IDLE_GRACE_MS, and never the full 70s wall gap.
+    expect(emitted[0].engaged_ms).toBeLessThanOrEqual(THRESHOLDS.IDLE_GRACE_MS);
   });
 });
 

--- a/taxonomy-editor/src/renderer/lib/dwellTracker.ts
+++ b/taxonomy-editor/src/renderer/lib/dwellTracker.ts
@@ -32,6 +32,8 @@ export interface EngagementThresholds {
   ENGAGED_MIN_MS: number;
   MIN_VISIT_MS: number;
   PULSE_THROTTLE_MS: number;
+  /** t/3420: grace window after the last pulse that still counts as engaged on an idle/hidden close. */
+  IDLE_GRACE_MS: number;
 }
 
 export interface Subject {
@@ -268,7 +270,15 @@ export class DwellTracker {
 
   /** Called when the idle timer fires (no pulse for IDLE_TIMEOUT_MS). */
   onIdleTimeout(t: number): void {
-    if (!this.recentlyActive(t)) this.emitClose(t, 'idle');
+    if (this.recentlyActive(t)) return;
+    // t/3420: the idle timer fires IDLE_TIMEOUT_MS after the last pulse, but the visit stayed
+    // "engaged" (per EngagementAccumulator.startEngaged's idempotent open-span model) the whole
+    // time — closing at `t` directly would bleed that full idle tail into engaged_ms. Stop the
+    // engaged span early, at lastPulseTime + a short grace, mirroring how onVisibilityChange
+    // already stops accrual at the true hide moment; wall_ms (computed from `t` in close()) is
+    // unaffected. The subsequent close()/finish() then no-ops on accrual (already stopped).
+    this.currentVisit?.pause(Math.min(t, this.lastPulseTime + this.getThresholds().IDLE_GRACE_MS));
+    this.emitClose(t, 'idle');
   }
 
   /** Called on `visibilitychange`. */
@@ -283,7 +293,12 @@ export class DwellTracker {
 
   /** Called when the tab has been hidden for IDLE_TIMEOUT_MS+ (from a scheduled timer). */
   onHiddenTimeout(t: number): void {
-    if (!this.visible) this.emitClose(t, 'hidden');
+    if (this.visible) return;
+    // t/3420: onVisibilityChange already pauses accrual at the true hide moment, so this is
+    // normally a no-op by the time it runs — kept as defense-in-depth for the same idle-tail
+    // flaw class (in case pause() was ever skipped), not because it currently does anything.
+    this.currentVisit?.pause(Math.min(t, this.lastPulseTime + this.getThresholds().IDLE_GRACE_MS));
+    this.emitClose(t, 'hidden');
   }
 
   /** Called on `beforeunload`. */

--- a/taxonomy-editor/src/server/__tests__/runtimeConfig.test.ts
+++ b/taxonomy-editor/src/server/__tests__/runtimeConfig.test.ts
@@ -300,7 +300,7 @@ describe('REST-endpoint support — file round-trip (t/927)', () => {
     const client = getClientConfig();
     expect(Object.keys(client).sort()).toEqual(['analytics', 'debate', 'flightRecorder', 'resilience']);
     expect(Object.keys(client.flightRecorder).sort()).toEqual(['dumpWindowMs', 'maxDumpsPerWindow', 'minDumpIntervalMs']);
-    expect(Object.keys(client.analytics)).toEqual(['bufferRequeueLimit', 'IDLE_TIMEOUT_MS', 'MAX_ENGAGED_MS', 'ENGAGED_MIN_MS', 'MIN_VISIT_MS', 'PULSE_THROTTLE_MS']);
+    expect(Object.keys(client.analytics)).toEqual(['bufferRequeueLimit', 'IDLE_TIMEOUT_MS', 'MAX_ENGAGED_MS', 'ENGAGED_MIN_MS', 'MIN_VISIT_MS', 'PULSE_THROTTLE_MS', 'IDLE_GRACE_MS']);
     expect(client.resilience.circuitThreshold).toBe(5);
     expect(client.debate).toEqual({
       defaultConfrontationRounds: 1, defaultArgumentationRounds: 2, defaultConcludingRounds: 1,

--- a/taxonomy-editor/src/server/runtimeConfig.ts
+++ b/taxonomy-editor/src/server/runtimeConfig.ts
@@ -81,6 +81,9 @@ export interface RuntimeConfig {
     ENGAGED_MIN_MS: number;
     MIN_VISIT_MS: number;
     PULSE_THROTTLE_MS: number;
+    /** t/3420: grace window after the last pulse that still counts as engaged on an idle-close —
+     *  caps the idle-tail bleed into engaged_ms (the idle timer itself fires IDLE_TIMEOUT_MS later). */
+    IDLE_GRACE_MS: number;
   };
   flightRecorder: {
     minDumpIntervalMs: number;
@@ -188,6 +191,7 @@ const DEFAULTS: RuntimeConfig = {
     ENGAGED_MIN_MS: 8_000,
     MIN_VISIT_MS: 1_000,
     PULSE_THROTTLE_MS: 5_000,
+    IDLE_GRACE_MS: 10_000,
   },
   flightRecorder: {
     minDumpIntervalMs: 10_000,
@@ -416,6 +420,7 @@ export function validateAndMerge(raw: unknown, defaults: RuntimeConfig): { confi
       ENGAGED_MIN_MS: vNum(an.ENGAGED_MIN_MS, defaults.analytics.ENGAGED_MIN_MS, { min: 0, max: DURATION_MAX }, 'analytics.ENGAGED_MIN_MS', errors),
       MIN_VISIT_MS: vNum(an.MIN_VISIT_MS, defaults.analytics.MIN_VISIT_MS, { min: 0, max: DURATION_MAX }, 'analytics.MIN_VISIT_MS', errors),
       PULSE_THROTTLE_MS: vNum(an.PULSE_THROTTLE_MS, defaults.analytics.PULSE_THROTTLE_MS, { min: 0, max: DURATION_MAX }, 'analytics.PULSE_THROTTLE_MS', errors),
+      IDLE_GRACE_MS: vNum(an.IDLE_GRACE_MS, defaults.analytics.IDLE_GRACE_MS, { min: 0, max: DURATION_MAX }, 'analytics.IDLE_GRACE_MS', errors),
     },
     flightRecorder: {
       minDumpIntervalMs: vNum(fr.minDumpIntervalMs, defaults.flightRecorder.minDumpIntervalMs, { min: 0, max: DURATION_MAX }, 'flightRecorder.minDumpIntervalMs', errors),
@@ -658,7 +663,7 @@ export function diffFromDefaults(): ConfigDiffEntry[] {
 export interface ClientConfig {
   resilience: RuntimeConfig['resilience'];
   flightRecorder: Pick<RuntimeConfig['flightRecorder'], 'minDumpIntervalMs' | 'maxDumpsPerWindow' | 'dumpWindowMs'>;
-  analytics: Pick<RuntimeConfig['analytics'], 'bufferRequeueLimit' | 'IDLE_TIMEOUT_MS' | 'MAX_ENGAGED_MS' | 'ENGAGED_MIN_MS' | 'MIN_VISIT_MS' | 'PULSE_THROTTLE_MS'>;
+  analytics: Pick<RuntimeConfig['analytics'], 'bufferRequeueLimit' | 'IDLE_TIMEOUT_MS' | 'MAX_ENGAGED_MS' | 'ENGAGED_MIN_MS' | 'MIN_VISIT_MS' | 'PULSE_THROTTLE_MS' | 'IDLE_GRACE_MS'>;
   debate: RuntimeConfig['debate'];
 }
 
@@ -683,6 +688,7 @@ export function getClientConfig(): ClientConfig {
       ENGAGED_MIN_MS: c.analytics.ENGAGED_MIN_MS,
       MIN_VISIT_MS: c.analytics.MIN_VISIT_MS,
       PULSE_THROTTLE_MS: c.analytics.PULSE_THROTTLE_MS,
+      IDLE_GRACE_MS: c.analytics.IDLE_GRACE_MS,
     },
     debate: c.debate,
   };


### PR DESCRIPTION
## Summary

Fixes the engagement idle-inflation bug (t/3420): `onIdleTimeout` closed visits at the idle-timer-fire timestamp while `EngagementAccumulator`'s engaged span (idempotent `startEngaged`) stayed open the entire idle wait, bleeding a full `IDLE_TIMEOUT_MS+` tail into `engaged_ms` on every idle-close. This is item 1 of TL's 5-item diagnosis on t/3420; staged delivery per t/3420#1, approved by TL in t/3420#2.

- `dwellTracker.ts`: `onIdleTimeout` now stops the engaged span at `lastPulseTime + IDLE_GRACE_MS` (new threshold) before closing, mirroring the existing `onVisibilityChange` pause-at-true-hide-moment pattern. `onHiddenTimeout` gets the same guard as defense-in-depth (already effectively a no-op).
- New `IDLE_GRACE_MS` threshold plumbed through `EngagementThresholds` (dwellTracker.ts), `ClientConfig['analytics']` (clientConfig.ts), and `RuntimeConfig['analytics']` + its client-facing `Pick` mapping (runtimeConfig.ts — ServerAPI-owned, self-managed per t/3401 precedent since it's a small, exact mirror of the existing `PULSE_THROTTLE_MS` pattern; a client-only change would silently regress to `undefined` in prod via clientConfig.ts's shallow `{...DEFAULTS, ...data}` merge). ServerAPI notified with an objection window.
- Existing test that asserted `engaged_ms=70_000` on an idle-close (i.e. pinned the bug itself) corrected to `20_000`.
- 3 new test arms per TL review: idle-tail-grace boundary, continuous-pulse regression guard, and the TL-required `initiallyEngaged`+zero-pulses+idle-close→~0 arm (pins `EngagementAccumulator.accrue`'s `deltaMs<=0` guard).

Follow-ups filed: t/3421 (item 4, dashboard aggregation robustness → Server Community), t/3422 (item 2, accumulator rewrite, needs own design), t/3423 (item 3, session ceiling, needs own design).

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` (renderer) — clean
- [x] `npx tsc --noEmit -p tsconfig.server.json` (server) — clean
- [x] `npx vitest run src/renderer/lib/dwellTracker.test.ts src/server/__tests__/runtimeConfig.test.ts` — 54/54 pass
- [x] RED-arm proof: reverted `onIdleTimeout`'s fix, confirmed exactly the 3 new/updated assertions fail (not the continuous-pulse regression guard), restored, re-verified green
- [x] `npx eslint` on all 5 touched files — clean

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>