### PR TITLE
fix(summary): Finalize-Summary normalizes null/absent camp key_points to @() + WARN (t/3434)

### DIFF
--- a/scripts/AITriad/Private/Invoke-DocumentSummary.ps1
+++ b/scripts/AITriad/Private/Invoke-DocumentSummary.ps1
@@ -720,13 +720,18 @@ function Finalize-Summary {
             } else {
                 $KP = Get-Field $CampData 'key_points'
                 if ($null -eq $KP) {
-                    $SchemaErrors.Add("pov_summaries.$Camp.key_points missing or not an array")
-                } else {
-                    # Force-array: ConvertFrom-Json unwraps single-element arrays to scalars
-                    $KP = @($KP)
-                    if ($CampData -is [System.Collections.IDictionary]) { $CampData['key_points'] = $KP }
-                    else { $CampData.key_points = $KP }
+                    # A camp with null/absent key_points is NOT a fatal schema error — L763 only fails
+                    # when pov_summaries itself is missing, so the old red "✗ Schema:" mislabeled it.
+                    # Normalize to @() like the sibling fields (factual_claims / unmapped_concepts) and
+                    # WARN instead (t/3434). Genuine empty-camp is already handled by the yield check.
+                    Write-Warning "pov_summaries.$Camp.key_points missing/null — defaulting to empty array (model=$Model)"
+                    $KP = @()
                 }
+                # Force-array: ConvertFrom-Json unwraps single-element arrays to scalars.
+                $KP = @($KP)
+                if ($CampData -is [System.Collections.IDictionary]) { $CampData['key_points'] = $KP }
+                elseif ($CampData.PSObject.Properties['key_points']) { $CampData.key_points = $KP }
+                else { $CampData | Add-Member -NotePropertyName 'key_points' -NotePropertyValue $KP -Force }
             }
         }
     }

