### PR TITLE
fix(dwellTracker): heartbeat-credit accrual replaces idempotent open-span model (t/3420 item 2, t/3422)

### DIFF
--- a/taxonomy-editor/src/renderer/lib/clientConfig.ts
+++ b/taxonomy-editor/src/renderer/lib/clientConfig.ts
@@ -39,6 +39,8 @@ export interface ClientConfig {
     PULSE_THROTTLE_MS: number;
     /** t/3420: grace window after the last pulse that still counts as engaged on an idle-close. */
     IDLE_GRACE_MS: number;
+    /** t/3422: each pulse grants engagement credit valid through t + CREDIT_WINDOW_MS. */
+    CREDIT_WINDOW_MS: number;
   };
   healthProbe: {
     intervalMs: number;
@@ -99,6 +101,7 @@ const DEFAULTS: ClientConfig = {
     MIN_VISIT_MS: 1_000,
     PULSE_THROTTLE_MS: 5_000,
     IDLE_GRACE_MS: 10_000,
+    CREDIT_WINDOW_MS: 15_000,
   },
   healthProbe: {
     intervalMs: 30_000,

--- a/taxonomy-editor/src/renderer/lib/dwellTracker.test.ts
+++ b/taxonomy-editor/src/renderer/lib/dwellTracker.test.ts
@@ -22,6 +22,7 @@ const THRESHOLDS: EngagementThresholds = {
   MIN_VISIT_MS: 1_000,
   PULSE_THROTTLE_MS: 5_000,
   IDLE_GRACE_MS: 10_000,
+  CREDIT_WINDOW_MS: 15_000,
 };
 
 function makeTracker(thresholds: EngagementThresholds = THRESHOLDS): DwellTracker {
@@ -58,29 +59,62 @@ describe('parseNodeId / deriveSubject / categoryForSubject (t/2466)', () => {
   });
 });
 
-describe('EngagementAccumulator (t/2466 §3.1-3.2)', () => {
-  it('accrues time only across explicit engaged spans', () => {
-    const acc = new EngagementAccumulator(1_800_000);
-    acc.startEngaged(0);
-    acc.stopEngaged(5_000);
+describe('EngagementAccumulator (t/2466 §3.1-3.2, rewritten t/3422 heartbeat-credit)', () => {
+  const WINDOW = 15_000;
+
+  it('accrues time across a pulse-then-pause within the credit window', () => {
+    const acc = new EngagementAccumulator(1_800_000, WINDOW);
+    acc.pulse(0);
+    acc.pause(5_000);
     expect(acc.currentEngagedMs).toBe(5_000);
     expect(acc.isCapped).toBe(false);
   });
 
-  it('clamps to MAX_ENGAGED_MS and sets capped', () => {
-    const acc = new EngagementAccumulator(10_000);
-    acc.startEngaged(0);
-    acc.stopEngaged(50_000); // way over cap
+  it('clamps to MAX_ENGAGED_MS and sets capped across many pulses', () => {
+    const acc = new EngagementAccumulator(10_000, WINDOW);
+    for (let t = 0; t <= 20_000; t += 5_000) acc.pulse(t);
+    acc.pause(20_000);
     expect(acc.currentEngagedMs).toBe(10_000);
     expect(acc.isCapped).toBe(true);
   });
 
-  it('does not double count a span already stopped', () => {
-    const acc = new EngagementAccumulator(1_800_000);
-    acc.startEngaged(0);
-    acc.stopEngaged(1_000);
-    acc.stopEngaged(2_000); // no-op, already stopped
+  it('does not double count an interval already paused', () => {
+    const acc = new EngagementAccumulator(1_800_000, WINDOW);
+    acc.pulse(0);
+    acc.pause(1_000);
+    acc.pause(2_000); // no-op, already paused
     expect(acc.currentEngagedMs).toBe(1_000);
+  });
+
+  // t/3422: correctness properties specific to the credit model.
+  it('a gap wider than the credit window splits into separate intervals (no idle-tail credit)', () => {
+    const acc = new EngagementAccumulator(1_800_000, WINDOW);
+    acc.pulse(0);
+    acc.pulse(100_000); // gap >> WINDOW — old interval closes at its expiry, a new one starts here
+    acc.pause(100_000); // immediately paused — the new interval books 0
+    expect(acc.currentEngagedMs).toBe(WINDOW);
+  });
+
+  it('pause() truncates a live credit at the true stop time, not its full window', () => {
+    const acc = new EngagementAccumulator(1_800_000, WINDOW);
+    acc.pulse(0);
+    acc.pause(2_000); // pulse-then-hide at +2s
+    expect(acc.currentEngagedMs).toBe(2_000); // NOT the full 15s window
+  });
+
+  it('pause() after a credit has already lapsed clamps to the credit expiry (bounded to one window)', () => {
+    const acc = new EngagementAccumulator(1_800_000, WINDOW);
+    acc.pulse(0);
+    acc.pause(70_000); // way past expiry (0 + WINDOW)
+    expect(acc.currentEngagedMs).toBe(WINDOW);
+  });
+
+  it('hasActiveCredit reflects whether a live interval covers time t', () => {
+    const acc = new EngagementAccumulator(1_800_000, WINDOW);
+    expect(acc.hasActiveCredit(0)).toBe(false);
+    acc.pulse(0);
+    expect(acc.hasActiveCredit(WINDOW)).toBe(true);
+    expect(acc.hasActiveCredit(WINDOW + 1)).toBe(false);
   });
 });
 
@@ -158,46 +192,45 @@ describe('DwellTracker — emitted engaged_ms excludes hidden + idle spans (AC a
     expect(detail.capped).toBe(false);
   });
 
-  it('idle-close emits engaged_ms bounded by the trailing idle window, not the full wall gap', () => {
+  it('idle-close emits engaged_ms bounded by the credit window, not the full wall gap', () => {
     const emitted: DwellDetail[] = [];
     const tracker = new DwellTracker(() => THRESHOLDS, (_c, detail) => emitted.push(detail));
     const nodeA: Subject = { subject_type: 'node', subject_id: 'skp-bel-002', pov: 'skp', cat: 'bel', tab: 'skeptic' };
     tracker.onSubjectChange(nodeA, 0);
     tracker.onPulse(0);
-    tracker.onPulse(10_000);                   // active reading through t=10s (single engaged span from 0)
+    tracker.onPulse(10_000);                   // merges into one interval (10s <= 15s window): expires at 25s
     tracker.onIdleTimeout(70_000);             // no pulse since 10s; idle fires at 70s (>60s after last pulse)
     expect(emitted).toHaveLength(1);
     expect(emitted[0].close_reason).toBe('idle');
-    // t/3420: the engaged span stops at lastPulseTime (10s) + IDLE_GRACE_MS (10s) = 20s,
-    // NOT at the full 70s idle-timer-fire moment — the idle tail no longer bleeds into engaged_ms.
-    expect(emitted[0].engaged_ms).toBe(20_000);
+    // t/3422: the interval's credit expires at lastPulse(10s) + CREDIT_WINDOW_MS(15s) = 25s —
+    // pause()'s internal clamp to that expiry is what bounds this, not the 70s idle-fire moment.
+    expect(emitted[0].engaged_ms).toBe(25_000);
     expect(emitted[0].engaged).toBe(true);
   });
 
-  it('t/3420: idle-closed visit books engaged time only through last-pulse + IDLE_GRACE_MS', () => {
+  it('t/3422: idle-closed visit books engaged time only through last-pulse + CREDIT_WINDOW_MS', () => {
     const emitted: DwellDetail[] = [];
     const tracker = new DwellTracker(() => THRESHOLDS, (_c, detail) => emitted.push(detail));
     const nodeA: Subject = { subject_type: 'node', subject_id: 'skp-bel-002', pov: 'skp', cat: 'bel', tab: 'skeptic' };
     tracker.onSubjectChange(nodeA, 0);
     tracker.onPulse(0);
-    tracker.onPulse(5_000); // lastPulseTime = 5_000
+    tracker.onPulse(5_000); // merges (5s <= 15s window); credit now expires at 5_000 + 15_000 = 20_000
     // No more pulses; idle timer fires well past IDLE_TIMEOUT_MS after the last pulse.
     tracker.onIdleTimeout(65_000);
     expect(emitted).toHaveLength(1);
     expect(emitted[0].close_reason).toBe('idle');
-    // Grace window: 5_000 + IDLE_GRACE_MS (10_000) = 15_000, far short of the 65_000 wall gap.
-    expect(emitted[0].engaged_ms).toBe(15_000);
+    expect(emitted[0].engaged_ms).toBe(20_000);
     expect(emitted[0].wall_ms).toBe(65_000);
   });
 
-  it('t/3420: a visit with continuous pulses through close is unaffected by the idle-grace change', () => {
+  it('t/3422: a visit with pulses inside the credit window merges into one continuous interval', () => {
     const emitted: DwellDetail[] = [];
     const tracker = new DwellTracker(() => THRESHOLDS, (_c, detail) => emitted.push(detail));
     const nodeA: Subject = { subject_type: 'node', subject_id: 'skp-bel-002', pov: 'skp', cat: 'bel', tab: 'skeptic' };
     tracker.onSubjectChange(nodeA, 0);
-    tracker.onPulse(0);
-    tracker.onPulse(20_000);
-    tracker.onPulse(40_000);
+    // Pulses every 10s — each within the 15s credit window of the last, so they merge into
+    // one continuous interval rather than splitting (regression guard for sustained reading).
+    for (let t = 0; t <= 50_000; t += 10_000) tracker.onPulse(t);
     // Closed via subject_change (never idle), so onIdleTimeout's pause logic never runs.
     tracker.onSubjectChange({ ...nodeA, subject_id: 'skp-bel-003' }, 60_000);
     expect(emitted).toHaveLength(1);
@@ -206,20 +239,33 @@ describe('DwellTracker — emitted engaged_ms excludes hidden + idle spans (AC a
     expect(emitted[0].wall_ms).toBe(60_000);
   });
 
-  it('t/3420: initiallyEngaged visit with zero pulses books ~0 engaged_ms on idle-close (deltaMs<=0 guard)', () => {
+  it('t/3422: a visit with pulses wider than the credit window apart does NOT get full credit for the gaps', () => {
+    const emitted: DwellDetail[] = [];
+    const tracker = new DwellTracker(() => THRESHOLDS, (_c, detail) => emitted.push(detail));
+    const nodeA: Subject = { subject_type: 'node', subject_id: 'skp-bel-002', pov: 'skp', cat: 'bel', tab: 'skeptic' };
+    tracker.onSubjectChange(nodeA, 0);
+    tracker.onPulse(0);       // interval [0, 15_000)
+    tracker.onPulse(20_000);  // gap (20s) > 15s window — splits: first interval books 15_000, second starts at 20_000
+    tracker.onSubjectChange({ ...nodeA, subject_id: 'skp-bel-003' }, 20_000); // closes immediately, second interval books 0
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].engaged_ms).toBe(15_000); // NOT the full 20_000 wall gap — sparse pulses don't purchase it
+    expect(emitted[0].wall_ms).toBe(20_000);
+  });
+
+  it('t/3420/t/3422: initiallyEngaged visit with zero pulses is bounded to one credit window on idle-close', () => {
     const emitted: DwellDetail[] = [];
     const tracker = new DwellTracker(() => THRESHOLDS, (_c, detail) => emitted.push(detail));
     const nodeA: Subject = { subject_type: 'node', subject_id: 'skp-bel-002', pov: 'skp', cat: 'bel', tab: 'skeptic' };
     // Subject change opens the visit as initiallyEngaged=true (see DwellVisit ctor), but no
-    // onPulse ever fires — lastPulseTime stays at its initial 0, same as the visit start.
+    // onPulse ever fires — the initial construction-time credit is the only one granted.
     tracker.onSubjectChange(nodeA, 0);
     tracker.onIdleTimeout(70_000);
     expect(emitted).toHaveLength(1);
     expect(emitted[0].close_reason).toBe('idle');
-    // pause() clamps to lastPulseTime (0) + IDLE_GRACE_MS, i.e. effectively no engaged span opened
-    // beyond the grace window from t=0 — EngagementAccumulator.accrue's deltaMs<=0 guard means this
-    // books at most IDLE_GRACE_MS, and never the full 70s wall gap.
-    expect(emitted[0].engaged_ms).toBeLessThanOrEqual(THRESHOLDS.IDLE_GRACE_MS);
+    // pause() clamps to the credit's expiry (0 + CREDIT_WINDOW_MS), bounding this to at most one
+    // window regardless of how long the idle wait was — never the full 70s wall gap.
+    expect(emitted[0].engaged_ms).toBeLessThanOrEqual(THRESHOLDS.CREDIT_WINDOW_MS);
+    expect(emitted[0].engaged_ms).toBe(THRESHOLDS.CREDIT_WINDOW_MS);
   });
 });
 
@@ -265,6 +311,11 @@ describe('DwellVisit.close — visit count independent of engaged duration (AC c
     const { DwellVisit } = await import('./dwellTracker');
     const subject: Subject = { subject_type: 'node', subject_id: 'skp-bel-002', pov: 'skp', cat: 'bel', tab: 'skeptic' };
     const visit = new DwellVisit(subject, 0, THRESHOLDS, true);
+    // t/3422: sustained engagement now requires periodic pulses (credit model) — simulate
+    // reading with a pulse every half-window through the full 420s.
+    for (let t = THRESHOLDS.CREDIT_WINDOW_MS / 2; t < 420_000; t += THRESHOLDS.CREDIT_WINDOW_MS / 2) {
+      visit.pulse(t);
+    }
     const detail = visit.close(420_000, 'subject_change', THRESHOLDS);
     expect(detail?.engaged).toBe(true);
     expect(detail?.engaged_ms).toBe(420_000);
@@ -285,9 +336,11 @@ describe('Thresholds read from config, not hardcoded (AC d)', () => {
   });
 
   it('a larger MAX_ENGAGED_MS raises the cap accordingly', () => {
-    const acc = new EngagementAccumulator(3_600_000); // configured 1hr cap
-    acc.startEngaged(0);
-    acc.stopEngaged(3_600_500);
+    // Window sized larger than the tested delta so this isolates the cap from credit-expiry
+    // mechanics (covered separately above) — this test is purely about MAX_ENGAGED_MS.
+    const acc = new EngagementAccumulator(3_600_000, 3_700_000); // configured 1hr cap
+    acc.pulse(0);
+    acc.pause(3_600_500);
     expect(acc.currentEngagedMs).toBe(3_600_000);
     expect(acc.isCapped).toBe(true);
   });

--- a/taxonomy-editor/src/renderer/lib/dwellTracker.ts
+++ b/taxonomy-editor/src/renderer/lib/dwellTracker.ts
@@ -32,8 +32,18 @@ export interface EngagementThresholds {
   ENGAGED_MIN_MS: number;
   MIN_VISIT_MS: number;
   PULSE_THROTTLE_MS: number;
-  /** t/3420: grace window after the last pulse that still counts as engaged on an idle/hidden close. */
+  /**
+   * t/3420: grace window after the last pulse that still counts as engaged on an idle/hidden
+   * close. Superseded as of t/3422 — `onIdleTimeout`/`onHiddenTimeout` no longer consume this
+   * (the credit-window model below provides a more principled bound). Kept for
+   * ClientConfig/RuntimeConfig wire-compatibility with existing deployments.
+   */
   IDLE_GRACE_MS: number;
+  /**
+   * t/3422: each pulse grants engagement credit valid through `t + CREDIT_WINDOW_MS`. See
+   * `EngagementAccumulator`'s docblock for the full accrual model.
+   */
+  CREDIT_WINDOW_MS: number;
 }
 
 export interface Subject {
@@ -101,19 +111,48 @@ export function categoryForSubject(subject: Subject): string {
 }
 
 /**
- * Pure engaged-time accumulator (§3.1-3.2). Tracks spans where the subject was
- * both visible and recently interacted with, clamped to `maxEngagedMs`. No
- * busy polling — accrual happens only on explicit state-transition calls.
+ * Pure engaged-time accumulator (§3.1-3.2, rewritten t/3422). Tracks time via
+ * per-pulse bounded CREDITS instead of an open-ended span: each `pulse(t)`
+ * grants engagement validity through `t + creditWindowMs`. A later pulse
+ * arriving within a still-live credit MERGES into the same interval
+ * (extending its expiry, `intervalStart` unchanged); a gap wider than the
+ * window means the old interval already silently ended at its expiry —
+ * that gets accrued, then a fresh interval starts at the new pulse. This
+ * replaces the old idempotent open-span model (`startEngaged`/`stopEngaged`)
+ * that was the root cause of t/3420's idle-tail inflation: a span could sit
+ * open indefinitely because nothing ever re-checked whether real time had
+ * elapsed since the last actual signal.
+ *
+ * `pause(t)` always truncates any live interval AT `t` (clamped to its
+ * credit expiry, whichever is earlier) — a pulse immediately followed by a
+ * hide/subject-change/idle-close must book only the real elapsed time, not
+ * the full credit window. This is why `pause` never skips accrual just
+ * because a credit is still "active": t/3422 review flagged that the
+ * truncate-at-true-stop behavior is what makes hidden and mid-credit
+ * subject-change closes correct, not incidental.
+ *
+ * Over-credit, by design: when `pause(t)` is called well after a credit has
+ * already lapsed (the idle-close path — the idle timer fires
+ * `IDLE_TIMEOUT_MS` after the last pulse, far past `creditWindowMs`), the
+ * clamp binds at the credit's expiry instead of `t`. A visit can therefore
+ * accrue at most one `creditWindowMs` of engaged time past its last real
+ * pulse — bounded, intentional, and far tighter than the pre-t/3420 bug
+ * (which had no bound at all).
  */
 export class EngagementAccumulator {
-  private engagedSince: number | null = null;
+  private intervalStart: number | null = null;
+  private creditExpiresAt: number | null = null;
   private engagedMs = 0;
   private capped = false;
 
-  constructor(private readonly maxEngagedMs: number) {}
+  constructor(
+    private readonly maxEngagedMs: number,
+    private readonly creditWindowMs: number,
+  ) {}
 
-  get isEngaged(): boolean {
-    return this.engagedSince !== null;
+  /** Is there a live credit (an interval that hasn't yet expired) at time t? */
+  hasActiveCredit(t: number): boolean {
+    return this.creditExpiresAt !== null && t <= this.creditExpiresAt;
   }
 
   get currentEngagedMs(): number {
@@ -124,16 +163,32 @@ export class EngagementAccumulator {
     return this.capped;
   }
 
-  /** Start (or continue, idempotently) an engaged span at time t. */
-  startEngaged(t: number): void {
-    if (this.engagedSince === null) this.engagedSince = t;
+  /** Grant a pulse credit at time t, valid through t + creditWindowMs. */
+  pulse(t: number): void {
+    if (this.intervalStart === null) {
+      this.intervalStart = t;
+      this.creditExpiresAt = t + this.creditWindowMs;
+      return;
+    }
+    if (t > (this.creditExpiresAt as number)) {
+      // Gap exceeded the credit window: the old interval silently ended at its
+      // expiry — accrue only up to there, then start a fresh interval at t.
+      this.accrue((this.creditExpiresAt as number) - this.intervalStart);
+      this.intervalStart = t;
+      this.creditExpiresAt = t + this.creditWindowMs;
+      return;
+    }
+    // Still within the credit window — merge: keep intervalStart, extend expiry.
+    this.creditExpiresAt = t + this.creditWindowMs;
   }
 
-  /** Stop the current engaged span at time t, accruing its duration (clamped). */
-  stopEngaged(t: number): void {
-    if (this.engagedSince === null) return;
-    this.accrue(t - this.engagedSince);
-    this.engagedSince = null;
+  /** Truncate any live interval at time t (clamped to its credit expiry) and accrue it. */
+  pause(t: number): void {
+    if (this.intervalStart === null) return;
+    const stopAt = Math.min(t, this.creditExpiresAt as number);
+    this.accrue(stopAt - this.intervalStart);
+    this.intervalStart = null;
+    this.creditExpiresAt = null;
   }
 
   private accrue(deltaMs: number): void {
@@ -151,9 +206,9 @@ export class EngagementAccumulator {
     }
   }
 
-  /** Close any open span at time t and return the final accumulated result. */
+  /** Close any open interval at time t and return the final accumulated result. */
   finish(t: number): { engagedMs: number; capped: boolean } {
-    this.stopEngaged(t);
+    this.pause(t);
     return { engagedMs: this.engagedMs, capped: this.capped };
   }
 }
@@ -170,20 +225,16 @@ export class DwellVisit {
     initiallyEngaged: boolean,
   ) {
     this.startWall = startWall;
-    this.accumulator = new EngagementAccumulator(thresholds.MAX_ENGAGED_MS);
-    if (initiallyEngaged) this.accumulator.startEngaged(startWall);
+    this.accumulator = new EngagementAccumulator(thresholds.MAX_ENGAGED_MS, thresholds.CREDIT_WINDOW_MS);
+    if (initiallyEngaged) this.accumulator.pulse(startWall);
   }
 
   pulse(t: number): void {
-    this.accumulator.startEngaged(t);
+    this.accumulator.pulse(t);
   }
 
   pause(t: number): void {
-    this.accumulator.stopEngaged(t);
-  }
-
-  get isEngaged(): boolean {
-    return this.accumulator.isEngaged;
+    this.accumulator.pause(t);
   }
 
   /**
@@ -271,13 +322,12 @@ export class DwellTracker {
   /** Called when the idle timer fires (no pulse for IDLE_TIMEOUT_MS). */
   onIdleTimeout(t: number): void {
     if (this.recentlyActive(t)) return;
-    // t/3420: the idle timer fires IDLE_TIMEOUT_MS after the last pulse, but the visit stayed
-    // "engaged" (per EngagementAccumulator.startEngaged's idempotent open-span model) the whole
-    // time — closing at `t` directly would bleed that full idle tail into engaged_ms. Stop the
-    // engaged span early, at lastPulseTime + a short grace, mirroring how onVisibilityChange
-    // already stops accrual at the true hide moment; wall_ms (computed from `t` in close()) is
-    // unaffected. The subsequent close()/finish() then no-ops on accrual (already stopped).
-    this.currentVisit?.pause(Math.min(t, this.lastPulseTime + this.getThresholds().IDLE_GRACE_MS));
+    // t/3420/t/3422: the idle timer fires IDLE_TIMEOUT_MS after the last pulse, far past any
+    // live credit's expiry (CREDIT_WINDOW_MS) — EngagementAccumulator.pause()'s own clamp to
+    // its credit expiry already bounds accrual to at most one CREDIT_WINDOW_MS past the last
+    // pulse, so this call is a no-op by the time it runs (the credit expired long before `t`).
+    // Kept explicit for readability/symmetry with onHiddenTimeout, not because it does anything.
+    this.currentVisit?.pause(t);
     this.emitClose(t, 'idle');
   }
 
@@ -297,7 +347,7 @@ export class DwellTracker {
     // t/3420: onVisibilityChange already pauses accrual at the true hide moment, so this is
     // normally a no-op by the time it runs — kept as defense-in-depth for the same idle-tail
     // flaw class (in case pause() was ever skipped), not because it currently does anything.
-    this.currentVisit?.pause(Math.min(t, this.lastPulseTime + this.getThresholds().IDLE_GRACE_MS));
+    this.currentVisit?.pause(t);
     this.emitClose(t, 'hidden');
   }
 

--- a/taxonomy-editor/src/server/__tests__/runtimeConfig.test.ts
+++ b/taxonomy-editor/src/server/__tests__/runtimeConfig.test.ts
@@ -300,7 +300,7 @@ describe('REST-endpoint support — file round-trip (t/927)', () => {
     const client = getClientConfig();
     expect(Object.keys(client).sort()).toEqual(['analytics', 'debate', 'flightRecorder', 'resilience']);
     expect(Object.keys(client.flightRecorder).sort()).toEqual(['dumpWindowMs', 'maxDumpsPerWindow', 'minDumpIntervalMs']);
-    expect(Object.keys(client.analytics)).toEqual(['bufferRequeueLimit', 'IDLE_TIMEOUT_MS', 'MAX_ENGAGED_MS', 'ENGAGED_MIN_MS', 'MIN_VISIT_MS', 'PULSE_THROTTLE_MS', 'IDLE_GRACE_MS']);
+    expect(Object.keys(client.analytics)).toEqual(['bufferRequeueLimit', 'IDLE_TIMEOUT_MS', 'MAX_ENGAGED_MS', 'ENGAGED_MIN_MS', 'MIN_VISIT_MS', 'PULSE_THROTTLE_MS', 'IDLE_GRACE_MS', 'CREDIT_WINDOW_MS']);
     expect(client.resilience.circuitThreshold).toBe(5);
     expect(client.debate).toEqual({
       defaultConfrontationRounds: 1, defaultArgumentationRounds: 2, defaultConcludingRounds: 1,

--- a/taxonomy-editor/src/server/runtimeConfig.ts
+++ b/taxonomy-editor/src/server/runtimeConfig.ts
@@ -84,6 +84,8 @@ export interface RuntimeConfig {
     /** t/3420: grace window after the last pulse that still counts as engaged on an idle-close —
      *  caps the idle-tail bleed into engaged_ms (the idle timer itself fires IDLE_TIMEOUT_MS later). */
     IDLE_GRACE_MS: number;
+    /** t/3422: each pulse grants engagement credit valid through t + CREDIT_WINDOW_MS. */
+    CREDIT_WINDOW_MS: number;
   };
   flightRecorder: {
     minDumpIntervalMs: number;
@@ -192,6 +194,7 @@ const DEFAULTS: RuntimeConfig = {
     MIN_VISIT_MS: 1_000,
     PULSE_THROTTLE_MS: 5_000,
     IDLE_GRACE_MS: 10_000,
+    CREDIT_WINDOW_MS: 15_000,
   },
   flightRecorder: {
     minDumpIntervalMs: 10_000,
@@ -421,6 +424,7 @@ export function validateAndMerge(raw: unknown, defaults: RuntimeConfig): { confi
       MIN_VISIT_MS: vNum(an.MIN_VISIT_MS, defaults.analytics.MIN_VISIT_MS, { min: 0, max: DURATION_MAX }, 'analytics.MIN_VISIT_MS', errors),
       PULSE_THROTTLE_MS: vNum(an.PULSE_THROTTLE_MS, defaults.analytics.PULSE_THROTTLE_MS, { min: 0, max: DURATION_MAX }, 'analytics.PULSE_THROTTLE_MS', errors),
       IDLE_GRACE_MS: vNum(an.IDLE_GRACE_MS, defaults.analytics.IDLE_GRACE_MS, { min: 0, max: DURATION_MAX }, 'analytics.IDLE_GRACE_MS', errors),
+      CREDIT_WINDOW_MS: vNum(an.CREDIT_WINDOW_MS, defaults.analytics.CREDIT_WINDOW_MS, { min: 0, max: DURATION_MAX }, 'analytics.CREDIT_WINDOW_MS', errors),
     },
     flightRecorder: {
       minDumpIntervalMs: vNum(fr.minDumpIntervalMs, defaults.flightRecorder.minDumpIntervalMs, { min: 0, max: DURATION_MAX }, 'flightRecorder.minDumpIntervalMs', errors),
@@ -663,7 +667,7 @@ export function diffFromDefaults(): ConfigDiffEntry[] {
 export interface ClientConfig {
   resilience: RuntimeConfig['resilience'];
   flightRecorder: Pick<RuntimeConfig['flightRecorder'], 'minDumpIntervalMs' | 'maxDumpsPerWindow' | 'dumpWindowMs'>;
-  analytics: Pick<RuntimeConfig['analytics'], 'bufferRequeueLimit' | 'IDLE_TIMEOUT_MS' | 'MAX_ENGAGED_MS' | 'ENGAGED_MIN_MS' | 'MIN_VISIT_MS' | 'PULSE_THROTTLE_MS' | 'IDLE_GRACE_MS'>;
+  analytics: Pick<RuntimeConfig['analytics'], 'bufferRequeueLimit' | 'IDLE_TIMEOUT_MS' | 'MAX_ENGAGED_MS' | 'ENGAGED_MIN_MS' | 'MIN_VISIT_MS' | 'PULSE_THROTTLE_MS' | 'IDLE_GRACE_MS' | 'CREDIT_WINDOW_MS'>;
   debate: RuntimeConfig['debate'];
 }
 
@@ -689,6 +693,7 @@ export function getClientConfig(): ClientConfig {
       MIN_VISIT_MS: c.analytics.MIN_VISIT_MS,
       PULSE_THROTTLE_MS: c.analytics.PULSE_THROTTLE_MS,
       IDLE_GRACE_MS: c.analytics.IDLE_GRACE_MS,
+      CREDIT_WINDOW_MS: c.analytics.CREDIT_WINDOW_MS,
     },
     debate: c.debate,
   };


### PR DESCRIPTION
## Summary

t/3420 item 2 (TL-approved design, t/3422#1/#2): replaces `EngagementAccumulator`'s idempotent open-span model — the root mechanism behind the idle-tail inflation item 1 patched symptomatically — with per-pulse bounded credits.

- Each `pulse(t)` grants engagement validity through `t + CREDIT_WINDOW_MS` (15s). Pulses within a still-live credit merge into one interval; a gap wider than the window closes the old interval at its expiry and starts fresh — sparse jitter stops purchasing continuous time.
- `pause(t)` always truncates any live interval **at t** (clamped to its credit expiry, whichever is earlier) — the TL-required addition: a pulse-then-hide/subject-change must book only the real elapsed time, never the full window.
- `isEngaged` (unused no-arg getter) → `hasActiveCredit(t)`, matching the class's existing explicit-timestamp convention.
- `onIdleTimeout`/`onHiddenTimeout` simplified to plain `pause(t)` — the accumulator's own credit-expiry clamp now provides the bound, making the old `IDLE_GRACE_MS`-based `Math.min(...)` at those call sites redundant (left in config for wire-compat, doc-noted as superseded, not removed — out of scope here).
- New `CREDIT_WINDOW_MS` threshold plumbed through `EngagementThresholds`, `ClientConfig['analytics']`, and `RuntimeConfig['analytics']` (self-managed cross-scope per t/3401/t/3420 precedent — mechanical mirror of the existing `IDLE_GRACE_MS` pattern across all 5 spots + test key-list).
- Existing idle-close test recomputed for the new model (20_000 → 25_000). New arms per TL review: gap-splitting, pause-truncates-at-stop, pause-after-lapse bounds-to-one-window, `hasActiveCredit`, continuous-pulse regression guard, and the zero-pulse `initiallyEngaged` arm (now exactly one `CREDIT_WINDOW_MS`, was `≤IDLE_GRACE_MS`).

Per TL: PR routes to Tech Lead for review — opened as draft pending that review, not self-merging.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` (renderer) — clean
- [x] `npx tsc --noEmit -p tsconfig.server.json` (server) — clean
- [x] `npx vitest run src/renderer/lib/dwellTracker.test.ts src/server/__tests__/runtimeConfig.test.ts` — 59/59 pass
- [x] RED-arm proof: reverted `dwellTracker.ts` to pre-t/3422 state, confirmed exactly the 12 tests targeting new credit-model API/behavior failed (not the 2 unaffected regression-guard tests), restored, re-verified green
- [x] `npx eslint` on all 5 touched files — clean

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>
Co-Authored-By: Tech Lead (Orca) <main.tech-lead@ai-triad-research.orca.local>