### PR TITLE
docs(devops): narrow serialize-canary trigger to serialize-specific paths (t/3236)

### DIFF
--- a/deploy/azure/runbooks/production-release.md
+++ b/deploy/azure/runbooks/production-release.md
@@ -13,7 +13,7 @@
 
 ## Conditional Gate: Serialize-Phase Canary (staging, pre-promotion)
 
-If this release touches the synthetic-embeddings corpus path, the JSON serializer (`jsonStringifyChunked`), or embeddings load/serve, run the **[serialize-canary](./serialize-canary.md)** probe on a fresh staging revision **before** promoting to production. It exercises *and* asserts the response serialize phase under the loop-sampler — the phase the t/3165 storm-canary silently omitted (phase-blind false-green; t/3236). Not applicable to releases that don't touch those paths.
+If this release touches the **serialize path specifically** — the synthetic-embeddings endpoint (`routes/taxonomy.ts`, `getSyntheticEmbeddingsBuffer`), the chunk-yield JSON serializer (`httpKit.ts` `jsonStringifyChunked`), or the corpus loader (`fileIO.loadSyntheticEmbeddings`) — run the **[serialize-canary](./serialize-canary.md)** probe on a fresh staging revision **before** promoting to production. It exercises *and* asserts the response serialize phase under the loop-sampler — the phase the t/3165 storm-canary silently omitted (phase-blind false-green; t/3236). **Compute-path-only deltas** (worker-pool internals, queue-depth gauges, shed-token observability) leave the serialize tail byte-identical and are **N/A** (t/3236#11) — do not confuse "embeddings load/serve" broadly with the serialize phase this gate guards.
 
 ## Step 1: Pre-Build Verification (App Side)
 

--- a/deploy/azure/runbooks/serialize-canary.md
+++ b/deploy/azure/runbooks/serialize-canary.md
@@ -1,6 +1,8 @@
 # Runbook: Serialize-Phase Canary Probe
 
-**Trigger:** Any staging canary of a change that touches the synthetic-embeddings corpus path, the JSON serializer (`jsonStringifyChunked`), or embeddings load/serve — run this probe **before** promoting the revision to production.
+**Trigger:** Any staging canary of a change that touches the **serialize path specifically** — the synthetic-embeddings endpoint (`routes/taxonomy.ts`, `getSyntheticEmbeddingsBuffer`), the chunk-yield JSON serializer (`httpKit.ts` `jsonStringifyChunked`), or the corpus loader (`fileIO.loadSyntheticEmbeddings`). Run this probe **before** promoting the revision to production.
+
+> **Scope note (t/3236#11):** the trigger is deliberately the serialize path, **not** the broader "embeddings load/serve." Compute-path-only deltas (worker-pool internals, queue-depth gauges, shed-token observability) do **not** touch the ~400MB serialize tail this probe guards and are **N/A** — the earlier broad phrasing spuriously matched a compute-only delta (main `39445130`). If the diff over the deploy range leaves `getSyntheticEmbeddingsBuffer` / `jsonStringifyChunked` / `loadSyntheticEmbeddings` byte-identical, the canary is N/A.
 
 **Owner:** DevOps. Endpoint + loop-sampler owned by ServerAPI (`taxonomy-editor/src/server/`).
 


### PR DESCRIPTION
Applies ServerAPI's t/3236#11 refinement: narrow the conditional serialize-canary trigger from the too-broad "embeddings load/serve" to the **serialize path specifically** — `getSyntheticEmbeddingsBuffer` (`routes/taxonomy.ts`), `jsonStringifyChunked` (`httpKit.ts`), `loadSyntheticEmbeddings` (`fileIO`).

**Why:** the broad phrasing spuriously matched a compute-path-only delta (main `39445130`: worker-pool internals, queue-depth gauge, shed-token observability) that leaves the ~400MB serialize tail byte-identical — forcing an unnecessary "is the canary needed?" investigation. Compute-only embed deltas now correctly read N/A; a real serialize-tail change always trips it.

**Scope:** docs-only, 2 DevOps-owned runbooks. Self-certifying under /trivial-change.

Closes the prevention deliverable for t/3236 (the gate itself landed in #2087; this is the trigger-precision refinement).