--- a/tests/Finalize-Summary.NullKeyPoints.Tests.ps1
+++ b/tests/Finalize-Summary.NullKeyPoints.Tests.ps1
@@ -1,0 +1,76 @@
+# Tag: summarization (t/3434)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+# Regression tests for Finalize-Summary null/absent camp key_points handling (t/3434, Diagnostics p/17).
+# Bug: a camp with null (or absent) key_points added a SchemaError that printed a red "✗ Schema:" line —
+# which LOOKED fatal but wasn't (the function only returns failure when pov_summaries itself is missing)
+# — and did NOT normalize the field to @() like the sibling factual_claims / unmapped_concepts do.
+# Fix: WARN + default to @() (+ force-array/write-back), no SchemaError.
+#
+# Fixtures are built via ConvertFrom-Json (the real pipeline input shape) — a `[]` stays a non-null empty
+# array, unlike `[pscustomobject]@{ key_points = @() }` which collapses @() to $null. All camps carry
+# EMPTY key_points so the heavy gated passes (retrieval/polarity/veto) never fire. Finalize-Summary is a
+# SIMPLE function (no CmdletBinding), so warnings are captured via the `3>` stream redirect, not
+# -WarningVariable. Write-Utf8NoBom is mocked; the metadata read/write is try/caught inside the function.
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1') -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Finalize-Summary null/absent camp key_points (t/3434)' -Tag 'summarization' {
+
+    It 'normalizes a NULL camp key_points to @(), warns, and does NOT fail' {
+        InModuleScope AITriad {
+            $script:CachedEmbeddings = @{}; $script:TaxonomyData = @{}; $script:ContextRotStages = @()
+            Mock Get-TaxonomyNodeIdSet { [System.Collections.Generic.HashSet[string]]::new() }
+            Mock Write-Utf8NoBom { }
+
+            $summary = '{"pov_summaries":{"accelerationist":{"key_points":null},"safetyist":{"key_points":[]},"skeptic":{"key_points":[]}},"factual_claims":[],"unmapped_concepts":[]}' | ConvertFrom-Json
+
+            $wf = Join-Path $TestDrive "warn-null-$(Get-Random).txt"
+            $r = Finalize-Summary -SummaryObject $summary -ThisDocId 'doc-null-kp' -TaxonomyVersion 'v1' `
+                -Model 'gemini-3.5-flash-lite' -Temperature 0.2 -Now '2026-09-12T00:00:00Z' `
+                -SummariesDir $TestDrive -Doc @{ MetaFile = (Join-Path $TestDrive 'nope-meta.json') } `
+                -Elapsed ([TimeSpan]::FromSeconds(1)) 3> $wf
+            $warnText = [string](Get-Content -Raw -LiteralPath $wf -ErrorAction SilentlyContinue)
+
+            $r.Success | Should -BeTrue                                                   # not a schema failure
+            @($summary.pov_summaries.accelerationist.key_points).Count | Should -Be 0     # normalized to empty
+            $summary.pov_summaries.accelerationist.PSObject.Properties['key_points'] | Should -Not -BeNullOrEmpty
+            $warnText | Should -Match 'accelerationist\.key_points missing/null'           # WARN, not red ✗
+        }
+    }
+
+    It 'normalizes an ABSENT camp key_points property to @() (hardening beyond the null case)' {
+        InModuleScope AITriad {
+            $script:CachedEmbeddings = @{}; $script:TaxonomyData = @{}; $script:ContextRotStages = @()
+            Mock Get-TaxonomyNodeIdSet { [System.Collections.Generic.HashSet[string]]::new() }
+            Mock Write-Utf8NoBom { }
+
+            # accelerationist has NO key_points property at all.
+            $summary = '{"pov_summaries":{"accelerationist":{},"safetyist":{"key_points":[]},"skeptic":{"key_points":[]}},"factual_claims":[],"unmapped_concepts":[]}' | ConvertFrom-Json
+
+            $wf = Join-Path $TestDrive "warn-absent-$(Get-Random).txt"
+            $r = Finalize-Summary -SummaryObject $summary -ThisDocId 'doc-absent-kp' -TaxonomyVersion 'v1' `
+                -Model 'gemini-3.5-flash-lite' -Temperature 0.2 -Now '2026-09-12T00:00:00Z' `
+                -SummariesDir $TestDrive -Doc @{ MetaFile = (Join-Path $TestDrive 'nope-meta.json') } `
+                -Elapsed ([TimeSpan]::FromSeconds(1)) 3> $wf
+            $warnText = [string](Get-Content -Raw -LiteralPath $wf -ErrorAction SilentlyContinue)
+
+            $r.Success | Should -BeTrue
+            $prop = $summary.pov_summaries.accelerationist.PSObject.Properties['key_points']
+            $prop | Should -Not -BeNullOrEmpty                                            # property was created
+            @($prop.Value).Count | Should -Be 0
+            $warnText | Should -Match 'accelerationist\.key_points missing/null'
+        }
+    }
+
+    # NOTE: a camp with a genuine empty array `[]` is INDISTINGUISHABLE from null here — Get-Field
+    # returns @(), which PowerShell unwraps to $null on function return, so `[]` also takes the
+    # normalize+warn path. That is harmless (normalizing [] → @() is a no-op) and matches the prior
+    # code, which likewise flagged []-camps. A "no-warning" case therefore requires a genuinely
+    # POPULATED camp, which pulls in the polarity-gate path — out of scope for this focused fix.
+}


### PR DESCRIPTION
**Bug (t/3434, reported by Diagnostics p/17).** In `Invoke-DocumentSummary.ps1` `Finalize-Summary` (L721-723): a camp with null/absent `key_points` added a `SchemaError` that printed a red `✗ Schema:` line — which **looks fatal but isn't** (the function only returns failure when `pov_summaries` itself is missing) — and did **not** normalize the field to `@()` like the sibling `factual_claims` / `unmapped_concepts` do. Trigger: gemini-3.5-flash-lite dropped the accelerationist camp on doc `openais-disconcerting-hack-...`. Genuine empty-camp is already handled upstream by the L460-482 yield check, so this is Finalize consistency + de-noising.

**Fix (Diagnostics-recommended).** When `key_points` is null/absent → `Write-Warning "... missing/null — defaulting to empty array (model=$Model)"; $KP = @()`, then the existing force-array + write-back. Hardened the write-back to also handle the **absent-property** case (`Add-Member`), covering IDictionary, PSCustomObject-with-prop, and PSCustomObject-without-prop.

**Tests** (new `tests/Finalize-Summary.NullKeyPoints.Tests.ps1`): null-camp and absent-property cases both normalize to `@()`, emit the warning (captured via `3>` since Finalize-Summary is a simple function — no `-WarningVariable`), and return `Success` (not a schema failure). 2/2 green. (A genuine `[]` is indistinguishable from null at the `Get-Field` boundary — empty-array-unwrap — so it also takes the harmless normalize+warn path; documented in the test.)

**Self-cert:** /trivial-change (single-file de-noising + consistency fix + regression tests; no API/schema/cross-role change). Ticket created by me from Diagnostics' report — no TL design gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)