### PR TITLE
fix(opeds): community share sends the community id, not the doc's own set_id (t/3426)

### DIFF
--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTab.shareGuard.test.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTab.shareGuard.test.tsx
@@ -6,14 +6,23 @@
 // Share"); community op-eds are PUBLIC and share via /api/community/opeds/:id/share ("🔗 Get public
 // link", t/3315). This locks the guard: no share when shareSource is null; own vs community render
 // distinct controls (different endpoint + label). Share is web-only (t/2728).
+//
+// t/3426: also locks WHICH id gets posted for a community op-ed — the community-share endpoint
+// keys on the community addressing id (the community list entry's `.id`), NOT the loaded
+// document's own `.set_id` (the submitter's original id, which can differ once a community
+// submission is addressed distinctly from its source, t/856). The bug shipped because every prior
+// fixture used set_id === communityId, so the mismatch was never exercised.
 
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type { OpEdSet } from '../../../../../lib/oped/types';
+
+const shareCommunityOpEd = vi.fn().mockResolvedValue({ shareId: 'share-1' });
 
 // Web mode (share is web-only, t/2728); api is only touched on click, not on render.
 vi.mock('@bridge', () => ({
-  api: { shareOpEdSet: vi.fn(), unshareOpEdSet: vi.fn(), shareCommunityOpEd: vi.fn() },
+  api: { shareOpEdSet: vi.fn(), unshareOpEdSet: vi.fn(), shareCommunityOpEd: (...args: unknown[]) => shareCommunityOpEd(...args) },
   isElectronMode: () => false,
 }));
 
@@ -24,7 +33,7 @@ const SHARE_LABEL_COMMUNITY = 'Get a public share link for this community op-ed'
 const set = { set_id: 'set-1' } as unknown as OpEdSet;
 
 // readerLoading keeps OpEdReader unrendered so we isolate the reader bar (where Share lives).
