### PR TITLE
feat(community): discriminated getCommunityOpEd result + mint-guard warn split (t/3430, t/3429)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/communityOpedShareRoute.test.ts
+++ b/taxonomy-editor/src/server/__tests__/communityOpedShareRoute.test.ts
@@ -79,7 +79,7 @@ describe('POST/DELETE /api/community/opeds/:id/share (t/3315)', () => {
   });
 
   it('mints: returns {shareId,url}, writes the public projection, response carries NO item/identity data', async () => {
-    getCommunityOpEd.mockResolvedValue(GOOD_ITEM);
+    getCommunityOpEd.mockResolvedValue({ found: true, item: GOOD_ITEM });
     const res = fakeRes();
     await post(req('/api/community/opeds/oped-1/share'), res, {});
     expect(res._status).toBe(200);
@@ -92,31 +92,45 @@ describe('POST/DELETE /api/community/opeds/:id/share (t/3315)', () => {
     expect(logServerWarn).not.toHaveBeenCalled();
   });
 
-  it('404 when the community item does not exist — WARNs (operator-visible) with id + backend (t/3334)', async () => {
-    getCommunityOpEd.mockResolvedValue(null);
+  it('404 when the community item is ABSENT (wrong/missing id) — routine, NO operator WARN (t/3430)', async () => {
+    getCommunityOpEd.mockResolvedValue({ found: false, reason: 'absent' });
     const res = fakeRes();
     await post(req('/api/community/opeds/missing/share'), res, {});
     expect(res._status).toBe(404);
     expect(mintCommunityOpedShare).not.toHaveBeenCalled();
-    // t/3334: mint-path empty/absent → WARN→Log_s with discriminating data (NOT silent).
+    // t/3430: 'absent' is ordinary not-found — must NOT emit the operator corruption WARN
+    // (pre-t/3430 this arm was conflated with silent-empty and warned on every wrong id).
+    expect(logServerWarn).not.toHaveBeenCalled();
+  });
+
+  it('404 + operator WARN when getCommunityOpEd is SILENT-EMPTY (reason=empty = possible corruption) (t/3430)', async () => {
+    getCommunityOpEd.mockResolvedValue({ found: false, reason: 'empty' });
+    const res = fakeRes();
+    await post(req('/api/community/opeds/silent-empty/share'), res, {});
+    expect(res._status).toBe(404);
+    expect(mintCommunityOpedShare).not.toHaveBeenCalled();
+    // t/3430: 'empty' = ADR-001 silent-empty guard = possible GitHub-API silent-empty / corruption →
+    // WARN→Log_s, DISCRIMINATED from ordinary 'absent' (the whole point of the discriminated union).
     expect(logServerWarn).toHaveBeenCalledTimes(1);
     expect(logServerWarn).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'missing', backend: 'FilesystemBackend', path: 'mint' }),
-      expect.stringContaining('empty/absent'),
+      expect.objectContaining({ id: 'silent-empty', backend: 'FilesystemBackend', path: 'mint', reason: 'empty' }),
+      expect.stringContaining('SILENT-EMPTY'),
     );
   });
 
-  it('422 (assert-presence) when the item is empty/malformed — never mints a shareId, and WARNs (t/3334)', async () => {
-    getCommunityOpEd.mockResolvedValue({ topic: '', opeds: [] });
+  it('422 (assert-presence) when a FOUND item is malformed (missing topic) — never mints, and WARNs (t/3334)', async () => {
+    // Post-t/3430: empty-opeds is a found:false reason:'empty' (404, covered above), so the reachable
+    // malformed case on found:true is a present-but-topicless item (non-empty opeds, no topic).
+    getCommunityOpEd.mockResolvedValue({ found: true, item: { topic: '', opeds: [{ pov: 'accelerationist', body: 'x' }] } });
     const res = fakeRes();
-    await post(req('/api/community/opeds/empty/share'), res, {});
+    await post(req('/api/community/opeds/malformed/share'), res, {});
     expect(res._status).toBe(422);
     expect(mintCommunityOpedShare).not.toHaveBeenCalled();
     expect(writePublicCommunityOpEd).not.toHaveBeenCalled();
-    // t/3334: malformed = unambiguous corruption → WARN→Log_s with id + backend.
+    // t/3334: malformed found item = unambiguous corruption → WARN→Log_s with id + backend.
     expect(logServerWarn).toHaveBeenCalledTimes(1);
     expect(logServerWarn).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'empty', backend: 'FilesystemBackend' }),
+      expect.objectContaining({ id: 'malformed', backend: 'FilesystemBackend' }),
       expect.stringContaining('malformed'),
     );
   });

