### PR TITLE
feat(debate): expose breadthAwareSituationSelection in CLI config (t/3411)

### DIFF
--- a/lib/debate/cli.ts
+++ b/lib/debate/cli.ts
@@ -75,6 +75,7 @@ interface CLIConfig {
   exploreFirst?: boolean;
   exploreModel?: string;
   excludeGreatestHits?: boolean;
+  breadthAwareSituationSelection?: boolean;
 }
 
 interface GoldenFixtureConfig extends CLIConfig {
@@ -447,6 +448,7 @@ async function main(): Promise<void> {
     stageModels: config.stageModels,
     utilityModels: config.utilityModels,
     excludeGreatestHits: config.excludeGreatestHits,
+    breadthAwareSituationSelection: config.breadthAwareSituationSelection,
   };
 
   // Prepare output paths early so the snapshot callback can write partial files


### PR DESCRIPTION
Exposes the `breadthAwareSituationSelection` flag (added in #2116) through `CLIConfig` so batch runners and `Show-TriadDialogue` can activate it via JSON config.

Two lines added, matching the `excludeGreatestHits` pattern exactly. Self-cert /trivial-change — single-scope, no new exports, no interface changes.

Part of t/3411 A/B batch infrastructure.