### PR TITLE
feat(fol-eval): score-vs-gold classifier scorer (§5) — CL-requested (t/3354)

### DIFF
--- a/scripts/fol-eval-score.ps1
+++ b/scripts/fol-eval-score.ps1
@@ -1,0 +1,148 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    FOL-on-debate eval — score the clause classifier against CL's blind gold set (design §5). PURE.
+.DESCRIPTION
+    Joins the harness's classified-clauses.jsonl (predicted §3 labels, by clause id) with CL's blind gold
+    (fol-eval-classifier-gold.jsonl: the same ids + CL's hand labels) and computes per-primary-type
+    precision / recall / F1 + a gold×predicted confusion matrix + overall accuracy + per-attribute accuracy
+    (attribution / anaphora_dependency / polarity). This is the instrument CL asked for (t/3354#28/#29) to
+    lift classified-clauses out of INSTRUMENT-PROVISIONAL (§5, t/3342).
+
+    GOLD IS AUTHORITATIVE: only clause ids present in the gold set are scored. A gold id absent from the
+    classified output scores as predicted 'missing' (counts against that gold type's recall) — never dropped,
+    so a starved/again-broken classifier can't inflate the score by silently shrinking the denominator.
+
+    All functions are PURE (no AI, no I/O); the runner (score-fol-classifier-gold.ps1) reads the two JSONL
+    files and feeds parsed rows in. Single-annotator gold spot-checks DIRECTION; κ/α is not established until
+    CL's second annotation (§11), so no number here certifies precision on its own.
+.LINK
+    score-fol-classifier-gold.ps1
+.LINK
+    fol-eval-classify.ps1
+#>
+
+Set-StrictMode -Version Latest
+
+$script:FOL_SCORE_TYPES = @('assertoric-factual', 'assertoric-causal', 'normative-deontic', 'speech-act-belief-revision-meta', 'rhetorical-evaluative')
+
+function Join-FolGold {
+    <#
+    .SYNOPSIS
+        Join classified predictions onto the gold rows by clause id. Pure. Gold is authoritative.
+    .OUTPUTS
+        [object[]] one row per gold item: { id, gold_type, pred_type, gold_attribution, pred_attribution,
+        gold_anaphora, pred_anaphora, gold_polarity, pred_polarity, matched }. A gold id absent from
+        Classified gets pred_type 'missing' (matched=$false).
+    .PARAMETER Classified
+        Parsed classified-clauses.jsonl rows (each with id + primary_type + attributes).
+    .PARAMETER Gold
+        Parsed gold rows (each with id + primary_type + optional attributes).
+    #>
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Classified,
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Gold
+    )
+    Set-StrictMode -Version Latest
+
+    $predById = @{}
+    foreach ($c in $Classified) {
+        if ($c.PSObject.Properties['id'] -and $c.id) { $predById[[string]$c.id] = $c }
+    }
+    $get = { param($obj, $name) if ($obj -and $obj.PSObject.Properties[$name] -and $null -ne $obj.$name) { [string]$obj.$name } else { '' } }
+
+    $out = [System.Collections.Generic.List[object]]::new()
+    foreach ($g in $Gold) {
+        if (-not ($g.PSObject.Properties['id'] -and $g.id)) { continue }
+        $id = [string]$g.id
+        $pred = if ($predById.ContainsKey($id)) { $predById[$id] } else { $null }
+        $predType = if ($null -ne $pred) { & $get $pred 'primary_type' } else { 'missing' }
+        $goldType = & $get $g 'primary_type'
+        $out.Add([PSCustomObject]@{
+                id               = $id
+                gold_type        = $goldType
+                pred_type        = $predType
+                gold_attribution = & $get $g 'attribution'
+                pred_attribution = & $get $pred 'attribution'
+                gold_anaphora    = & $get $g 'anaphora_dependency'
+                pred_anaphora    = & $get $pred 'anaphora_dependency'
+                gold_polarity    = & $get $g 'polarity'
+                pred_polarity    = & $get $pred 'polarity'
+                matched          = ($goldType -eq $predType)
+            })
+    }
+    return @($out)
+}
+
+function Measure-FolClassifierScore {
+    <#
+    .SYNOPSIS
+        Per-type precision/recall/F1 + confusion matrix + overall + per-attribute accuracy. Pure.
+    .PARAMETER Joined
+        Output of Join-FolGold.
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param([Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Joined)
+    Set-StrictMode -Version Latest
+
+    $n = @($Joined).Count
+    $correct = @($Joined | Where-Object { $_.matched }).Count
+
+    $perType = [System.Collections.Generic.List[object]]::new()
+    foreach ($t in $script:FOL_SCORE_TYPES) {
+        $tp = @($Joined | Where-Object { $_.gold_type -eq $t -and $_.pred_type -eq $t }).Count
+        $predT = @($Joined | Where-Object { $_.pred_type -eq $t }).Count
+        $goldT = @($Joined | Where-Object { $_.gold_type -eq $t }).Count
+        $precision = if ($predT -gt 0) { [Math]::Round($tp / [double]$predT, 4) } else { $null }   # null: never predicted
+        $recall = if ($goldT -gt 0) { [Math]::Round($tp / [double]$goldT, 4) } else { $null }       # null: absent from gold
+        $f1 = if ($null -ne $precision -and $null -ne $recall -and ($precision + $recall) -gt 0) {
+            [Math]::Round((2 * $precision * $recall) / ($precision + $recall), 4)
+        } else { $null }
+        $perType.Add([PSCustomObject]@{
+                primary_type = $t
+                support      = $goldT
+                tp           = $tp
+                predicted    = $predT
+                precision    = $precision
+                recall       = $recall
+                f1           = $f1
+            })
+    }
+
+    # Confusion matrix: gold -> { pred -> count } (predicted may include 'missing' + any junk label).
+    $confusion = [ordered]@{}
+    foreach ($row in $Joined) {
+        $gt = [string]$row.gold_type; $pt = [string]$row.pred_type
+        if (-not $confusion.Contains($gt)) { $confusion[$gt] = [ordered]@{} }
+        if (-not $confusion[$gt].Contains($pt)) { $confusion[$gt][$pt] = 0 }
+        $confusion[$gt][$pt]++
+    }
+
+    # Per-attribute accuracy over rows where BOTH gold + pred carry the attribute.
+    $attrAcc = [ordered]@{}
+    foreach ($a in @(@{k = 'attribution'; g = 'gold_attribution'; p = 'pred_attribution' },
+            @{k = 'anaphora_dependency'; g = 'gold_anaphora'; p = 'pred_anaphora' },
+            @{k = 'polarity'; g = 'gold_polarity'; p = 'pred_polarity' })) {
+        $scoreable = @($Joined | Where-Object { $_.($a.g) -ne '' -and $_.($a.p) -ne '' })
+        $agree = @($scoreable | Where-Object { $_.($a.g) -eq $_.($a.p) }).Count
+        $attrAcc[$a.k] = [PSCustomObject]@{
+            scoreable = $scoreable.Count
+            correct   = $agree
+            accuracy  = if ($scoreable.Count -gt 0) { [Math]::Round($agree / [double]$scoreable.Count, 4) } else { $null }
+        }
+    }
+
+    return [PSCustomObject]@{
+        n                  = $n
+        overall_accuracy   = if ($n -gt 0) { [Math]::Round($correct / [double]$n, 4) } else { 0.0 }
+        per_type           = @($perType)
+        confusion          = $confusion
+        attribute_accuracy = $attrAcc
+        provenance         = 'single-annotator gold spot-checks DIRECTION; kappa/alpha not established until CL double-annotation (design §11).'
+    }
+}

--- a/scripts/score-fol-classifier-gold.ps1
+++ b/scripts/score-fol-classifier-gold.ps1
@@ -1,0 +1,90 @@
+#Requires -Version 7
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    Score the FOL-on-debate clause classifier against CL's blind gold set (design §5, t/3354). READ-ONLY IO.
+.DESCRIPTION
+    Reads a keyed run's classified-clauses.jsonl (predicted §3 labels) and CL's blind
+    fol-eval-classifier-gold.jsonl (hand labels, same clause ids), joins by id, and reports per-primary-type
+    precision / recall / F1 + a gold×predicted confusion matrix + overall + per-attribute accuracy
+    (fol-eval-score.ps1, all pure). Emits a JSON report to -ReportPath. This is the CL-requested scorer that
+    lifts classified-clauses out of INSTRUMENT-PROVISIONAL once the gold exists.
+
+    Gold is authoritative: only ids present in the gold set are scored; a gold id absent from the classified
+    output scores as predicted 'missing'. Single-annotator gold spot-checks DIRECTION; no number certifies
+    precision until CL's second annotation (§11).
+
+    Pure-IO glue only — the scoring transforms live in fol-eval-score.ps1 (dot-source unit-tested); this
+    script just reads the two JSONL files, calls them, prints, and writes the report.
+.PARAMETER ClassifiedPath
+    Path to classified-clauses.jsonl from a keyed run's -OutputDir. Required.
+.PARAMETER GoldPath
+    Path to the blind gold JSONL. Default: scripts/fol-eval-classifier-gold.jsonl (CL's deliverable).
+.PARAMETER ReportPath
+    Where to write the JSON score report. Default: <ClassifiedPath dir>/classifier-score.json.
+.EXAMPLE
+    pwsh -File scripts/score-fol-classifier-gold.ps1 -ClassifiedPath ./fol-eval-run1/classified-clauses.jsonl
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$ClassifiedPath,
+
+    [Parameter()]
+    [string]$GoldPath,
+
+    [Parameter()]
+    [string]$ReportPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'fol-eval-score.ps1')
+
+function Read-JsonLines {
+    param([Parameter(Mandatory)][string]$Path)
+    $rows = [System.Collections.Generic.List[object]]::new()
+    foreach ($line in (Get-Content -LiteralPath $Path)) {
+        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+        $rows.Add(($line | ConvertFrom-Json))
+    }
+    return @($rows)
+}
+
+if (-not (Test-Path -LiteralPath $ClassifiedPath -PathType Leaf)) {
+    throw "score-fol-classifier-gold: classified file not found: '$ClassifiedPath' — run the harness first (run-fol-debate-eval.ps1, keyed) to produce classified-clauses.jsonl."
+}
+if (-not $GoldPath) { $GoldPath = Join-Path $PSScriptRoot 'fol-eval-classifier-gold.jsonl' }
+if (-not (Test-Path -LiteralPath $GoldPath -PathType Leaf)) {
+    throw "score-fol-classifier-gold: gold file not found: '$GoldPath' — this is CL's blind §5 deliverable (label classified-clauses.jsonl clause ids by hand). Pass -GoldPath once it exists."
+}
+if (-not $ReportPath) { $ReportPath = Join-Path (Split-Path -Parent (Resolve-Path -LiteralPath $ClassifiedPath)) 'classifier-score.json' }
+
+$classified = Read-JsonLines -Path $ClassifiedPath
+$gold = Read-JsonLines -Path $GoldPath
+
+$joined = @(Join-FolGold -Classified $classified -Gold $gold)
+$score = Measure-FolClassifierScore -Joined $joined
+
+Write-Host ''
+Write-Host "=== FOL clause-classifier score vs gold (design §5) ===" -ForegroundColor Cyan
+Write-Host "  Gold items scored: $($score.n)  (classified rows: $(@($classified).Count))   Overall accuracy: $($score.overall_accuracy)" -ForegroundColor White
+Write-Host '  Per primary_type:' -ForegroundColor White
+Write-Host ("    {0,-32} {1,4} {2,7} {3,7} {4,7}" -f 'type', 'supp', 'prec', 'rec', 'f1') -ForegroundColor DarkGray
+foreach ($t in $score.per_type) {
+    Write-Host ("    {0,-32} {1,4} {2,7} {3,7} {4,7}" -f $t.primary_type, $t.support, ("$($t.precision)"), ("$($t.recall)"), ("$($t.f1)")) -ForegroundColor DarkGray
+}
+Write-Host '  Attribute accuracy:' -ForegroundColor White
+foreach ($k in $score.attribute_accuracy.Keys) {
+    $a = $score.attribute_accuracy[$k]
+    Write-Host ("    {0,-22} {1}/{2} = {3}" -f $k, $a.correct, $a.scoreable, ("$($a.accuracy)")) -ForegroundColor DarkGray
+}
+
+$score | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $ReportPath -Encoding utf8
+Write-Host "  Report -> $ReportPath" -ForegroundColor Green
+Write-Host '  (Single-annotator gold spot-checks DIRECTION; no threshold until CL double-annotates, §11.)' -ForegroundColor DarkGray
+Write-Host ''
+return $score

--- a/tests/FolDebateScore.Tests.ps1
+++ b/tests/FolDebateScore.Tests.ps1
@@ -1,0 +1,74 @@
+# Tag: qbaf (t/3354 — FOL-on-debate clause-classifier scoring vs blind gold, design §5)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Tests for the FOL classifier scoring PURE transforms (scripts/fol-eval-score.ps1, design §5).
+.DESCRIPTION
+    Join-FolGold + Measure-FolClassifierScore are pure (no AI, no I/O). The IO runner
+    (score-fol-classifier-gold.ps1) is covered by a manual/CL run once a real gold set exists.
+#>
+
+BeforeAll {
+    . "$PSScriptRoot/../scripts/fol-eval-score.ps1"
+    # 4 gold items; classified: g1 correct, g2 wrong (causal), g3 correct, g4 absent -> 'missing'.
+    $script:gold = @(
+        [pscustomobject]@{ id = 'g1'; primary_type = 'assertoric-factual'; attribution = 'own'; anaphora_dependency = 'self-contained'; polarity = 'asserted' }
+        [pscustomobject]@{ id = 'g2'; primary_type = 'assertoric-factual'; attribution = 'own' }
+        [pscustomobject]@{ id = 'g3'; primary_type = 'assertoric-causal'; attribution = 'attributed-opponent' }
+        [pscustomobject]@{ id = 'g4'; primary_type = 'normative-deontic' }
+    )
+    $script:classified = @(
+        [pscustomobject]@{ id = 'g1'; primary_type = 'assertoric-factual'; attribution = 'own'; anaphora_dependency = 'self-contained'; polarity = 'asserted' }
+        [pscustomobject]@{ id = 'g2'; primary_type = 'assertoric-causal'; attribution = 'own' }
+        [pscustomobject]@{ id = 'g3'; primary_type = 'assertoric-causal'; attribution = 'own' }
+        [pscustomobject]@{ id = 'x9'; primary_type = 'rhetorical-evaluative' }  # not in gold -> ignored
+    )
+}
+
+Describe 'Join-FolGold — gold authoritative, missing -> missing, never drop' -Tag 'qbaf' {
+    It 'joins by id; a gold id absent from classified becomes pred_type missing' {
+        $j = @(Join-FolGold -Classified $classified -Gold $gold)
+        $j.Count | Should -Be 4                                  # 4 gold items (x9 ignored — not in gold)
+        ($j | Where-Object { $_.id -eq 'g4' }).pred_type | Should -Be 'missing'
+        ($j | Where-Object { $_.id -eq 'g1' }).matched | Should -BeTrue
+        ($j | Where-Object { $_.id -eq 'g2' }).matched | Should -BeFalse
+    }
+}
+
+Describe 'Measure-FolClassifierScore — P/R/F1 + confusion + accuracy' -Tag 'qbaf' {
+    BeforeAll { $script:score = Measure-FolClassifierScore -Joined (@(Join-FolGold -Classified $classified -Gold $gold)) }
+
+    It 'overall accuracy = matched / n' {
+        $score.n | Should -Be 4
+        $score.overall_accuracy | Should -Be 0.5                 # g1 + g3 correct of 4
+    }
+    It 'assertoric-factual: precision 1.0, recall 0.5' {
+        $f = $score.per_type | Where-Object { $_.primary_type -eq 'assertoric-factual' }
+        $f.support | Should -Be 2
+        $f.precision | Should -Be 1.0                            # predicted factual once (g1), correct
+        $f.recall | Should -Be 0.5                               # 1 of 2 gold-factual recovered
+    }
+    It 'assertoric-causal: precision 0.5, recall 1.0' {
+        $c = $score.per_type | Where-Object { $_.primary_type -eq 'assertoric-causal' }
+        $c.precision | Should -Be 0.5                            # predicted causal twice (g2,g3), 1 correct
+        $c.recall | Should -Be 1.0
+    }
+    It 'a never-predicted type has null precision but a real recall' {
+        $nd = $score.per_type | Where-Object { $_.primary_type -eq 'normative-deontic' }
+        $null -eq $nd.precision | Should -BeTrue                 # never predicted
+        $nd.recall | Should -Be 0.0                              # gold had 1, missed
+    }
+    It 'confusion matrix records the gold->pred mass incl. missing' {
+        $score.confusion['normative-deontic']['missing'] | Should -Be 1
+        $score.confusion['assertoric-factual']['assertoric-causal'] | Should -Be 1   # g2 misread
+    }
+    It 'attribute accuracy scores only rows where both sides carry the attribute' {
+        # attribution present on gold g1,g2,g3 and pred g1,g2,g3 -> 3 scoreable; agree on g1,g2 (own/own), g3 gold=attributed-opponent vs pred=own -> 2/3
+        $score.attribute_accuracy['attribution'].scoreable | Should -Be 3
+        $score.attribute_accuracy['attribution'].correct | Should -Be 2
+    }
+}


### PR DESCRIPTION
## score-vs-gold classifier scorer (design §5)

The helper CL confirmed wanting (t/3354#28/#29) — lifts `classified-clauses.jsonl` out of INSTRUMENT-PROVISIONAL once the blind gold exists. Joins the harness output with CL's blind `fol-eval-classifier-gold.jsonl` by clause id and scores the §3 classifier.

### What lands
- **`scripts/fol-eval-score.ps1`** (PURE): `Join-FolGold` (gold-authoritative join — a gold id absent from the classified output scores as predicted `missing`, never dropped, so a broken classifier can't inflate the score by shrinking the denominator) + `Measure-FolClassifierScore` (per-primary-type precision/recall/F1, gold×predicted confusion matrix incl. `missing`, overall accuracy, per-attribute accuracy for attribution/anaphora_dependency/polarity). Null precision for a never-predicted type (not 0), so the confusion isn't misread.
- **`scripts/score-fol-classifier-gold.ps1`** — thin read-only IO runner: reads the two JSONL files, calls the pure lib, prints the per-type table + attribute accuracy, writes `classifier-score.json`. Actionable errors when the classified/gold file is missing.
- Tests: **`FolDebateScore.Tests.ps1`** (7 cases — join/missing/never-drop, P/R/F1 on a worked example, null-precision for never-predicted, confusion incl. `missing`, attribute accuracy).

### Verification
- **10/10 Pester** (7 scorer + 3 sink-guard) / 0 failed / **0 container errors** (checked container errors, not just FailedCount).
- Runner smoke over tiny fixtures emits `classifier-score.json` (n=2, overall 0.5).

### Scope / gates
Read-only; pure/structural; no AI, no prompt/usage (no promptCatalog coupling); no `ai-models.json`/schema change → no Second Opinion (t/3361). Single-annotator gold spot-checks direction; no threshold until CL double-annotates (§11).

**Usage:** `pwsh -File scripts/score-fol-classifier-gold.ps1 -ClassifiedPath ./fol-eval-run1/classified-clauses.jsonl -GoldPath <CL gold>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)