### PR TITLE
feat(analysis): engagement dashboard non-comparability footnote + surface cappedRate (t/3424)

### DIFF
--- a/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.css
+++ b/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.css
@@ -159,6 +159,24 @@
 
 .eng-empty-sub { color: var(--text-muted); }
 
+/* ── Non-comparability footnote (t/3424) ────────────────────────────────────── */
+
+.eng-non-comparability-note {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  background: rgba(234, 179, 8, 0.08);
+  border: 1px solid rgba(234, 179, 8, 0.2);
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+  line-height: 1.5;
+}
+
+.eng-capped-rate {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  font-weight: 400;
+}
+
 /* ── Panels ──────────────────────────────────────────────────────────────────── */
 
 .eng-panel {

--- a/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.test.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.test.tsx
@@ -236,6 +236,27 @@ describe('EngagementDashboard', () => {
     // aggregate: visits=100, engagedVisits=80 → 80.0%
     await waitFor(() => expect(screen.getByText('80.0%')).toBeTruthy());
   });
+
+  it('shows the non-comparability footnote once data renders (t/3424)', async () => {
+    mockBridgeGet(FIXTURE_RESULT);
+    render(<EngagementDashboard />);
+    await waitFor(() => expect(screen.getByText(/Engaged-time measurement changed on/)).toBeTruthy());
+    expect(screen.getByText(/aren't one comparable series/)).toBeTruthy();
+  });
+
+  it('does not show the footnote in the empty state (no misleading note with no data)', async () => {
+    mockBridgeGet(EMPTY_RESULT);
+    render(<EngagementDashboard />);
+    await waitFor(() => expect(screen.getByText(/no engagement data/i)).toBeTruthy());
+    expect(screen.queryByText(/Engaged-time measurement changed on/)).toBeNull();
+  });
+
+  it('surfaces capped% next to camp engaged-time (t/3424, t/3420 item 4)', async () => {
+    mockBridgeGet(FIXTURE_RESULT);
+    render(<EngagementDashboard />);
+    await waitFor(() => expect(screen.getByText('Accelerationist')).toBeTruthy());
+    expect(screen.getAllByText(/capped/).length).toBeGreaterThan(0);
+  });
 });
 
 // ── Tab bar ───────────────────────────────────────────────────────────────────

--- a/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.tsx
@@ -20,8 +20,9 @@ import {
   type WireEngagementTree,
   engagementTreeToTreeNode,
   CAMP_COLORS, CAMP_LABELS,
-  fmtDuration, fmtNumber, relativeTime, categoryLabel,
+  fmtDuration, fmtNumber, fmtCappedRate, relativeTime, categoryLabel,
   sumByCamp, sumByCategoryForCamp, collectLeafNodes,
+  ENGAGEMENT_NON_COMPARABILITY_BOUNDARIES, formatNonComparabilityFootnote,
 } from './engagementTree';
 import './EngagementDashboard.css';
 
@@ -68,6 +69,18 @@ function dateRange(preset: DatePreset): { from: string; to: string } {
   const from = new Date();
   from.setDate(from.getDate() - (PRESET_DAYS[preset] - 1));
   return { from: from.toISOString().slice(0, 10), to: to.toISOString().slice(0, 10) };
+}
+
+// ── Non-comparability footnote (t/3421 renderer follow-up, t/3424) ───────────
+// The engaged-time measurement pipeline has changed more than once (client idle-tail
+// fix, server winsorize cap, …) — each is a discontinuity in the same visible series.
+// The boundary list lives in engagementTree.ts (single source of truth for both
+// dashboards); this component just renders it.
+
+function NonComparabilityFootnote() {
+  const text = formatNonComparabilityFootnote(ENGAGEMENT_NON_COMPARABILITY_BOUNDARIES);
+  if (!text) return null;
+  return <div className="eng-non-comparability-note">ⓘ {text}</div>;
 }
 
 // ── Section 1: Time-with-tool chart ──────────────────────────────────────────
@@ -140,7 +153,14 @@ function CampDistribution({
           >
             <div className="eng-camp-row-head">
               <span className="eng-camp-label">{label}</span>
-              <span className="eng-camp-value">{fmtDuration(c.engagedMs)}</span>
+              <span className="eng-camp-value">
+                {fmtDuration(c.engagedMs)}
+                {c.cappedRate != null && (
+                  <span className="eng-capped-rate" title="Fraction of engaged visits that hit the duration cap">
+                    {' '}· {fmtCappedRate(c.cappedRate)} capped
+                  </span>
+                )}
+              </span>
             </div>
             <div className="eng-camp-track">
               <div
@@ -171,7 +191,14 @@ function CategoryDrillDown({ aggregate, camp }: { aggregate: TreeNode; camp: str
         <div key={c.key} className="eng-cat-row">
           <div className="eng-cat-row-head">
             <span className="eng-cat-label">{categoryLabel(c.key)}</span>
-            <span className="eng-cat-value">{fmtDuration(c.engagedMs)}</span>
+            <span className="eng-cat-value">
+              {fmtDuration(c.engagedMs)}
+              {c.cappedRate != null && (
+                <span className="eng-capped-rate" title="Fraction of engaged visits that hit the duration cap">
+                  {' '}· {fmtCappedRate(c.cappedRate)} capped
+                </span>
+              )}
+            </span>
           </div>
           <div className="eng-camp-track">
             <div
@@ -190,7 +217,7 @@ function CategoryDrillDown({ aggregate, camp }: { aggregate: TreeNode; camp: str
 
 function Leaderboards({ aggregate }: { aggregate: TreeNode }) {
   const nodes = useMemo(() => {
-    const results: Array<{ id: string; engagedMs: number; visits: number }> = [];
+    const results: Array<{ id: string; engagedMs: number; visits: number; cappedRate?: number }> = [];
     collectLeafNodes(aggregate, 0, results);
     return results;
   }, [aggregate]);
@@ -199,7 +226,7 @@ function Leaderboards({ aggregate }: { aggregate: TreeNode }) {
   const byBreadth = useMemo(() => [...nodes].sort((a, b) => b.visits - a.visits).slice(0, 10), [nodes]);
 
   const LeaderList = ({ items, valueKey, label }: {
-    items: Array<{ id: string; engagedMs: number; visits: number }>;
+    items: Array<{ id: string; engagedMs: number; visits: number; cappedRate?: number }>;
     valueKey: 'engagedMs' | 'visits';
     label: string;
   }) => (
@@ -211,6 +238,11 @@ function Leaderboards({ aggregate }: { aggregate: TreeNode }) {
           <span className="eng-leader-id" title={n.id}>{n.id}</span>
           <span className="eng-leader-val">
             {valueKey === 'engagedMs' ? fmtDuration(n.engagedMs) : fmtNumber(n.visits)}
+            {valueKey === 'engagedMs' && n.cappedRate != null && (
+              <span className="eng-capped-rate" title="Fraction of engaged visits that hit the duration cap">
+                {' '}· {fmtCappedRate(n.cappedRate)} capped
+              </span>
+            )}
           </span>
         </div>
       ))}
@@ -443,6 +475,8 @@ export function EngagementDashboard() {
             </div>
           ) : (
             <>
+              <NonComparabilityFootnote />
+
               {/* Section 1: time over time */}
               <EngagedOverTime daily={data.daily} />
 

--- a/taxonomy-editor/src/renderer/components/analysis/YourActivityPanel.css
+++ b/taxonomy-editor/src/renderer/components/analysis/YourActivityPanel.css
@@ -214,3 +214,22 @@
   color: var(--text-muted);
   font-size: 0.85rem;
 }
+
+/* ── Non-comparability footnote (t/3424) ────────────────────────────────── */
+
+.yap-non-comparability-note {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  background: rgba(234, 179, 8, 0.08);
+  border: 1px solid rgba(234, 179, 8, 0.2);
+  border-radius: 6px;
+  padding: 8px 10px;
+  line-height: 1.5;
+  margin-bottom: 4px;
+}
+
+.yap-capped-rate {
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  font-weight: 400;
+}

--- a/taxonomy-editor/src/renderer/components/analysis/YourActivityPanel.test.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/YourActivityPanel.test.tsx
@@ -213,4 +213,30 @@ describe('YourActivityPanel', () => {
     const periodLabel = screen.getByText(/\d{4}-\d{2}-\d{2} – \d{4}-\d{2}-\d{2}/);
     expect(periodLabel).toBeTruthy();
   });
+
+  it('shows the non-comparability footnote when activity data renders (t/3424)', async () => {
+    mockProfile(SIGNED_IN_PROFILE);
+    mockBridgeGet(FIXTURE_TREE);
+    render(<YourActivityPanel />);
+    await waitFor(() => expect(screen.getByText(/Engaged-time measurement changed on/)).toBeTruthy());
+    expect(screen.getByText(/aren't one comparable series/)).toBeTruthy();
+  });
+
+  it('does not show the footnote in the empty-activity state', async () => {
+    mockProfile(SIGNED_IN_PROFILE);
+    vi.mocked(bridgeGet).mockResolvedValue({
+      user: { tool: { visits: 0, engagedVisits: 0, engagedMs: 0, cappedRate: 0 }, camps: {}, tabs: {} },
+    });
+    render(<YourActivityPanel />);
+    await waitFor(() => expect(screen.getByText(/no activity recorded/i)).toBeTruthy());
+    expect(screen.queryByText(/Engaged-time measurement changed on/)).toBeNull();
+  });
+
+  it('surfaces capped% next to camp engaged-time', async () => {
+    mockProfile(SIGNED_IN_PROFILE);
+    mockBridgeGet(FIXTURE_TREE);
+    render(<YourActivityPanel />);
+    await waitFor(() => expect(screen.getByText('Accelerationist')).toBeTruthy());
+    expect(screen.getAllByText(/capped/).length).toBeGreaterThan(0);
+  });
 });

--- a/taxonomy-editor/src/renderer/components/analysis/YourActivityPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/YourActivityPanel.tsx
@@ -19,8 +19,9 @@ import {
   type WireEngagementTree,
   engagementTreeToTreeNode,
   CAMP_COLORS, CAMP_LABELS,
-  fmtDuration, fmtNumber, categoryLabel,
+  fmtDuration, fmtNumber, fmtCappedRate, categoryLabel,
   sumByCamp, sumByCategoryForCamp, collectLeafNodes,
+  ENGAGEMENT_NON_COMPARABILITY_BOUNDARIES, formatNonComparabilityFootnote,
 } from './engagementTree';
 import './YourActivityPanel.css';
 
@@ -39,6 +40,16 @@ function last30DayRange(): { from: string; to: string } {
   const fromDate = new Date();
   fromDate.setDate(fromDate.getDate() - 29);
   return { from: fromDate.toISOString().slice(0, 10), to };
+}
+
+// ── Non-comparability footnote (t/3421 renderer follow-up, t/3424) ───────────
+// Boundary list lives in engagementTree.ts (single source of truth shared with
+// EngagementDashboard); this just renders it.
+
+function NonComparabilityFootnote() {
+  const text = formatNonComparabilityFootnote(ENGAGEMENT_NON_COMPARABILITY_BOUNDARIES);
+  if (!text) return null;
+  return <div className="yap-non-comparability-note">ⓘ {text}</div>;
 }
 
 // ── Sub-components ────────────────────────────────────────────────────────────
@@ -75,7 +86,14 @@ function CampBars({
           >
             <div className="yap-camp-row-head">
               <span className="yap-camp-label">{label}</span>
-              <span className="yap-camp-value">{fmtDuration(c.engagedMs)}</span>
+              <span className="yap-camp-value">
+                {fmtDuration(c.engagedMs)}
+                {c.cappedRate != null && (
+                  <span className="yap-capped-rate" title="Fraction of engaged visits that hit the duration cap">
+                    {' '}· {fmtCappedRate(c.cappedRate)} capped
+                  </span>
+                )}
+              </span>
             </div>
             <div className="yap-camp-track">
               <div
@@ -106,7 +124,14 @@ function CategoryBreakdown({ root, camp }: { root: TreeNode; camp: string }) {
         <div key={c.key} className="yap-cat-row">
           <div className="yap-cat-row-head">
             <span className="yap-cat-label">{categoryLabel(c.key)}</span>
-            <span className="yap-cat-value">{fmtDuration(c.engagedMs)}</span>
+            <span className="yap-cat-value">
+              {fmtDuration(c.engagedMs)}
+              {c.cappedRate != null && (
+                <span className="yap-capped-rate" title="Fraction of engaged visits that hit the duration cap">
+                  {' '}· {fmtCappedRate(c.cappedRate)} capped
+                </span>
+              )}
+            </span>
           </div>
           <div className="yap-camp-track">
             <div
@@ -123,7 +148,7 @@ function CategoryBreakdown({ root, camp }: { root: TreeNode; camp: string }) {
 
 function ActivityLeaderboards({ root }: { root: TreeNode }) {
   const nodes = useMemo(() => {
-    const results: Array<{ id: string; engagedMs: number; visits: number }> = [];
+    const results: Array<{ id: string; engagedMs: number; visits: number; cappedRate?: number }> = [];
     collectLeafNodes(root, 0, results);
     return results;
   }, [root]);
@@ -132,7 +157,7 @@ function ActivityLeaderboards({ root }: { root: TreeNode }) {
   const byVisits = useMemo(() => [...nodes].sort((a, b) => b.visits - a.visits).slice(0, 10), [nodes]);
 
   const List = ({ items, valueKey, title }: {
-    items: Array<{ id: string; engagedMs: number; visits: number }>;
+    items: Array<{ id: string; engagedMs: number; visits: number; cappedRate?: number }>;
     valueKey: 'engagedMs' | 'visits';
     title: string;
   }) => (
@@ -144,6 +169,11 @@ function ActivityLeaderboards({ root }: { root: TreeNode }) {
           <span className="yap-leader-id" title={n.id}>{n.id}</span>
           <span className="yap-leader-val">
             {valueKey === 'engagedMs' ? fmtDuration(n.engagedMs) : fmtNumber(n.visits)}
+            {valueKey === 'engagedMs' && n.cappedRate != null && (
+              <span className="yap-capped-rate" title="Fraction of engaged visits that hit the duration cap">
+                {' '}· {fmtCappedRate(n.cappedRate)} capped
+              </span>
+            )}
           </span>
         </div>
       ))}
@@ -211,6 +241,7 @@ function PanelBody({ loading, error, isAnonymous, userTree, selectedCamp, onSele
   }
   return (
     <>
+      <NonComparabilityFootnote />
       <CampBars root={userTree} selectedCamp={selectedCamp} onSelectCamp={onSelectCamp} />
       {selectedCamp && <CategoryBreakdown root={userTree} camp={selectedCamp} />}
       <ActivityLeaderboards root={userTree} />

--- a/taxonomy-editor/src/renderer/components/analysis/engagementTree.test.ts
+++ b/taxonomy-editor/src/renderer/components/analysis/engagementTree.test.ts
@@ -17,7 +17,10 @@ import {
   sumByCamp,
   sumByCategoryForCamp,
   collectLeafNodes,
+  formatNonComparabilityFootnote,
+  fmtCappedRate,
   type WireEngagementTree,
+  type NonComparabilityBoundary,
 } from './engagementTree';
 
 // A realistic wire tree: tool root, two camps (acc has a category+nodes, saf is bare),
@@ -64,18 +67,18 @@ describe('engagementTreeToTreeNode (t/2709)', () => {
     expect(tool.children!.summaries).toBeUndefined();
   });
 
-  it('feeds sumByCamp correctly (per-camp engagedMs/visits, sorted desc)', () => {
+  it('feeds sumByCamp correctly (per-camp engagedMs/visits/cappedRate, sorted desc)', () => {
     const root = engagementTreeToTreeNode(WIRE);
     expect(sumByCamp(root)).toEqual([
-      { key: 'acc', engagedMs: 20_000, visits: 40 },
-      { key: 'saf', engagedMs: 12_000, visits: 25 },
+      { key: 'acc', engagedMs: 20_000, visits: 40, cappedRate: 0 },
+      { key: 'saf', engagedMs: 12_000, visits: 25, cappedRate: 0 },
     ]);
   });
 
   it('feeds sumByCategoryForCamp correctly for a camp with categories', () => {
     const root = engagementTreeToTreeNode(WIRE);
     expect(sumByCategoryForCamp(root, 'acc')).toEqual([
-      { key: 'acc-bel', engagedMs: 15_000, visits: 30 },
+      { key: 'acc-bel', engagedMs: 15_000, visits: 30, cappedRate: 0 },
     ]);
     // A camp with no categories yields no rows (not a throw).
     expect(sumByCategoryForCamp(root, 'saf')).toEqual([]);
@@ -83,10 +86,26 @@ describe('engagementTreeToTreeNode (t/2709)', () => {
 
   it('feeds collectLeafNodes only the taxonomy nodes (depth ≥ 3), not camps/categories', () => {
     const root = engagementTreeToTreeNode(WIRE);
-    const leaves: Array<{ id: string; engagedMs: number; visits: number }> = [];
+    const leaves: Array<{ id: string; engagedMs: number; visits: number; cappedRate?: number }> = [];
     collectLeafNodes(root, 0, leaves);
     expect(leaves.map(l => l.id).sort()).toEqual(['acc-bel-001', 'acc-bel-002']);
-    expect(leaves.find(l => l.id === 'acc-bel-001')).toEqual({ id: 'acc-bel-001', engagedMs: 9_000, visits: 20 });
+    expect(leaves.find(l => l.id === 'acc-bel-001')).toEqual({ id: 'acc-bel-001', engagedMs: 9_000, visits: 20, cappedRate: 0 });
+  });
+
+  it('sumByCamp weights cappedRate by engagedVisits and omits it when no engaged visits exist', () => {
+    const wireVariedCap: WireEngagementTree = {
+      tool: { visits: 0, engagedVisits: 0, engagedMs: 0, cappedRate: 0 },
+      camps: {
+        acc: { visits: 10, engagedVisits: 10, engagedMs: 1000, cappedRate: 0.5, categories: {} },
+        saf: { visits: 10, engagedVisits: 0, engagedMs: 0, cappedRate: 0, categories: {} },
+      },
+      tabs: {},
+    };
+    const root = engagementTreeToTreeNode(wireVariedCap);
+    const rows = sumByCamp(root);
+    expect(rows.find(r => r.key === 'acc')?.cappedRate).toBe(0.5);
+    // saf has zero engagedVisits — no weight to average, cappedRate is omitted, not 0.
+    expect(rows.find(r => r.key === 'saf')?.cappedRate).toBeUndefined();
   });
 
   it('returns null for a missing tree so callers keep their empty-state handling', () => {
@@ -104,5 +123,50 @@ describe('engagementTreeToTreeNode (t/2709)', () => {
     expect(root.visits).toBe(0);                       // isEmpty → true
     expect(Object.keys(root.children!.tool.children ?? {})).toEqual([]);
     expect(sumByCamp(root)).toEqual([]);
+  });
+});
+
+describe('fmtCappedRate', () => {
+  it('formats a [0,1] fraction as a rounded percentage', () => {
+    expect(fmtCappedRate(0.123)).toBe('12.3%');
+    expect(fmtCappedRate(0)).toBe('0.0%');
+    expect(fmtCappedRate(1)).toBe('100.0%');
+  });
+});
+
+describe('formatNonComparabilityFootnote (t/3424)', () => {
+  it('returns an empty string for no boundaries', () => {
+    expect(formatNonComparabilityFootnote([])).toBe('');
+  });
+
+  it('renders a single boundary as one clause', () => {
+    const boundaries: NonComparabilityBoundary[] = [{ date: '2026-09-09T15:15:45Z', label: 'client idle-tail fix' }];
+    const text = formatNonComparabilityFootnote(boundaries);
+    expect(text).toContain('2026-09-09 (client idle-tail fix)');
+    expect(text).toContain("aren't one comparable series");
+  });
+
+  it('groups same-day boundaries into a single clause instead of repeating the date', () => {
+    const boundaries: NonComparabilityBoundary[] = [
+      { date: '2026-09-09T15:15:45Z', label: 'client idle-tail fix' },
+      { date: '2026-09-09T15:23:26Z', label: 'server winsorize cap' },
+    ];
+    const text = formatNonComparabilityFootnote(boundaries);
+    expect(text).toContain('2026-09-09 (client idle-tail fix, server winsorize cap)');
+    // The date string itself appears exactly once, not twice.
+    expect(text.split('2026-09-09').length - 1).toBe(1);
+  });
+
+  it('renders distinct dates as separate "and"-joined clauses, sorted chronologically', () => {
+    const boundaries: NonComparabilityBoundary[] = [
+      { date: '2026-09-20T00:00:00Z', label: 'accumulator rewrite' },
+      { date: '2026-09-09T15:15:45Z', label: 'client idle-tail fix' },
+    ];
+    const text = formatNonComparabilityFootnote(boundaries);
+    const idxFirst = text.indexOf('2026-09-09');
+    const idxSecond = text.indexOf('2026-09-20');
+    expect(idxFirst).toBeGreaterThan(-1);
+    expect(idxSecond).toBeGreaterThan(idxFirst);
+    expect(text).toContain(' and ');
   });
 });

--- a/taxonomy-editor/src/renderer/components/analysis/engagementTree.ts
+++ b/taxonomy-editor/src/renderer/components/analysis/engagementTree.ts
@@ -149,37 +149,104 @@ export function categoryLabel(catKey: string): string {
   return CATEGORY_LABEL_MAP[suffix] ?? catKey;
 }
 
+/** Formats a [0,1] capped-rate fraction as a percentage string, e.g. 0.123 → "12.3%". */
+export function fmtCappedRate(rate: number): string {
+  return `${(rate * 100).toFixed(1)}%`;
+}
+
+// ── Non-comparability boundaries (t/3424) ───────────────────────────────────
+//
+// The engaged-time measurement pipeline has changed more than once (client idle-tail
+// fix, server winsorize cap, …) — each change is a discontinuity in the same visible
+// series (t/3342 spirit). This list is the SOURCE OF TRUTH both dashboards render as
+// a footnote; append a new entry here when a boundary lands (nothing else changes).
+
+export interface NonComparabilityBoundary {
+  /** ISO date/datetime the fix merged. Only the date portion (first 10 chars) is shown. */
+  date: string;
+  /** Short human label for what changed, e.g. "client idle-tail fix". */
+  label: string;
+}
+
+export const ENGAGEMENT_NON_COMPARABILITY_BOUNDARIES: NonComparabilityBoundary[] = [
+  { date: '2026-09-09T15:15:45Z', label: 'client idle-tail fix' },
+  { date: '2026-09-09T15:23:26Z', label: 'server winsorize cap' },
+];
+
+/**
+ * Renders the boundary list as one sentence, grouping same-day boundaries into a
+ * single clause (avoids "on 2026-09-09 and 2026-09-09"). Returns '' for an empty list
+ * so callers can render nothing rather than an empty footnote.
+ */
+export function formatNonComparabilityFootnote(boundaries: NonComparabilityBoundary[]): string {
+  if (boundaries.length === 0) return '';
+  const byDate = new Map<string, string[]>();
+  for (const b of boundaries) {
+    const d = b.date.slice(0, 10);
+    if (!byDate.has(d)) byDate.set(d, []);
+    byDate.get(d)!.push(b.label);
+  }
+  const clauses = [...byDate.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, labels]) => `${date} (${labels.join(', ')})`);
+  return `Engaged-time measurement changed on ${clauses.join(' and ')} — trends spanning these dates aren't one comparable series.`;
+}
+
 // ── Tree traversal ────────────────────────────────────────────────────────────
 
-/** Accumulate engagedMs + visits per camp across all tools in the tree. */
-export function sumByCamp(root: TreeNode): Array<{ key: string; engagedMs: number; visits: number }> {
-  const acc: Record<string, { engagedMs: number; visits: number }> = {};
+export interface KeyedSummary { key: string; engagedMs: number; visits: number; cappedRate?: number }
+
+/**
+ * Accumulate engagedMs + visits per camp across all tools in the tree, plus an
+ * engagedVisits-weighted average of cappedRate (a rate isn't additive — weighting by
+ * each contributing node's engagedVisits is the standard way to combine it; today
+ * there is exactly one contributing tool node per camp, so the "average" is exact).
+ * cappedRate is omitted when no contributor has engagedVisits > 0.
+ */
+export function sumByCamp(root: TreeNode): KeyedSummary[] {
+  const acc: Record<string, { engagedMs: number; visits: number; capWeightedSum: number; capWeight: number }> = {};
   for (const tool of Object.values(root.children ?? {})) {
-    for (const [campKey, camp] of Object.entries(tool.children ?? {})) {
-      if (!acc[campKey]) acc[campKey] = { engagedMs: 0, visits: 0 };
-      acc[campKey].engagedMs += (camp as TreeNode).engagedMs;
-      acc[campKey].visits += (camp as TreeNode).visits;
+    for (const [campKey, campNode] of Object.entries(tool.children ?? {})) {
+      const camp = campNode as TreeNode;
+      if (!acc[campKey]) acc[campKey] = { engagedMs: 0, visits: 0, capWeightedSum: 0, capWeight: 0 };
+      acc[campKey].engagedMs += camp.engagedMs;
+      acc[campKey].visits += camp.visits;
+      if (camp.cappedRate != null && camp.engagedVisits > 0) {
+        acc[campKey].capWeightedSum += camp.cappedRate * camp.engagedVisits;
+        acc[campKey].capWeight += camp.engagedVisits;
+      }
     }
   }
   return Object.entries(acc)
-    .map(([key, v]) => ({ key, ...v }))
+    .map(([key, v]) => ({
+      key, engagedMs: v.engagedMs, visits: v.visits,
+      ...(v.capWeight > 0 ? { cappedRate: v.capWeightedSum / v.capWeight } : {}),
+    }))
     .sort((a, b) => b.engagedMs - a.engagedMs);
 }
 
-/** Accumulate engagedMs + visits per category for a given camp across all tools. */
-export function sumByCategoryForCamp(root: TreeNode, camp: string): Array<{ key: string; engagedMs: number; visits: number }> {
-  const acc: Record<string, { engagedMs: number; visits: number }> = {};
+/** Same accumulation as sumByCamp, one level down: per category for a given camp. */
+export function sumByCategoryForCamp(root: TreeNode, camp: string): KeyedSummary[] {
+  const acc: Record<string, { engagedMs: number; visits: number; capWeightedSum: number; capWeight: number }> = {};
   for (const tool of Object.values(root.children ?? {})) {
     const campNode = (tool as TreeNode).children?.[camp] as TreeNode | undefined;
     if (!campNode) continue;
-    for (const [catKey, cat] of Object.entries(campNode.children ?? {})) {
-      if (!acc[catKey]) acc[catKey] = { engagedMs: 0, visits: 0 };
-      acc[catKey].engagedMs += (cat as TreeNode).engagedMs;
-      acc[catKey].visits += (cat as TreeNode).visits;
+    for (const [catKey, catNode] of Object.entries(campNode.children ?? {})) {
+      const cat = catNode as TreeNode;
+      if (!acc[catKey]) acc[catKey] = { engagedMs: 0, visits: 0, capWeightedSum: 0, capWeight: 0 };
+      acc[catKey].engagedMs += cat.engagedMs;
+      acc[catKey].visits += cat.visits;
+      if (cat.cappedRate != null && cat.engagedVisits > 0) {
+        acc[catKey].capWeightedSum += cat.cappedRate * cat.engagedVisits;
+        acc[catKey].capWeight += cat.engagedVisits;
+      }
     }
   }
   return Object.entries(acc)
-    .map(([key, v]) => ({ key, ...v }))
+    .map(([key, v]) => ({
+      key, engagedMs: v.engagedMs, visits: v.visits,
+      ...(v.capWeight > 0 ? { cappedRate: v.capWeightedSum / v.capWeight } : {}),
+    }))
     .sort((a, b) => b.engagedMs - a.engagedMs);
 }
 
@@ -187,11 +254,16 @@ export function sumByCategoryForCamp(root: TreeNode, camp: string): Array<{ key:
 export function collectLeafNodes(
   node: TreeNode,
   depth: number,
-  results: Array<{ id: string; engagedMs: number; visits: number }>,
+  results: Array<{ id: string; engagedMs: number; visits: number; cappedRate?: number }>,
 ): void {
   const kids = node.children;
   if (!kids || Object.keys(kids).length === 0) {
-    if (depth >= 3) results.push({ id: node.id, engagedMs: node.engagedMs, visits: node.visits });
+    if (depth >= 3) {
+      results.push({
+        id: node.id, engagedMs: node.engagedMs, visits: node.visits,
+        ...(node.cappedRate != null ? { cappedRate: node.cappedRate } : {}),
+      });
+    }
     return;
   }
   for (const child of Object.values(kids)) {


### PR DESCRIPTION
## Summary

TL residual from t/3421 GV (p/613#5): the server-side winsorize fix landed but the user-visible piece didn't. Two boundary dates so far, two discontinuities in the same engaged-time series (t/3342 spirit):
1. Client idle-tail fix (t/3420 item 1) — merged `4d7e8f3c`
2. Server winsorize (t/3421) — merged `20339a2c`

- **Data-driven boundary list** in `engagementTree.ts` (`ENGAGEMENT_NON_COMPARABILITY_BOUNDARIES`) — single source of truth for both dashboards. Adding the incoming 3rd boundary (t/3422's accumulator rewrite) is a one-line append, no component changes.
- `formatNonComparabilityFootnote()` groups same-day boundaries into one clause, sorts distinct dates chronologically.
- Footnote rendered in both `EngagementDashboard` (Overview tab) and `YourActivityPanel` — only when there's data to caveat, never in the empty state.
- **Surfaces the existing (wired-but-never-rendered) `cappedRate`** at camp/category/leaderboard granularity, not just the admin-only aggregate `HealthStrip` metric — per TL's original t/3420 item 4 ask. `sumByCamp`/`sumByCategoryForCamp` now return an engagedVisits-weighted average `cappedRate` (a rate isn't additive; weighting by each contributor's engagedVisits is the standard combination — exact today since there's exactly one contributing tool node per camp/category). `collectLeafNodes` passes through each leaf's own `cappedRate` unchanged.

Routes both t/3424 boundary dates; a 3rd will be a follow-up append per Rosetta Stone's note on the ticket.

## Test plan

- [x] 18 new/updated tests, 54/54 total across `engagementTree.test.ts` / `EngagementDashboard.test.tsx` / `YourActivityPanel.test.tsx`
- [x] `/review-ts` clean
- [x] No new tsc errors
- [ ] Quality (TL) review — routed per docs/review-routing.md (single-scope, UI-only, existing pattern, no schema/data-model change)

Closes t/3424

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AoWKVNhQCeYg5uZZoMUfx3