### PR TITLE
chore(analysis): add third non-comparability boundary — client accumulator rewrite (t/3424 follow-up)

### DIFF
--- a/taxonomy-editor/src/renderer/components/analysis/engagementTree.ts
+++ b/taxonomy-editor/src/renderer/components/analysis/engagementTree.ts
@@ -171,6 +171,7 @@ export interface NonComparabilityBoundary {
 export const ENGAGEMENT_NON_COMPARABILITY_BOUNDARIES: NonComparabilityBoundary[] = [
   { date: '2026-09-09T15:15:45Z', label: 'client idle-tail fix' },
   { date: '2026-09-09T15:23:26Z', label: 'server winsorize cap' },
+  { date: '2026-09-09T16:01:47Z', label: 'client accumulator rewrite' },
 ];
 
 /**


### PR DESCRIPTION
## Summary

Quick follow-up to t/3424 (PR #2114): appends the third engaged-time non-comparability boundary now that t/3422 (client accumulator rewrite, PR #2115) has merged.

- `afdb998191` @ 2026-09-09T16:01:47Z UTC — replaces the idempotent open-span dwell model with per-pulse heartbeat-credit accrual
- One-line append to `ENGAGEMENT_NON_COMPARABILITY_BOUNDARIES` in `engagementTree.ts`, per the extension point the original design (t/3424#2) was built for — no component changes needed

Self-cert `/trivial-change`: single data-array entry, no behavior/API change.

## Test plan

- [x] All 54 existing tests across `engagementTree.test.ts` / `EngagementDashboard.test.tsx` / `YourActivityPanel.test.tsx` pass unchanged (none assert exact boundary count)

Follow-up to t/3424

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AoWKVNhQCeYg5uZZoMUfx3