### PR TITLE
feat(debate): breadthAwareSituationSelection flag — experiment 1 wiring (t/3411)

### DIFF
--- a/lib/debate/debateEngine/internals.ts
+++ b/lib/debate/debateEngine/internals.ts
@@ -107,6 +107,8 @@ export interface DebateConfig {
   /** Replace description grounding text with the node's synthetic_phrase nearest the description embedding (t/3367).
    *  Off by default. Requires adapter.computeQueryEmbedding; WARN-falls back to description when unavailable. */
   useSyntheticPhraseGrounding?: boolean;
+  /** Rank situation selection by weighted breadth score (relevance + freshness + bdi_entropy via PRE_DEBATE_WEIGHTS) instead of pure relevance (t/3411 experiment). Off by default. */
+  breadthAwareSituationSelection?: boolean;
   /** Enable over-generate/select/rewrite pipeline: N=3 drafts, dedup, greedy top-K, rewrite, coherence gate (t/1581). */
   experiment_overgen_select_rewrite?: boolean;
   /** Exploration summary from a prior cheap-engine run — seeds cruxes, situations, AN priming, and config overrides. */

--- a/lib/debate/debateEngine/taxonomyContext.ts
+++ b/lib/debate/debateEngine/taxonomyContext.ts
@@ -25,6 +25,8 @@ import {
 } from '../debateConfig.js';
 import { loadProvisionalWeights } from '../phaseTransitions.js';
 import { cosineSimilarity } from '../../embeddings/similarity.js';
+import { computePreDebateFreshness, computeBdiEntropy, weightedSituationScore, PRE_DEBATE_WEIGHTS } from '../situationScoring.js';
+import { type Category } from '../taxonomyTypes.js';
 
 export function getNodeLabelMap(engine: DebateEngineInternals): Map<string, string> {
   if (engine._nodeLabelMap) return engine._nodeLabelMap;
@@ -343,6 +345,26 @@ export async function getRelevantTaxonomyContext(engine: DebateEngineInternals, 
       if (sitScores.has(sitId)) {
         sitScores.set(sitId, (sitScores.get(sitId) ?? 0) + adjustment);
       }
+    }
+  }
+
+  if (engine.config.breadthAwareSituationSelection) {
+    const nodeCategoryLookup = new Map<string, Category>();
+    for (const pov of ['accelerationist', 'safetyist', 'skeptic'] as const) {
+      for (const node of engine.taxonomy[pov].nodes) {
+        nodeCategoryLookup.set(node.id, node.category);
+      }
+    }
+    const maxDebateCount = Math.max(0, ...ctx.situationNodes.map(s => s.debate_refs?.length ?? 0));
+    for (const sit of ctx.situationNodes) {
+      const components = {
+        relevance: sitScores.get(sit.id) ?? 0,
+        diversity: 0,
+        freshness: computePreDebateFreshness(sit, maxDebateCount),
+        bdi_entropy: computeBdiEntropy(sit.linked_nodes ?? [], nodeCategoryLookup),
+        conflict_openness: 0,
+      };
+      sitScores.set(sit.id, weightedSituationScore(components, PRE_DEBATE_WEIGHTS));
     }
   }
 


### PR DESCRIPTION
Wires the PI-approved breadth-aware situation selection experiment (t/3411#3).

## What changed
- **`lib/debate/debateEngine/internals.ts`**: adds `breadthAwareSituationSelection?: boolean` flag (default off), same pattern as `enableSituationStatements` / `useSyntheticPhraseGrounding`.
- **`lib/debate/debateEngine/taxonomyContext.ts`**: when flag is on, replaces pure-relevance `sitScores` with `weightedSituationScore(components, PRE_DEBATE_WEIGHTS)` using relevance + `computePreDebateFreshness` + `computeBdiEntropy`. `diversity` and `conflict_openness` set to 0 (data-gap per t/3411#3 experiment 1 design — conflict_ids 1/443, disagreement_type 87% monotype). Downstream `selectRelevantSituationNodes` call unchanged.

## Self-cert
/trivial-change — flag-only, default-off, single-scope (lib/debate), no new exports, no interface changes. 103/103 tests pass at 54de077c.

Closes t/3411 wiring phase. CL owns A/B execution.