### PR TITLE
feat(fol-eval): -DebateIds/-DebateIdsPath allowlist for the §9 correlation-intersection (t/3354#38)

### DIFF
--- a/scripts/fol-eval-common.ps1
+++ b/scripts/fol-eval-common.ps1
@@ -69,3 +69,42 @@ function ConvertFrom-FolResultsJson {
     if ($parsed.PSObject.Properties['id']) { return @($parsed) }               # a single result row object
     return $null
 }
+
+function Select-FolDebatesByAllowlist {
+    <#
+    .SYNOPSIS
+        Filter loaded closed-debate entries to a debate_id allowlist (§9 correlation-intersection). Pure.
+    .DESCRIPTION
+        The §9 correlation join needs debates present in CL's calibration log (crux_addressed_rate /
+        convergence_score); the blind head-sample misses them. This restricts the run to an explicit
+        allowlist (the debates/ ∩ cal-log intersection) matched on DebateId — the same value the harness
+        emits as correlation-index.json's debate_id join key. Returns { Selected; MatchedIds; MissingIds }
+        so the runner can report requested-but-absent ids (no silent drop).
+    .PARAMETER Closed
+        The loaded closed-debate entries (each with a DebateId property).
+    .PARAMETER Allowlist
+        The debate ids to keep. Empty/null => Selected is all of Closed (no filtering).
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Closed,
+        [AllowNull()][AllowEmptyCollection()][string[]]$Allowlist
+    )
+    Set-StrictMode -Version Latest
+
+    $wanted = [System.Collections.Generic.HashSet[string]]::new()
+    foreach ($a in @($Allowlist)) { if (-not [string]::IsNullOrWhiteSpace($a)) { [void]$wanted.Add($a.Trim()) } }
+    if ($wanted.Count -eq 0) {
+        return @{ Selected = @($Closed); MatchedIds = @(); MissingIds = @() }
+    }
+
+    $selected = [System.Collections.Generic.List[object]]::new()
+    $present = [System.Collections.Generic.HashSet[string]]::new()
+    foreach ($c in $Closed) {
+        $id = if ($c.PSObject.Properties['DebateId']) { [string]$c.DebateId } else { '' }
+        if ($wanted.Contains($id)) { $selected.Add($c); [void]$present.Add($id) }
+    }
+    $missing = @($wanted | Where-Object { -not $present.Contains($_) } | Sort-Object)
+    return @{ Selected = @($selected); MatchedIds = @($present | Sort-Object); MissingIds = @($missing) }
+}

--- a/scripts/run-fol-debate-eval.ps1
+++ b/scripts/run-fol-debate-eval.ps1
@@ -56,6 +56,12 @@
     Clauses per classifier model call (batch-first, per-clause fallback for misses). Default 15.
 .PARAMETER SkipClassify
     Run SEGMENT only (emit clauses.jsonl), make NO model calls. Inspect segmentation without a key.
+.PARAMETER DebateIds
+    Optional debate_id allowlist — restrict the run to these debates (matched on debate_id, the
+    correlation-index join key). For the §9 correlation-intersection (debates present in CL's calibration
+    log). Composes with -MaxDebates. Requested-but-absent ids are reported, never silently dropped.
+.PARAMETER DebateIdsPath
+    File of debate_ids for the allowlist (one id per line, or a JSON array). Unioned with -DebateIds.
 .PARAMETER DryRun
     Plan only: load + sample debates, emit the manifest (sampling plan + cost ceiling), make
     NO model calls and hit NO stage. The cheapest runnable path.
