### PR TITLE
feat(lib): tighten Zod about[].ref → ^ent- — Option-C phase-3 (t/3425)

### DIFF
--- a/lib/entities/logicalForm.test.ts
+++ b/lib/entities/logicalForm.test.ts
@@ -222,10 +222,21 @@ describe('topical_candidates (Option C phase-1, t/3408) — additive marking obj
     expect(logicalFormSchema.safeParse({ ...CANONICAL, topical_candidates: bad }).success).toBe(false);
   });
 
-  // PHASE-3 REMOVAL: this tolerance-arm test is DELETED when about[].ref is tightened to ^ent- after
-  // the t/3391 migration (c-design.md §6). Until then about[] must accept term: refs on the live corpus.
-  it('about[] STILL tolerates a term: ref in phase-1 (removed in phase-3)', () => {
+  // PHASE-3 ENFORCEMENT (t/3425, replaces the phase-1 tolerance arm): after the t/3391 migration moved
+  // every term: ref out of about[] (TL second-agent re-count t/3391#8: 0 remain across 618 nodes), about[]
+  // is tightened to ^ent-. about[] now REJECTS a term: ref; term: topical refs live in topical_candidates.
+  it('about[] REJECTS a term: ref (phase-3 enforcement — term: refs belong in topical_candidates)', () => {
     const r = logicalFormSchema.safeParse({ ...CANONICAL, about: [{ ref: 'term:frontier-model', match_level: 'exact' }] });
+    expect(r.success).toBe(false);
+  });
+
+  it('about[] still accepts an ent- ref (the validated ent-only topical layer)', () => {
+    const r = logicalFormSchema.safeParse({ ...CANONICAL, about: [{ ref: 'ent-055', match_level: 'exact' }] });
     expect(r.success).toBe(true);
+  });
+
+  it('about[] REJECTS ent: (colon) — HYPHEN only, SO e/145#14 d2 typo guard', () => {
+    const r = logicalFormSchema.safeParse({ ...CANONICAL, about: [{ ref: 'ent:055', match_level: 'exact' }] });
+    expect(r.success).toBe(false);
   });
 });

--- a/lib/entities/logicalForm.ts
+++ b/lib/entities/logicalForm.ts
@@ -81,12 +81,15 @@ export const lfArgSchema = z.object({
 
 /** Topical grounding entry — an id the claim is *about* (schema doc §about[]).
  *  Superset convention: a topical participant appears in BOTH `args[]` and `about[]`.
- *  PHASE-1 (Option C, t/3408 / e/145): `ref` stays a plain string — about[] remains TOLERANT of
- *  `term:` refs. Do NOT tighten to `^ent-` here — enforcement is PHASE-3, AFTER the t/3391 corpus
- *  migration moves the 1560 `term:` refs into `topical_candidates`. The land-order is load-bearing:
- *  tightening before the data moves would red the fleet on the not-yet-migrated corpus (c-design.md §6). */
+ *  PHASE-3 (Option C, t/3425 / e/145): `ref` is now ENFORCED to `^ent-` — about[] is the validated
+ *  ent-only topical layer. The t/3391 corpus migration (verified green, TL second-agent re-count
+ *  t/3391#8: 0 `term:` refs remain across 618 nodes) moved the 1560 `term:` refs into
+ *  `topical_candidates`, so this tightening reds nothing on the live corpus. Concept (`term:`) topical
+ *  refs now live ONLY in `topical_candidates.refs` ({@link lfTopicalCandidateRefSchema}, `^(term:|ent-)`).
+ *  The land-order was load-bearing: this enforcement had to follow the migration, not precede it
+ *  (c-design.md §6). `ent-` is HYPHENATED (`ent-360`), never `ent:` (SO e/145#14 d2 typo guard). */
 export const lfAboutSchema = z.object({
-  ref: z.string(),
+  ref: z.string().regex(/^ent-/, 'about[] ref must be an entity ref starting with "ent-" (term: refs live in topical_candidates)'),
   match_level: lfMatchLevelSchema,
 }).passthrough();
 


### PR DESCRIPTION
## Option-C phase-3 — enforcement (t/3425)

Phase 3 of the signed-off Option-C land order (e/145, `c-design.md` §6). Tightens `logicalFormSchema` `about[].ref` from a plain `z.string()` to `z.string().regex(/^ent-/)`.

**Gate — CLEAR.** The t/3391 phase-2 corpus migration is verified green: TL second-agent re-count (t/3391#8) confirms **0 `term:` refs remain in `about[]` across 618 nodes** (1560 moved into `topical_candidates`). Enforcement-before-verified-data was the one land-order hazard; it's discharged. This tightening reds nothing on the live corpus.

### Changes
- `lib/entities/logicalForm.ts` — `lfAboutSchema.ref` now enforced to `^ent-`; `about[]` is the validated ent-only topical layer. Concept (`term:`) topical refs live **only** in `topical_candidates.refs` (still `^(term:|ent-)`). `ent-` is HYPHENATED, never `ent:` (SO e/145#14 d2 typo guard).
- `lib/entities/logicalForm.test.ts` — replaced the phase-1 tolerance arm with phase-3 enforcement: `about[]` **rejects** a `term:` ref, still accepts `ent-`, and rejects `ent:` (colon).

### Verification
- Targeted `logicalForm.test.ts`: **30/30 green**.
- `tsc` (main + server), renderer-tsc, eslint, depcruise: **pass** (bidirectional anti-drift guards hold).
- Full local `npm run verify` had 79 failures in 5 unrelated files (`validateDataRoot` Windows `C:\` path; `githubApi`/`t2020Security` undici major-version skew — the invariant itself labels this LOCAL-ONLY, CI's node:22 matches the userland pin; `azureBlobBackend` Azurite; `relevantNodesRealEmbedParity` needs corpus). **Confirmed identical failures on the pristine `main` checkout** — pre-existing/environmental, not from this change. CI (Linux, node:22) is the authoritative gate.

### Review
Draft — **CL reviews the schema change** (DOLCE-typed field) per the ticket before un-drafting/merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)