### PR TITLE
fix(policy): batch Update-PolicyRegistry -Fix writes one-per-file + idempotent MaxId (t/3431)

### DIFF
--- a/scripts/AITriad/Public/Update-PolicyRegistry.ps1
+++ b/scripts/AITriad/Public/Update-PolicyRegistry.ps1
@@ -146,14 +146,26 @@ function Update-PolicyRegistry {
 
         # Assign IDs to unregistered actions
         if ($Unregistered.Count -gt 0 -and $PSCmdlet.ShouldProcess("$($Unregistered.Count) unregistered actions", 'Assign IDs')) {
+            # MaxId over registry ids UNION all referenced-on-disk ids (t/3431 #3): a prior partial run
+            # may have written a pol-NNNN reference to a node WITHOUT persisting the registry (the very
+            # bug this fixes). Counting referenced-but-unregistered ids here prevents a re-run from
+            # re-minting the same number onto the next unregistered action (id collision).
             $MaxId = 0
-            foreach ($Key in $ExistingPolicies.Keys) {
+            $idPool = [System.Collections.Generic.List[string]]::new()
+            foreach ($Key in $ExistingPolicies.Keys)   { $idPool.Add([string]$Key) }
+            foreach ($Key in $AllReferencedIds)         { $idPool.Add([string]$Key) }
+            foreach ($Key in $idPool) {
                 if ($Key -match 'pol-(\d+)') {
                     $Num = [int]$Matches[1]
                     if ($Num -gt $MaxId) { $MaxId = $Num }
                 }
             }
 
+            # Pass 1: assign IDs + register in memory, and record each node edit grouped BY FILE.
+            # No file writes in this loop — a per-iteration whole-file rewrite self-dirties the file and
+            # the BLOCK-tier dirty-tree guard then false-blocks the 2nd write, aborting mid-run and
+            # leaving the file referencing an unpersisted id (t/3431). Batch → one write per file below.
+            $fileAssignments = @{}   # POV key -> List of @{ NodeId; Action; NewId }
             foreach ($U in $Unregistered) {
                 $MaxId++
                 $NewId = 'pol-{0:D3}' -f $MaxId
@@ -164,21 +176,31 @@ function Update-PolicyRegistry {
                     member_count = 1
                     status       = 'active'
                 }
+                if (-not $fileAssignments.ContainsKey($U.POV)) {
+                    $fileAssignments[$U.POV] = [System.Collections.Generic.List[object]]::new()
+                }
+                $fileAssignments[$U.POV].Add([PSCustomObject]@{ NodeId = $U.NodeId; Action = $U.Action; NewId = $NewId })
+                Write-Info "  Assigned $NewId to $($U.NodeId)`: $($U.Action.Substring(0, [Math]::Min(50, $U.Action.Length)))"
+            }
 
-                # Update the node in the taxonomy file
-                $FilePath = Join-Path $TaxDir "$($U.POV).json"
+            # Pass 2: ONE whole-file rewrite per touched POV file (no self-dirtying → guard never
+            # false-fires). Node-match logic (action text + no existing policy_id, first-match break)
+            # is preserved, so duplicate action text within a node still maps to distinct ids in order.
+            foreach ($PovKey in $fileAssignments.Keys) {
+                $FilePath = Join-Path $TaxDir "$PovKey.json"
                 $FileData = Get-Content -Raw -Path $FilePath | ConvertFrom-Json
-                foreach ($Node in $FileData.nodes) {
-                    if ($Node.id -ne $U.NodeId) { continue }
-                    foreach ($PA in $Node.graph_attributes.policy_actions) {
-                        if ($PA.action -eq $U.Action -and (-not $PA.PSObject.Properties['policy_id'] -or $null -eq $PA.policy_id)) {
-                            $PA | Add-Member -NotePropertyName 'policy_id' -NotePropertyValue $NewId -Force
-                            break
+                foreach ($Asg in $fileAssignments[$PovKey]) {
+                    foreach ($Node in $FileData.nodes) {
+                        if ($Node.id -ne $Asg.NodeId) { continue }
+                        foreach ($PA in $Node.graph_attributes.policy_actions) {
+                            if ($PA.action -eq $Asg.Action -and (-not $PA.PSObject.Properties['policy_id'] -or $null -eq $PA.policy_id)) {
+                                $PA | Add-Member -NotePropertyName 'policy_id' -NotePropertyValue $Asg.NewId -Force
+                                break
+                            }
                         }
                     }
                 }
-                $FileData | ConvertTo-Json -Depth 20 | Write-Utf8NoBom -Path $FilePath 
-                Write-Info "  Assigned $NewId to $($U.NodeId)`: $($U.Action.Substring(0, [Math]::Min(50, $U.Action.Length)))"
+                $FileData | ConvertTo-Json -Depth 20 | Write-Utf8NoBom -Path $FilePath
             }
         }
 

--- a/tests/Update-PolicyRegistry.Tests.ps1
+++ b/tests/Update-PolicyRegistry.Tests.ps1
@@ -1,0 +1,145 @@
+# Tag: taxonomy (t/3431)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+# Regression tests for Update-PolicyRegistry -Fix (t/3431). The bug: a whole-file rewrite PER
+# unregistered action inside the assign loop self-dirtied the file, so the BLOCK-tier dirty-tree guard
+# false-blocked the 2nd write and aborted mid-run, leaving the file referencing an unpersisted pol-id.
+# Fix: accumulate edits and write ONCE per file after the loop, plus MaxId over registry∪referenced ids
+# so a re-run can't re-mint an already-referenced (but unpersisted) id.
+#
+# The dirty-tree guard is git-based and inert in a non-git TestDrive, so the distinguishing signal is
+# the WRITE COUNT (1 per file with the fix vs N without). Write-Utf8NoBom is mocked as a counting
+# pass-through (real Set-Content) so the cmdlet's post-fix re-scan still sees the persisted edits.
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1') -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Update-PolicyRegistry -Fix (t/3431 batched write + idempotent MaxId)' -Tag 'taxonomy' {
+
+    It 'batches >=2 unregistered actions in one file into a SINGLE write (no self-block, no partial state)' {
+        InModuleScope AITriad {
+            $TempDir = Join-Path ([System.IO.Path]::GetTempPath()) "polreg-batch-$(Get-Random)"
+            New-Item -ItemType Directory -Path $TempDir -Force | Out-Null
+            try {
+                # situations.json: sit-keep references the existing registry ids (so they survive orphan
+                # removal — keeping the registry max at 3); sit-477 has THREE unregistered actions (repro).
+                @{ _schema_version = '1.0.0'; last_modified = '2026-09-12'; nodes = @(
+                        @{ id = 'sit-keep'; graph_attributes = @{ policy_actions = @(
+                                    @{ action = 'p1'; framing = 'f'; policy_id = 'pol-001' }
+                                    @{ action = 'p2'; framing = 'f'; policy_id = 'pol-002' }
+                                    @{ action = 'p3'; framing = 'f'; policy_id = 'pol-003' }
+                                ) } }
+                        @{ id = 'sit-477'; graph_attributes = @{ policy_actions = @(
+                                    @{ action = 'Action Alpha'; framing = 'fa' }
+                                    @{ action = 'Action Bravo'; framing = 'fb' }
+                                    @{ action = 'Action Charlie'; framing = 'fc' }
+                                ) } }
+                    ) } | ConvertTo-Json -Depth 20 | Set-Content -Path (Join-Path $TempDir 'situations.json')
+                @{ _schema_version = '1.0.0'; _doc = 'x'; policy_count = 3; policies = @(
+                        @{ id = 'pol-001'; action = 'p1'; source_povs = @('situations'); member_count = 1; status = 'active' }
+                        @{ id = 'pol-002'; action = 'p2'; source_povs = @('situations'); member_count = 1; status = 'active' }
+                        @{ id = 'pol-003'; action = 'p3'; source_povs = @('situations'); member_count = 1; status = 'active' }
+                    ) } | ConvertTo-Json -Depth 20 | Set-Content -Path (Join-Path $TempDir 'policy_actions.json')
+
+                Mock Get-TaxonomyDir { $TempDir }
+                Mock Write-Utf8NoBom { Set-Content -Path $Path -Value $Value -Encoding utf8 }
+
+                { Update-PolicyRegistry -Fix } | Should -Not -Throw
+
+                # THE regression assertion: exactly ONE write for situations.json (old code = 3, one per action).
+                Should -Invoke Write-Utf8NoBom -Times 1 -Exactly -ParameterFilter { $Path -like '*situations.json' }
+
+                # All 3 actions now carry ids in the file; ids are the next 3 after the registry max.
+                $sit = Get-Content -Raw -Path (Join-Path $TempDir 'situations.json') | ConvertFrom-Json
+                $sit477 = $sit.nodes | Where-Object { $_.id -eq 'sit-477' }
+                $pas = @($sit477.graph_attributes.policy_actions)
+                @($pas | Where-Object { $_.PSObject.Properties['policy_id'] -and $_.policy_id }).Count | Should -Be 3
+                @($pas.policy_id | Sort-Object) | Should -Be @('pol-004', 'pol-005', 'pol-006')
+
+                # Registry is CONSISTENT — every freshly-referenced id is persisted (no partial state).
+                $reg = Get-Content -Raw -Path (Join-Path $TempDir 'policy_actions.json') | ConvertFrom-Json
+                $regIds = @($reg.policies.id)
+                foreach ($id in @('pol-004', 'pol-005', 'pol-006')) { $regIds | Should -Contain $id }
+            } finally {
+                Remove-Item $TempDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    It 'does not re-mint an id already referenced-but-unregistered on disk (idempotent MaxId collision-proof)' {
+        InModuleScope AITriad {
+            $TempDir = Join-Path ([System.IO.Path]::GetTempPath()) "polreg-idem-$(Get-Random)"
+            New-Item -ItemType Directory -Path $TempDir -Force | Out-Null
+            try {
+                # sit-A already references pol-005 (a prior partial run wrote the ref but not the registry);
+                # pol-005 is NOT in the registry (max there is pol-004). sit-B has an unregistered action.
+                @{ _schema_version = '1.0.0'; nodes = @(
+                        # sit-keep references the registry ids so they survive orphan removal (max stays 4).
+                        @{ id = 'sit-keep'; graph_attributes = @{ policy_actions = @(
+                                    @{ action = 'a'; framing = 'f'; policy_id = 'pol-001' }
+                                    @{ action = 'b'; framing = 'f'; policy_id = 'pol-002' }
+                                    @{ action = 'c'; framing = 'f'; policy_id = 'pol-003' }
+                                    @{ action = 'd'; framing = 'f'; policy_id = 'pol-004' }
+                                ) } }
+                        @{ id = 'sit-A'; graph_attributes = @{ policy_actions = @(
+                                    @{ action = 'already assigned'; framing = 'f'; policy_id = 'pol-005' }
+                                ) } }
+                        @{ id = 'sit-B'; graph_attributes = @{ policy_actions = @(
+                                    @{ action = 'needs an id'; framing = 'f' }
+                                ) } }
+                    ) } | ConvertTo-Json -Depth 20 | Set-Content -Path (Join-Path $TempDir 'situations.json')
+                @{ _schema_version = '1.0.0'; _doc = 'x'; policy_count = 4; policies = @(
+                        @{ id = 'pol-001'; action = 'a'; source_povs = @('situations'); member_count = 1; status = 'active' }
+                        @{ id = 'pol-002'; action = 'b'; source_povs = @('situations'); member_count = 1; status = 'active' }
+                        @{ id = 'pol-003'; action = 'c'; source_povs = @('situations'); member_count = 1; status = 'active' }
+                        @{ id = 'pol-004'; action = 'd'; source_povs = @('situations'); member_count = 1; status = 'active' }
+                    ) } | ConvertTo-Json -Depth 20 | Set-Content -Path (Join-Path $TempDir 'policy_actions.json')
+
+                Mock Get-TaxonomyDir { $TempDir }
+                Mock Write-Utf8NoBom { Set-Content -Path $Path -Value $Value -Encoding utf8 }
+
+                Update-PolicyRegistry -Fix | Out-Null
+
+                $sit = Get-Content -Raw -Path (Join-Path $TempDir 'situations.json') | ConvertFrom-Json
+                $bNode = $sit.nodes | Where-Object { $_.id -eq 'sit-B' }
+                $bId = $bNode.graph_attributes.policy_actions[0].policy_id
+                # max(registry 004, referenced-on-disk 005) + 1 = pol-006 — NOT pol-005 (that would collide
+                # with sit-A's existing reference). Registry-only MaxId would have re-minted pol-005.
+                $bId | Should -Be 'pol-006'
+                $bId | Should -Not -Be 'pol-005'
+            } finally {
+                Remove-Item $TempDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    It 'writes no POV file when there are no unregistered actions' {
+        InModuleScope AITriad {
+            $TempDir = Join-Path ([System.IO.Path]::GetTempPath()) "polreg-clean-$(Get-Random)"
+            New-Item -ItemType Directory -Path $TempDir -Force | Out-Null
+            try {
+                @{ _schema_version = '1.0.0'; nodes = @(
+                        @{ id = 'sit-C'; graph_attributes = @{ policy_actions = @(
+                                    @{ action = 'registered'; framing = 'f'; policy_id = 'pol-001' }
+                                ) } }
+                    ) } | ConvertTo-Json -Depth 20 | Set-Content -Path (Join-Path $TempDir 'situations.json')
+                @{ _schema_version = '1.0.0'; _doc = 'x'; policy_count = 1; policies = @(
+                        @{ id = 'pol-001'; action = 'registered'; source_povs = @('situations'); member_count = 1; status = 'active' }
+                    ) } | ConvertTo-Json -Depth 20 | Set-Content -Path (Join-Path $TempDir 'policy_actions.json')
+
+                Mock Get-TaxonomyDir { $TempDir }
+                Mock Write-Utf8NoBom { Set-Content -Path $Path -Value $Value -Encoding utf8 }
+
+                { Update-PolicyRegistry -Fix } | Should -Not -Throw
+                # No unregistered actions → no POV-file rewrite at all (only the registry may be rewritten).
+                Should -Invoke Write-Utf8NoBom -Times 0 -Exactly -ParameterFilter { $Path -like '*situations.json' }
+            } finally {
+                Remove-Item $TempDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Bug (t/3431, Diagnostics; P1, TL-escalated p/360#361).** `Update-PolicyRegistry -Fix` did a whole-file rewrite PER unregistered action inside the assign loop. On a BLOCK-tier file (e.g. `situations.json`) with ≥2 unregistered actions, iteration 2's write saw the file self-dirtied by iteration 1, so `Assert-CleanDataTree` (the dirty-tree guard) aborted mid-run — leaving the file referencing a freshly-minted `pol-NNNN` **absent from the registry** (referential inconsistency), and a naive re-run then re-minted the same number onto a different action (collision). Deterministic; hit live on sit-477.

**Fix (TL-blessed shape).**
1. **Batch writes:** accumulate all ID assignments in memory grouped by POV file; after the loop, write each touched file **once**. One write per BLOCK-tier file ⇒ the guard never sees a self-dirtied state ⇒ no false-block, no partial state. Node-match logic (action text + no existing policy_id, first-match break) preserved.
2. **Idempotent MaxId:** compute `MaxId` over `registry ids ∪ all referenced-on-disk ids`, so a prior partial run's unpersisted-but-referenced id (pol-3368/3369) can't be re-minted → collision-proof.

**Tests** (`tests/Update-PolicyRegistry.Tests.ps1`, new): single-write-per-file regression (the exact sit-477 repro — old code wrote N times, asserts exactly 1), collision-proofing (referenced-but-unregistered id on disk → next mint skips it), and no-op-when-clean. 3/3 green. (Guard is git-based/inert in a temp dir, so the distinguishing signal is the per-file write count.)

**Self-cert:** TL blessed the shape + both design additions (p/360#361/#364); Diagnostics-created ticket, not TL — no separate design round. Not a schema/data-model change (same output shape; only write-batching + id-selection) → no mandatory Second Opinion.

**Follow-up (separate, noted t/3431#1):** `-Fix` still doesn't re-add "missing from registry" ids (referenced-but-unregistered, e.g. pol-3368/9) back into the registry — this PR prevents COLLISIONS with them but doesn't reconcile them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)