-function renderReader(shareSource: 'my' | 'community' | null) {
+function renderReader(shareSource: 'my' | 'community' | null, communityId: string | null = null) {
   return render(
     <OpEdReaderView
       readerSet={set}
@@ -33,6 +42,7 @@ function renderReader(shareSource: 'my' | 'community' | null) {
       status={null}
       onBack={() => {}}
       shareSource={shareSource}
+      communityId={communityId}
     />,
   );
 }
@@ -51,8 +61,25 @@ describe('OpEdReaderView Share guard (t/2987 + t/3315)', () => {
   });
 
   it("renders '🔗 Get public link' for a community op-ed (shareSource='community', t/3315)", () => {
-    renderReader('community');
+    renderReader('community', 'community-1');
     expect(screen.queryByLabelText(SHARE_LABEL_COMMUNITY)).not.toBeNull();
     expect(screen.queryByLabelText(SHARE_LABEL_MY)).toBeNull();
+  });
+
+  it('renders NO share control for a community op-ed when communityId is missing', () => {
+    // Defensive: if the caller ever fails to thread communityId, fail closed (no broken share
+    // button) rather than falling back to the wrong (set_id) id — t/3426's exact failure mode.
+    renderReader('community', null);
+    expect(screen.queryByLabelText(SHARE_LABEL_COMMUNITY)).toBeNull();
+  });
+
+  it('t/3426: posts the COMMUNITY id, not the document set_id, when they differ', async () => {
+    // The regression fixture: set_id ('set-1') deliberately != communityId ('community-1') —
+    // every fixture before this bug used set_id === communityId, hiding the mismatch.
+    const user = userEvent.setup();
+    renderReader('community', 'community-1');
+    await user.click(screen.getByLabelText(SHARE_LABEL_COMMUNITY));
+    expect(shareCommunityOpEd).toHaveBeenCalledWith('community-1');
+    expect(shareCommunityOpEd).not.toHaveBeenCalledWith(set.set_id);
   });
 });

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
@@ -244,7 +244,7 @@ function ShareOpEdControl({ setId, source = 'my' }: { setId: string; source?: 'm
 // ── Reader view (back bar + article/loading/error) ────────────────────────────
 
 export function OpEdReaderView({
-  readerSet, readerLoading, readerError, status, onBack, shareSource,
+  readerSet, readerLoading, readerError, status, onBack, shareSource, communityId,
 }: {
   readerSet: OpEdSet | null;
   readerLoading: boolean;
@@ -254,7 +254,16 @@ export function OpEdReaderView({
   /** t/2987/t/3315: which store the op-ed came from — 'my' (own share) or 'community' (public community
    *  share); null = not shareable. Both mint a public /share/oped link via their respective endpoint. */
   shareSource: 'my' | 'community' | null;
+  /**
+   * t/3426: the community op-ed's own addressing id (the community list entry's `.id`, what the
+   * community-share endpoint keys on — `oped-{id}.json`). Required when shareSource is 'community':
+   * the loaded document's OWN `.set_id` is the submitter's ORIGINAL op-ed-set id, which differs from
+   * the community id once a community submission is addressed distinctly from its source (t/856) —
+   * passing set_id there 404s (getCommunityOpEd finds no record under the wrong id). Unused for 'my'.
+   */
+  communityId: string | null;
 }) {
+  const shareId = shareSource === 'community' ? communityId : (readerSet?.set_id ?? null);
   return (
     <div className="two-column oped-tab-table-mode">
       <div className="oped-reader-shell">
@@ -263,8 +272,9 @@ export function OpEdReaderView({
           {status && <span className="oped-status">{status}</span>}
           {/* Share is web-only (electron-bridge rejects, t/2728). Own op-eds use the own-share endpoint;
               community op-eds use the community-share endpoint (t/3315 — community is public). Both mint
-              a public /share/oped link. */}
-          {readerSet && shareSource && !isElectronMode() && <ShareOpEdControl setId={readerSet.set_id} source={shareSource} />}
+              a public /share/oped link. shareId (not readerSet.set_id) is what's sent — see communityId
+              doc above for why those two ids can differ for community op-eds (t/3426). */}
+          {readerSet && shareSource && shareId && !isElectronMode() && <ShareOpEdControl setId={shareId} source={shareSource} />}
         </div>
         {readerLoading && <p className="oped-reader-loading">Loading op-ed…</p>}
         {readerError && <p className="oped-reader-error">{readerError}</p>}
@@ -305,10 +315,14 @@ export function OpEdTab() {
   // The set currently open in the reader — may come from the personal store (My)
   // or a community load (Community). null = table view.
   const [readerSet, setReaderSet] = useState<OpEdSet | null>(null);
-  // t/2987: which store the open op-ed came from. 'my' sets are shareable (they live in the
-  // user's oped-sets store); 'community' ones are NOT — the share endpoint reads the user's own
-  // store, so sharing a community-loaded op-ed 404s. Design: Share (My) / Copy (Community).
+  // t/2987/t/3315: which store the open op-ed came from — 'my' shares via the own-set endpoint,
+  // 'community' shares via the community endpoint (both mint a public /share/oped link).
   const [readerSource, setReaderSource] = useState<'my' | 'community' | null>(null);
+  // t/3426: the community entry's own addressing id, captured at open time — the loaded
+  // document's `.set_id` is the submitter's ORIGINAL id, which the community-share endpoint does
+  // NOT key on once it differs from the community id (t/856). null unless readerSource is
+  // 'community'. See OpEdReaderView's communityId prop doc for the full explanation.
+  const [readerCommunityId, setReaderCommunityId] = useState<string | null>(null);
   const [readerLoading, setReaderLoading] = useState(false);
   const [readerError, setReaderError] = useState<string | null>(null);
 
@@ -376,6 +390,7 @@ export function OpEdTab() {
     // The My list holds index summaries (no body) — load the full doc for the reader.
     selectSet(id);
     setReaderSource('my'); // t/2987: My sets are shareable.
+    setReaderCommunityId(null); // t/3426: only set for the community branch.
     setReaderError(null);
     setReaderSet(null);
     setReaderLoading(true);
@@ -389,7 +404,8 @@ export function OpEdTab() {
 
   const openCommunity = useCallback((id: string) => {
     selectSet(id);
-    setReaderSource('community'); // t/2987: community op-eds are NOT shareable (Copy, not Share).
+    setReaderSource('community');
+    setReaderCommunityId(id); // t/3426: capture the community addressing id at open time.
     setReaderError(null);
     setReaderSet(null);
     setReaderLoading(true);
@@ -405,6 +421,7 @@ export function OpEdTab() {
     selectSet(null);
     setReaderSet(null);
     setReaderSource(null);
+    setReaderCommunityId(null);
     setReaderError(null);
   }, [selectSet]);
 
@@ -415,6 +432,7 @@ export function OpEdTab() {
     // loadSets returns index summaries (no body) — load the full doc for the reader.
     selectSet(setId);
     setReaderSource('my'); // t/2987: a freshly-created set is the user's own → shareable.
+    setReaderCommunityId(null); // t/3426: only set for the community branch.
     setReaderError(null);
     setReaderSet(null);
     setReaderLoading(true);
@@ -498,6 +516,7 @@ export function OpEdTab() {
         status={status}
         onBack={closeReader}
         shareSource={readerSource}
+        communityId={readerCommunityId}
       />
     );
   }


### PR DESCRIPTION
## Summary

Fixes t/3426 — community op-ed "Get public link" 404s. Diagnosed by Diagnostics (flight recorder + server log correlation, full evidence in the ticket).

`ShareOpEdControl` passed `readerSet.set_id` to `shareCommunityOpEd` for both the "my" and "community" branches. For a COMMUNITY op-ed, the loaded document's own `.set_id` is the submitter's ORIGINAL op-ed-set id — the community-share endpoint keys on the **community id** instead (`oped-{communityId}.json`), which differs once a community submission is addressed distinctly from its source (t/856). Passing `set_id` there reads a record that never existed under that id → `getCommunityOpEd` returns absent → the ADR-001/t/3315#9 non-empty mint guard correctly refuses → 404.

- Threaded the community id (the community list entry's own `.id`, already known at open time via `openCommunity`'s `id` param) through a new `readerCommunityId` state in `OpEdTab`, down through `OpEdReaderView`'s new `communityId` prop.
- `shareId = shareSource === 'community' ? communityId : readerSet?.set_id` — "my" shares unaffected (their `set_id` IS the addressing id already).
- Fails closed (no share control rendered) if `communityId` is somehow missing for a community-sourced reader, rather than falling back to the wrong id.
- Closed the test-gap the ticket flagged: every existing `shareGuard` fixture had `set_id === communityId`, hiding the mismatch. Added a regression case with the two ids deliberately different.

**Out of scope, flagged separately:**
- `communityOpedShareRoute.test.ts` (ServerAPI-owned) has the same fixture gap server-side — notified ServerAPI.
- The mint-guard log conflating `raw===null` (wrong id) with `opeds`-empty (corruption) — routed to ServerAPI/Server Community as an observability follow-up per the ticket.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx vitest run src/renderer/components/opeds/` — 89/89 pass
- [x] RED-arm proof: reverted the `shareId` computation to the old `set_id`-only logic, confirmed exactly the 2 new/changed tests failed (fail-closed case + differing-ids regression, reproducing the exact bug — `set-1` posted instead of `community-1`), restored, re-verified green
- [x] `npx eslint` on both touched files — 0 new warnings (1 pre-existing complexity warning on an untouched function, confirmed via baseline diff)

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>