### PR TITLE
fix(fol-eval): §3 normative-vs-causal disambiguation in the clause-classify prompt (t/3354#35)

### DIFF
--- a/scripts/AITriad/Prompts/fol-clause-classify.prompt
+++ b/scripts/AITriad/Prompts/fol-clause-classify.prompt
@@ -7,6 +7,19 @@ PRIMARY TYPE (closed set — choose exactly one):
 - "speech-act-belief-revision-meta" = a move about the discourse itself: concession, retained commitment, or defeater-conditional. e.g. "I concede the telemetry point"; "I still hold the ban is premature"; "I would change my position if <defeater>".
 - "rhetorical-evaluative" = no truth-apt propositional core to formalize: rhetorical question, category-error charge, pure evaluative framing. e.g. "who gave regulators the authority?"; "comparing a chatbot to a 737 MAX is a category error".
 
+DISTINGUISH assertoric-causal FROM normative-deontic (the most common error):
+- assertoric-causal = a DESCRIPTIVE claim about what actually causes/produces what, truth-apt and checkable
+  independent of anyone's goals. E.g. "Static compute thresholds fail to restrict intrusion tools";
+  "Auditors competing for the same labs are incentivized to give clean audits."
+- normative-deontic = a PRESCRIPTION or PROPOSAL — what should/must be done, or what an advocated policy
+  WOULD achieve. Tells: "we should/must/need to…", "X is necessary/essential", "a Y approach would involve…",
+  and especially "by doing X, we can achieve/ensure/create Y" when the speaker is ARGUING FOR X.
+- RULE: if the clause advocates or proposes a course of action — even phrased as "by X we can achieve Y" —
+  classify it normative-deontic, NOT assertoric-causal. Reserve assertoric-causal for how the world works,
+  not for what should be done.
+- Normative (NOT causal): "By prioritizing safety, we can ensure AI is developed responsibly." "A precautionary
+  approach is necessary to mitigate this risk." "By addressing these challenges we can create a robust process."
+
 ATTRIBUTES (orthogonal — record all three on every clause):
 - "attribution" ∈ "own" | "attributed-opponent" | "attributed-third-party". An attributed restatement ("Accelerationist proposes that P") is typed by the EMBEDDED proposition P's kind, with attribution "attributed-opponent". The attributed + assertoric combination is the highest-value, highest-anaphora-risk cell.
 - "anaphora_dependency" ∈ "self-contained" | "demonstrative" | "topic-ellipsis" | "attributed-restatement". Whether resolving the clause needs a cross-turn referent (a demonstrative like "that approach", a bare elided topic like "the ban", or an attributed restatement).


### PR DESCRIPTION
## §3 normative-vs-causal disambiguation (CL-authoritative content)

CL's canonical scoring (`score-fol-classifier-gold.ps1` on the 51-item blind gold, t/3354#35) pinned a systematic bleed: **normative recall 0.68 + assertoric-causal precision 0.67** — the classifier reads prescriptive "by X we can achieve Y" proposals as descriptive `assertoric-causal`, contaminating ~20% of the assertoric (FOL) subset with non-truth-apt normatives.

Adds CL's authoritative disambiguation block to `fol-clause-classify.prompt`: `assertoric-causal` = DESCRIPTIVE cause→effect (truth-apt independent of goals); a PRESCRIPTION/PROPOSAL — incl. "by doing X we can achieve/ensure/create Y" when arguing FOR X — is `normative-deontic`, not causal.

### Scope / gates
Prompt content is CL-authoritative (§3); implemented in PS scope. **Prompt-only change** — the `.prompt` file is already catalogued (`ps-fol-clause-classify`), so no promptCatalog coupling; no code/schema change → no Second Opinion (t/3361). Offline research eval, not in-loop → no calibration-validation trigger.

### Verification
Prompt renders (`Get-Prompt`, no unresolved placeholders; disambiguation block present). CL re-runs keyed + re-scores vs the same 51-gold to confirm normative recall rises without tanking causal recall (single-annotator until the 2nd pass, §11/§12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)