### PR TITLE
fix(community): winsorize idle-inflated engaged_ms at aggregation (t/3421)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/analytics.engagement.test.ts
+++ b/taxonomy-editor/src/server/__tests__/analytics.engagement.test.ts
@@ -354,4 +354,77 @@ describe('queryEngagement — rollup math', () => {
       expect(sessionIds).not.toContain('sb1');
     });
   });
+
+  // ── t/3421: winsorize idle-inflated engaged_ms at aggregation ──
+
+  it('winsorizes a single visit engagedMs at the tool/camp/category/node level (10min cap)', async () => {
+    await withEvents([
+      // 4h05m idle-inflated visit — mirrors the PI-reported acc-desires-010 case
+      nodeEvent('acc-des-010', 'acc', 'des', { duration_ms: 4 * 60 * 60 * 1000 + 5 * 60 * 1000 }),
+    ], async () => {
+      const agg = (await analytics.queryEngagement('2026-08-10', '2026-08-10')).aggregate;
+      const capped = 10 * 60 * 1000;
+      expect(agg.tool.engagedMs).toBe(capped);
+      expect(agg.camps['acc'].engagedMs).toBe(capped);
+      expect(agg.camps['acc'].categories['acc-des'].engagedMs).toBe(capped);
+      expect(agg.camps['acc'].categories['acc-des'].nodes['acc-des-010'].engagedMs).toBe(capped);
+    });
+  });
+
+  it('leaves a visit under the cap unaffected (regression guard)', async () => {
+    await withEvents([
+      nodeEvent('acc-des-010', 'acc', 'des', { duration_ms: 5 * 60 * 1000 }),
+    ], async () => {
+      const agg = (await analytics.queryEngagement('2026-08-10', '2026-08-10')).aggregate;
+      expect(agg.tool.engagedMs).toBe(5 * 60 * 1000);
+    });
+  });
+
+  it('sums mixed capped+uncapped visits correctly at the node level', async () => {
+    await withEvents([
+      nodeEvent('acc-des-010', 'acc', 'des', { duration_ms: 30 * 60 * 1000 }), // winsorized to 10min
+      nodeEvent('acc-des-010', 'acc', 'des', { duration_ms: 2 * 60 * 1000 }),  // untouched
+    ], async () => {
+      const agg = (await analytics.queryEngagement('2026-08-10', '2026-08-10')).aggregate;
+      const expected = 10 * 60 * 1000 + 2 * 60 * 1000;
+      expect(agg.camps['acc'].categories['acc-des'].nodes['acc-des-010'].engagedMs).toBe(expected);
+    });
+  });
+
+  it('winsorizes engagedMs in the daily rollup', async () => {
+    await withEvents([
+      nodeEvent('acc-des-010', 'acc', 'des', { duration_ms: 45 * 60 * 1000 }),
+    ], async () => {
+      const result = await analytics.queryEngagement('2026-08-10', '2026-08-10');
+      expect(result.daily[0].engagedMs).toBe(10 * 60 * 1000);
+    });
+  });
+
+  it('winsorizes engagedMs in the per-user rollup', async () => {
+    await withEvents([
+      nodeEvent('acc-des-010', 'acc', 'des', { user: 'alice', duration_ms: 45 * 60 * 1000 }),
+    ], async () => {
+      const result = await analytics.queryEngagement('2026-08-10', '2026-08-10');
+      expect(result.users.find(u => u.user === 'alice')!.engagedMs).toBe(10 * 60 * 1000);
+    });
+  });
+
+  it('winsorizes engagedMs in the per-session rollup', async () => {
+    await withEvents([
+      dwell({ session_id: 's1', duration_ms: 45 * 60 * 1000, detail: { subject_type: 'node', subject_id: 'acc-bel-001', pov: 'acc', cat: 'bel', engaged: true, capped: false } }),
+    ], async () => {
+      const result = await analytics.queryEngagement('2026-08-10', '2026-08-10', { includeSessions: true });
+      expect(result.sessions!.find(s => s.session === 's1')!.engagedMs).toBe(10 * 60 * 1000);
+    });
+  });
+
+  it('winsorizes engagedMs in querySubjectBreakdown', async () => {
+    await withEvents([
+      dwell({ user: 'alice', session_id: 's1', duration_ms: 45 * 60 * 1000, detail: { subject_type: 'node', subject_id: 'acc-bel-001', pov: 'acc', cat: 'bel', engaged: true, capped: false } }),
+    ], async () => {
+      const result = await analytics.querySubjectBreakdown('2026-08-10', '2026-08-10', 'acc-bel-001', 'user');
+      const alice = result.rows.find(r => 'user' in r && r.user === 'alice') as { engagedMs: number };
+      expect(alice.engagedMs).toBe(10 * 60 * 1000);
+    });
+  });
 });