--- a/taxonomy-editor/src/server/__tests__/getCommunityOpEd.test.ts
+++ b/taxonomy-editor/src/server/__tests__/getCommunityOpEd.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment node
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3430 — getCommunityOpEd must discriminate WHY a lookup failed: 'absent' (the blob doesn't
+// exist — ordinary, expected) vs 'empty' (the blob exists but has no voices — the ADR-001
+// silent-empty/corruption guard). Callers (routes/community.ts, t/3429) use this to warn only
+// on the corruption case, not on ordinary 404s.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockReadFile } = vi.hoisted(() => ({
+  mockReadFile: vi.fn(),
+}));
+
+vi.mock('../storage/fileIO.js', () => ({
+  getUserContentBackend: () => ({ readFile: mockReadFile }),
+  assertSafeId: (id: string, label: string) => {
+    if (!id || id.includes('..') || id.includes('/')) {
+      throw new Error(`Unsafe ${label}: ${id}`);
+    }
+  },
+}));
+
+vi.mock('../config.js', () => ({
+  resolveDataPath: (p: string) => `/data/${p}`,
+}));
+
+import { getCommunityOpEd } from '../community/community.js';
+
+describe('getCommunityOpEd (t/3430)', () => {
+  beforeEach(() => {
+    mockReadFile.mockReset();
+  });
+
+  it("returns { found: false, reason: 'absent' } when the blob doesn't exist", async () => {
+    mockReadFile.mockResolvedValue(null);
+    const result = await getCommunityOpEd('missing-id');
+    expect(result).toEqual({ found: false, reason: 'absent' });
+  });
+
+  it("returns { found: false, reason: 'empty' } when opeds is an empty array (ADR-001 silent-empty)", async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({ topic: 'x', opeds: [] }));
+    const result = await getCommunityOpEd('empty-id');
+    expect(result).toEqual({ found: false, reason: 'empty' });
+  });
+
+  it("returns { found: false, reason: 'empty' } when opeds is missing entirely", async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({ topic: 'x' }));
+    const result = await getCommunityOpEd('no-opeds-id');
+    expect(result).toEqual({ found: false, reason: 'empty' });
+  });
+
+  it("returns { found: false, reason: 'empty' } when opeds is not an array", async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({ topic: 'x', opeds: 'not-an-array' }));
+    const result = await getCommunityOpEd('malformed-id');
+    expect(result).toEqual({ found: false, reason: 'empty' });
+  });
+
+  it('returns { found: true, item } with the full parsed item when voices are present', async () => {
+    const item = { topic: 'AI Safety', opeds: [{ pov: 'acc', headline: 'h' }], community_metadata: { submitted_by_display: 'Jane' } };
+    mockReadFile.mockResolvedValue(JSON.stringify(item));
+    const result = await getCommunityOpEd('good-id');
+    expect(result).toEqual({ found: true, item });
+  });
+
+  it('rejects a path-traversal id via assertSafeId', async () => {
+    await expect(getCommunityOpEd('../evil')).rejects.toThrow();
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+});