@@ -102,6 +108,12 @@ param(
 
     [Parameter()]
     [string]$FnFixturePath,
+
+    [Parameter()]
+    [string[]]$DebateIds,
+
+    [Parameter()]
+    [string]$DebateIdsPath,
 
     [Parameter()]
     [ValidateRange(0, 100000)]
@@ -190,8 +202,40 @@ foreach ($f in $allFiles) {
     $closed.Add([PSCustomObject]@{ File = $f.Name; DebateId = $debateId; StatementCount = $statements.Count; Statements = $statements })
 }
 
+# ── DEBATE-ID ALLOWLIST (design §9 correlation-intersection) ────────────────────────
+# Restrict the run to an explicit debate_id allowlist — the debates/ ∩ CL-calibration-log
+# intersection — so the §9 correlation has convergence metrics to join to (the blind head-sample
+# misses them, t/3354#36). Union of -DebateIds + -DebateIdsPath (one id/line or a JSON array).
+$allowlist = [System.Collections.Generic.List[string]]::new()
+foreach ($id in @($DebateIds)) { if (-not [string]::IsNullOrWhiteSpace($id)) { $allowlist.Add($id.Trim()) } }
+if ($DebateIdsPath) {
+    if (-not (Test-Path -LiteralPath $DebateIdsPath -PathType Leaf)) {
+        throw (New-EvalError 'Run the FOL-on-debate offline eval' "debate-ids file not found: $DebateIdsPath" 'Pass -DebateIdsPath to a readable file (one debate_id per line, or a JSON array of ids).')
+    }
+    $raw = Get-Content -Raw -LiteralPath $DebateIdsPath
+    $fromFile = $null
+    try { $parsedIds = $raw | ConvertFrom-Json -ErrorAction Stop; if ($parsedIds -is [System.Array]) { $fromFile = @($parsedIds) } } catch { $fromFile = $null }
+    if ($null -eq $fromFile) { $fromFile = @($raw -split '\r?\n') }
+    foreach ($id in $fromFile) { if (-not [string]::IsNullOrWhiteSpace([string]$id)) { $allowlist.Add(([string]$id).Trim()) } }
+}
+$allowlistCount = $allowlist.Count
+$allowlistMissing = @()
+if ($allowlistCount -gt 0) {
+    $sel = Select-FolDebatesByAllowlist -Closed @($closed) -Allowlist @($allowlist)
+    $allowlistMissing = @($sel.MissingIds)
+    Write-Host "  Debate-id allowlist: $allowlistCount requested -> $(@($sel.Selected).Count) matched among closed debates$(if ($allowlistMissing.Count) { " ($($allowlistMissing.Count) requested id(s) not found/closed — NOT silently dropped)" })" -ForegroundColor DarkYellow
+    $closed = [System.Collections.Generic.List[object]]::new()
+    foreach ($c in @($sel.Selected)) { $closed.Add($c) }
+}
+
 # ── RUN-BOUNDING (design §10): deterministic sample + LOG, never silent truncation ──
 $totalClosed = $closed.Count
+if ($totalClosed -eq 0) {
+    throw (New-EvalError `
+            'Run the FOL-on-debate offline eval' `
+            $(if ($allowlistCount -gt 0) { "the -DebateIds/-DebateIdsPath allowlist ($allowlistCount id(s)) matched 0 closed debates" } else { "no closed (phase=closed) debates with statement turns were found in $DebatesDir" }) `
+            $(if ($allowlistCount -gt 0) { 'Check the allowlist ids match debate_id (the correlation-index join key); the missing-id count was logged above.' } else { 'Verify the debates dir + that debates have phase=closed transcripts.' }))
+}
 $selected = @($closed)
 $dropped = 0
 if ($totalClosed -gt $MaxDebates) {
@@ -213,6 +257,8 @@ $manifest = [ordered]@{
     debates_dir            = $DebatesDir
     model                  = $Model
     total_closed_debates   = $totalClosed
+    debate_ids_allowlist   = $allowlistCount
+    debate_ids_missing     = $allowlistMissing.Count
     selected_debates       = $selected.Count
     dropped_over_cap       = $dropped
     max_debates            = $MaxDebates

--- a/tests/FolDebateCommon.Tests.ps1
+++ b/tests/FolDebateCommon.Tests.ps1
@@ -57,3 +57,28 @@ Describe 'ConvertFrom-FolResultsJson — tolerant extraction' -Tag 'qbaf' {
         $null -eq (ConvertFrom-FolResultsJson -Text 'I could not classify these clauses.') | Should -BeTrue
     }
 }
+
+Describe 'Select-FolDebatesByAllowlist — §9 correlation-intersection filter' -Tag 'qbaf' {
+    BeforeAll {
+        $script:closed = @(
+            [pscustomobject]@{ DebateId = 'deb-a'; File = 'a.json' }
+            [pscustomobject]@{ DebateId = 'deb-b'; File = 'b.json' }
+            [pscustomobject]@{ DebateId = 'deb-c'; File = 'c.json' }
+        )
+    }
+    It 'keeps only allowlisted debate_ids and reports matched' {
+        $r = Select-FolDebatesByAllowlist -Closed $closed -Allowlist @('deb-a', 'deb-c')
+        @($r.Selected).Count | Should -Be 2
+        ($r.Selected.DebateId | Sort-Object) -join ',' | Should -Be 'deb-a,deb-c'
+        ($r.MatchedIds | Sort-Object) -join ',' | Should -Be 'deb-a,deb-c'
+        @($r.MissingIds).Count | Should -Be 0
+    }
+    It 'reports requested-but-absent ids (no silent drop)' {
+        $r = Select-FolDebatesByAllowlist -Closed $closed -Allowlist @('deb-a', 'deb-z')
+        @($r.Selected).Count | Should -Be 1
+        $r.MissingIds -join ',' | Should -Be 'deb-z'
+    }
+    It 'empty allowlist = no filtering (all selected)' {
+        (Select-FolDebatesByAllowlist -Closed $closed -Allowlist @()).Selected.Count | Should -Be 3
+    }
+}


### PR DESCRIPTION
## -DebateIds allowlist — unblocks the §9 correlation join (CL, t/3354#37/#38)

CL hit a §9 join gap: the blind head-sample debates aren't in the calibration log, so there's nothing to join `crux_addressed_rate`/`convergence_score` to. The `debates/ ∩ cal-log` intersection is **90 debates**. This lets the run target that intersection instead of the blind head.

### What lands
- **`scripts/fol-eval-common.ps1`** — `Select-FolDebatesByAllowlist` (PURE): filter closed debates to a `debate_id` allowlist (the correlation-index join key); returns `{Selected, MatchedIds, MissingIds}` — requested-but-absent ids are reported, never silently dropped.
- **`run-fol-debate-eval.ps1`** — new `-DebateIds` (array) + `-DebateIdsPath` (file: one id/line or a JSON array, unioned). Filters after load, before run-bounding, so it **composes with `-MaxDebates`** (chunk the 90). Manifest records `debate_ids_allowlist` + `debate_ids_missing`. **Fail-closed guard:** a 0-match allowlist (or empty corpus) now throws a clear `ActionableError` instead of a cryptic `Measure-Object .Sum` failure.
- Tests: 3 allowlist cases in `FolDebateCommon.Tests.ps1`.

### Verification
- **34/34 Pester** / 0 failed / **0 container errors**.
- Live DryRun over the real corpus with 2 real ids + 1 bogus → `total_closed=2, allowlist=3, missing=1, selected=2`; all-bogus allowlist throws cleanly.

### Scope / gates
Read-only over `../ai-triad-data`; no AI/prompt/schema change → no Second Opinion (t/3361). **CL runs:** `-DebateIdsPath <90-id list> -MaxDebates 25` → the §9 correlation over the intersection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)