--- a/taxonomy-editor/src/server/community/analytics.ts
+++ b/taxonomy-editor/src/server/community/analytics.ts
@@ -381,6 +381,18 @@ export async function queryRawEvents(from: string, to: string, user?: string, se
 
 const KNOWN_CAMPS = new Set(['acc', 'saf', 'skp', 'cc']);
 
+// t/3420/t/3421: client-side idle-inflation (renewable per-visit cap + idle tail counted as
+// engaged) let a single visit's engaged_ms grow unbounded. Winsorize at aggregation so the
+// CURRENT dashboard view is robust immediately, independent of the client-side dwellTracker
+// fixes landing separately.
+const ENGAGED_MS_WINSORIZE_CAP = 10 * 60 * 1000; // 10min per visit
+
+/** Cap a single visit's engaged_ms contribution before summing into any aggregate. */
+function winsorizedEngagedMs(evt: AnalyticsEvent): number {
+  const raw = typeof evt.duration_ms === 'number' ? evt.duration_ms : 0;
+  return Math.min(raw, ENGAGED_MS_WINSORIZE_CAP);
+}
+
 /** Per-node engagement stats. `uniqueUsers` is present on aggregate rollups only. */
 export interface EngagementNodeResult {
   visits: number;
@@ -458,7 +470,7 @@ function mkAccum(): EngAccum {
 function addToAccum(acc: EngAccum, evt: AnalyticsEvent): void {
   acc.visits++;
   if (evt.detail.engaged === true) acc.engagedVisits++;
-  acc.engagedMs += typeof evt.duration_ms === 'number' ? evt.duration_ms : 0;
+  acc.engagedMs += winsorizedEngagedMs(evt);
   if (evt.detail.capped === true) acc.cappedCount++;
   acc.users.add(evt.user);
 }
@@ -514,14 +526,14 @@ function placeEvent(state: EngState, evt: AnalyticsEvent): void {
   if (!day) { day = { visits: 0, engagedVisits: 0, engagedMs: 0 }; state.daily.set(date, day); }
   day.visits++;
   if (d.engaged === true) day.engagedVisits++;
-  day.engagedMs += typeof evt.duration_ms === 'number' ? evt.duration_ms : 0;
+  day.engagedMs += winsorizedEngagedMs(evt);
 
   // Per-user summary roll-up
   let u = state.userSummaries.get(evt.user);
   if (!u) { u = { visits: 0, engagedVisits: 0, engagedMs: 0, lastActive: evt.timestamp, campCounts: new Map() }; state.userSummaries.set(evt.user, u); }
   u.visits++;
   if (d.engaged === true) u.engagedVisits++;
-  u.engagedMs += typeof evt.duration_ms === 'number' ? evt.duration_ms : 0;
+  u.engagedMs += winsorizedEngagedMs(evt);
   if (evt.timestamp > u.lastActive) u.lastActive = evt.timestamp;
 
   // Tree placement
@@ -550,7 +562,7 @@ function placeEvent(state: EngState, evt: AnalyticsEvent): void {
     let se = state.sessionEntries.get(sessId);
     if (!se) { se = { startTime: evt.timestamp, engagedMs: 0, nodes: new Set(), user: evt.user }; state.sessionEntries.set(sessId, se); }
     if (evt.timestamp < se.startTime) se.startTime = evt.timestamp;
-    se.engagedMs += typeof evt.duration_ms === 'number' ? evt.duration_ms : 0;
+    se.engagedMs += winsorizedEngagedMs(evt);
     // nodeCount: cap subject_id at 100 chars to match the node accumulator bound above
     const subId = typeof d.subject_id === 'string' && d.subject_id ? d.subject_id.slice(0, 100) : '';
     if (subId) se.nodes.add(subId);
@@ -659,7 +671,7 @@ export async function querySubjectBreakdown(
     let entry = acc.get(key);
     if (!entry) { entry = { engagedMs: 0, visits: 0 }; acc.set(key, entry); }
     entry.visits++;
-    entry.engagedMs += typeof evt.duration_ms === 'number' ? evt.duration_ms : 0;
+    entry.engagedMs += winsorizedEngagedMs(evt);
   }
   const rows: SubjectBreakdownRow[] = Array.from(acc.entries())
     .sort(([, a], [, b]) => b.engagedMs - a.engagedMs)


### PR DESCRIPTION
## Summary

- t/3421 (TL diagnosis t/3420 item 4) — winsorize per-visit engaged_ms at aggregation so a single idle-inflated visit can no longer dominate the dashboard (PI report: one node held 42% of all 30d engagement).
- Single `winsorizedEngagedMs()` helper (10min cap), applied at all 5 summation sites in analytics.ts: tool/camp/category/node accumulator, daily rollup, per-user rollup, per-session rollup, and `querySubjectBreakdown` (same events, same inflation per t/3420's cross-feature note).
- `cappedRate` already surfaces measurement confidence from the client `capped` flag — no change needed there.
- Ships independently of the client-side dwellTracker.ts fixes (t/3420 items 1-3) per TL's framing.

**Non-comparability note (t/3342 spirit):** pre/post-fix engaged-time is not one series for the same period — flagged to Analysis/Rosetta Stone for the dashboard trend footnote.

Design approved by Quality (TL) at t/3421#1 / p/634#2.

## Test plan
- [x] 7 new tests: winsorize at tool/camp/category/node, under-cap unaffected (regression), mixed capped+uncapped sum, daily rollup, user rollup, session rollup, querySubjectBreakdown
- [x] 38/38 analytics tests pass (4 files)
- [x] Full server suite: no new failures vs main (pre-existing local-only undici skew + 1 flaky real-embed test confirmed identical on main checkout)
- [ ] CI verify gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)