--- a/taxonomy-editor/src/server/community/community.ts
+++ b/taxonomy-editor/src/server/community/community.ts
@@ -243,21 +243,33 @@ export async function loadCommunityItem(type: 'chats' | 'debates' | 'opeds', id:
 }
 
 /**
+ * t/3430: discriminates why a lookup failed. `'absent'` = the blob doesn't exist (wrong id,
+ * or a genuinely missing record) — ordinary, expected, never corruption. `'empty'` = the blob
+ * exists but has no voices (the ADR-001 guard) — a GitHub API silent-empty response or real
+ * data corruption; callers should treat this as a signal worth logging.
+ */
+export type CommunityOpEdLookup =
+  | { found: true; item: Record<string, unknown> }
+  | { found: false; reason: 'absent' | 'empty' };
+
+/**
  * Internal accessor for a community op-ed — returns the raw parsed item including
  * full community_metadata (not stripped for public exposure). Intended for
  * share-projection callers that need submittedBy and the full voice list.
- * ADR-001 non-empty guard: returns null if the item has no voices, which indicates
+ * ADR-001 non-empty guard: reason 'empty' means the item has no voices, which indicates
  * a GitHub API silent-empty response rather than a legitimate zero-voice item.
  */
-export async function getCommunityOpEd(id: string): Promise<Record<string, unknown> | null> {
+export async function getCommunityOpEd(id: string): Promise<CommunityOpEdLookup> {
   assertSafeId(id, 'community oped id');
   const backend = getUserContentBackend();
   const raw = await backend.readFile(path.join(communityOpedsDir(), `oped-${id}.json`));
-  if (raw === null) return null;
+  if (raw === null) return { found: false, reason: 'absent' };
   const parsed = JSON.parse(raw) as Record<string, unknown>;
   // ADR-001: GitHub API can return empty content on network hiccups; a real oped always has voices.
-  if (!Array.isArray(parsed.opeds) || (parsed.opeds as unknown[]).length === 0) return null;
-  return parsed;
+  if (!Array.isArray(parsed.opeds) || (parsed.opeds as unknown[]).length === 0) {
+    return { found: false, reason: 'empty' };
+  }
+  return { found: true, item: parsed };
 }
 
 // ── Submissions ──

--- a/taxonomy-editor/src/server/routes/community.ts
+++ b/taxonomy-editor/src/server/routes/community.ts
@@ -185,23 +185,27 @@ export function registerCommunityRoutes(r: Router, ctx: ServerCtx): void {
         return;
       }
 
-      const item = await community.getCommunityOpEd(id);
-      if (!item) {
-        // t/3334: a 404 here is client-loud but operator-SILENT — an authed user minting a share for an
-        // item that read empty/absent is low-frequency + suspicious (possible silent-empty/corruption),
-        // so WARN→Log_s with discriminating data. Scoped to the MINT path only (NOT the public GET
-        // not-found, which is ordinary). getCommunityOpEd returns null for both absent and empty-`opeds`.
-        log.server.warn(
-          { id, backend: getUserContentBackend().constructor.name, path: 'mint' },
-          'Community op-ed share mint: getCommunityOpEd returned empty/absent — refusing to mint (possible silent-empty/corruption)',
-        );
+      const lookup = await community.getCommunityOpEd(id);
+      if (!lookup.found) {
+        // t/3430: getCommunityOpEd now discriminates WHY the lookup failed, so the mint-guard WARN
+        // no longer conflates the ordinary case with the corruption case (was a single WARN on both).
+        if (lookup.reason === 'empty') {
+          // 'empty' = the ADR-001 guard tripped (blob present, zero voices) — a GitHub-API silent-empty
+          // response or real corruption. Operator-visible: WARN→Log_s, scoped to the MINT path only.
+          log.server.warn(
+            { id, backend: getUserContentBackend().constructor.name, path: 'mint', reason: 'empty' },
+            'Community op-ed share mint: getCommunityOpEd SILENT-EMPTY (blob present, zero voices) — possible corruption; refusing to mint',
+          );
+        }
+        // 'absent' = wrong/missing id — ordinary, expected, never corruption → routine 404, NO operator WARN.
         error(res, 'not_found', 404);
         return;
       }
 
-      // Condition 4: assert PRESENCE before minting — never register a shareId for an empty/partial
-      // read (ADR-001 silent-empty guard on the hosted github-api path). writePublicCommunityOpEd re-checks.
-      const it = item as { topic?: unknown; opeds?: unknown; community_metadata?: { submitted_by_display?: string } };
+      // Condition 4: assert PRESENCE before minting — never register a shareId for a malformed item
+      // (found:true guarantees non-empty opeds per ADR-001, so this now catches a missing topic;
+      // kept as defense-in-depth — writePublicCommunityOpEd re-checks).
+      const it = lookup.item as { topic?: unknown; opeds?: unknown; community_metadata?: { submitted_by_display?: string } };
       if (!it.topic || !Array.isArray(it.opeds) || it.opeds.length === 0) {
         // t/3334: malformed (has a file but no topic / empty opeds) = unambiguous corruption → always WARN→Log_s.
         log.server.warn(
@@ -216,7 +220,7 @@ export function registerCommunityRoutes(r: Router, ctx: ServerCtx): void {
       // (projectPublicOpEd strips all community_metadata — condition 1).
       const submittedBy = it.community_metadata?.submitted_by_display ?? '';
       const shareId = await mintCommunityOpedShare(id, submittedBy);
-      await writePublicCommunityOpEd(item as unknown as CommunityOpEdItem, shareId);
+      await writePublicCommunityOpEd(lookup.item as unknown as CommunityOpEdItem, shareId);
 
       json(res, { shareId, url: `/share/oped/${shareId}` });
     } catch (err) {


### PR DESCRIPTION
## Summary

Joint PR — Server Community + ServerAPI, per t/3430 (blocks t/3429).

**t/3430 (d8d06c0d, Server Community):** `getCommunityOpEd` returns a discriminated `CommunityOpEdLookup` — `{ found: true, item }` | `{ found: false, reason: 'absent' | 'empty' }` — replacing bare `null`. `'absent'` = blob doesn't exist (ordinary 404). `'empty'` = blob exists but no voices (ADR-001 silent-empty/corruption guard). Previously both collapsed to `null`, so no caller could discriminate.

**t/3429 (e5546c6c, ServerAPI):** mint-guard in `routes/community.ts` now matches on `reason` — WARNs only on `'empty'` (real corruption signal), stays silent on `'absent'` (ordinary 404). Fixes the t/3426 diagnosis where an absent-blob 404 was misread as possible corruption.

**Why this is one PR, not two:** consuming the old `null`-or-object shape via `if (!item)` + an `as {...}` cast that read the wrong nesting level against the new shape compiled clean (zero tsc errors) but would have silently broken the mint endpoint at runtime — and the pre-existing route test mocked the old shape, so CI would have stayed green on a 100%-broken mint path. Landing the two halves independently was unsafe in either order.

## Test plan
- [x] `getCommunityOpEd.test.ts` — 6 tests: absent, empty (missing/non-array/zero-length), found-with-full-item, path-traversal rejection
- [x] `communityOpedShareRoute.test.ts` — 9 tests, both discrimination arms: absent→404 no-warn, empty→404+warn, found→mint succeeds
- [x] Combined: tsc 0 errors repo-wide, 15/15 tests pass, eslint clean
- [ ] CI verify gate

**Landing:** manual co-merge only (`--match-head-commit` on e5546c6c) — never `--auto`, per the green-but-broken-alone risk above.

Co-Authored-By: ServerAPI (Orca) <main.taxonomy-editor-src-server@ai-triad-research.orca.local>

🤖 Generated with [Claude Code](https://claude.com/claude-code)