### PR TITLE
fix(diagnostics): StrictMode-safe workspace-cache guard in Get-TaxEditorServerLogs (t/3427)

### DIFF
--- a/scripts/AITriad/Public/Get-TaxEditorServerLogs.ps1
+++ b/scripts/AITriad/Public/Get-TaxEditorServerLogs.ps1
@@ -111,7 +111,9 @@ function Get-TaxEditorServerLogs {
         # ── Resolve + cache the Log Analytics workspace customerId ─────────
         $workspaceId = if ($env:TAXEDITOR_LOG_WORKSPACE_ID) {
             $env:TAXEDITOR_LOG_WORKSPACE_ID
-        } elseif ($script:TaxEditorLogWorkspaceId) {
+        } elseif ((Test-Path variable:script:TaxEditorLogWorkspaceId) -and $script:TaxEditorLogWorkspaceId) {
+            # StrictMode-safe: the cache var is unset until the az-resolve path below runs once, so
+            # existence-guard before reading it — a bare reference throws on fresh import (t/3427).
             $script:TaxEditorLogWorkspaceId
         } else {
             $wsRaw = Invoke-Az -CallerName 'Get-TaxEditorServerLogs' -Arguments @(

--- a/tests/Get-TaxEditorServerLogs.Tests.ps1
+++ b/tests/Get-TaxEditorServerLogs.Tests.ps1
@@ -21,6 +21,27 @@ Describe 'Get-TaxEditorServerLogs' -Tag 'diagnostics' {
         Get-Command -Module AITriad -Name 'Get-TaxEditorServerLogs' | Should -Not -BeNullOrEmpty
     }
 
+    It 'auto-resolves the workspace on a fresh import (cache var NEVER set) without a StrictMode throw (t/3427)' {
+        InModuleScope AITriad {
+            # Reproduce the fresh-import state: the cache var was never assigned AND no env override.
+            # Under the bug, the bare `elseif ($script:TaxEditorLogWorkspaceId)` reference throws under
+            # StrictMode before the az-resolve path can run. The Test-Path guard must reach that path.
+            Remove-Variable -Scope Script -Name TaxEditorLogWorkspaceId -ErrorAction Ignore
+            $prevEnv = $env:TAXEDITOR_LOG_WORKSPACE_ID
+            Remove-Item env:TAXEDITOR_LOG_WORKSPACE_ID -ErrorAction Ignore
+            try {
+                Mock Assert-AzCli { }
+                Mock Invoke-Az -ParameterFilter { $Arguments -contains 'list' }  -MockWith { 'ws-guid-fresh' }
+                Mock Invoke-Az -ParameterFilter { $Arguments -contains 'query' } -MockWith { '[]' }
+                { Get-TaxEditorServerLogs -WarningAction SilentlyContinue } | Should -Not -Throw
+                # Reached the auto-resolve path (would have thrown before it under the bug).
+                Should -Invoke Invoke-Az -Times 1 -Exactly -ParameterFilter { $Arguments -contains 'list' }
+            } finally {
+                if ($null -ne $prevEnv) { $env:TAXEDITOR_LOG_WORKSPACE_ID = $prevEnv }
+            }
+        }
+    }
+
     It 'parses Pino console rows and surfaces unparseable lines as Level=unparsed' {
         InModuleScope AITriad {
             $script:TaxEditorLogWorkspaceId = $null


### PR DESCRIPTION
**Bug (t/3427, by Diagnostics; recurs across diagnoses — also t/3165/t/3426).** On a fresh module import with neither `$env:TAXEDITOR_LOG_WORKSPACE_ID` nor the cached `$script:TaxEditorLogWorkspaceId` set, `Get-TaxEditorServerLogs` threw under `Set-StrictMode -Version Latest`: the bare `elseif ($script:TaxEditorLogWorkspaceId)` references a never-assigned `$script:` var (terminating error), so the az auto-resolve path was never reached — cmdlet unusable on first call every session.

**Fix.** Guard the reference: `elseif ((Test-Path variable:script:TaxEditorLogWorkspaceId) -and $script:TaxEditorLogWorkspaceId)`. Single-file, self-contained; the resolve path caches the var on first success as before.

**Test.** New regression arm removes the cache var entirely (true fresh-import state) + unsets the env override, asserts `Should -Not -Throw` and that the az `list` (auto-resolve) path is hit. Fails against the old bare reference, passes with the guard. Full file 11/11 green.

**Self-cert:** /trivial-change (single-file StrictMode-guard bug fix + regression test, no API/schema/cross-role change). Ticket by Diagnostics, not TL — no design-review gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)