### PR TITLE
fix(debate): inline feedback for disabled Start-debate button (t/3437)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate/NewDebateDialog.css
+++ b/taxonomy-editor/src/renderer/components/debate/NewDebateDialog.css
@@ -602,6 +602,25 @@
   text-decoration: underline;
 }
 
+/* Disabled-Start-button reason, below footer actions (t/3437) — the title
+   tooltip alone is unreliable in Electron, so mirror it inline. */
+.ndd-start-hint {
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  margin: var(--sp-2) 0 0;
+  text-align: right;
+}
+
+.ndd-start-hint-link {
+  background: none;
+  border: none;
+  color: var(--focus-ring, #3b82f6);
+  cursor: pointer;
+  font-size: inherit;
+  padding: 0;
+  text-decoration: underline;
+}
+
 /* Screen reader only — no global sr-only in this app yet */
 .sr-only {
   clip: rect(0, 0, 0, 0);

--- a/taxonomy-editor/src/renderer/components/debate/NewDebateDialog.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/NewDebateDialog.tsx
@@ -20,6 +20,7 @@ import { resolveMultiProviderModels } from '@lib/ai-client/modelRouter';
 import { useTierInfo, isFreeTier, type TierInfo } from '../../hooks/useTierInfo';
 import { useGeminiOnboarding } from '../../hooks/useGeminiOnboarding';
 import { useAuthStatus } from '../../hooks/useAuthStatus';
+import { useSettingsDialog } from '../../hooks/useSettingsDialog';
 import { GeminiOnboardingModal } from '../settings/GeminiOnboardingModal';
 import { buildDebateOptions } from './newDebateOptions';
 
@@ -1455,6 +1456,7 @@ export function NewDebateDialog({ onClose, onAtCap }: NewDebateDialogProps) {
               </div>
             </div>
           </div>
+          {!canStart && !creating && hasSource && selected.size >= 1 && (multiProvider ? <p className="ndd-start-hint" role="status">Select at least 2 active backends with an API key for multi-provider mode.</p> : <p className="ndd-start-hint" role="status">No API key for this model — <button type="button" className="ndd-start-hint-link" onClick={() => useSettingsDialog.getState().open('apiKeys')}>add one in Settings</button></p>)}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
Forwarded UX bug: DevOps → ElectronMain → DebateUI (p/615#5 → p/637#1). `NewDebateDialog.tsx`'s Start-debate button relied solely on a `title` tooltip to explain why it was disabled — unreliable in Electron, and Jeffrey couldn't tell why the button was greyed out (p/294#8). The multiProvider branch (`activeBackends.length < 2`) had no feedback at all.

- Adds an inline hint below the footer actions when the button is disabled for a fixable reason (topic/source present, ≥1 voice selected, but blocked on key/backend count):
  - Single-provider: "No API key for this model — add one in Settings" with a working link
  - Multi-provider: "Select at least 2 active backends with an API key for multi-provider mode"
- The Settings link opens the app-wide Settings dialog to the API Keys tab via the existing `useSettingsDialog` global signal — the same mechanism `QuotaBanner.tsx` already uses (t/3190/t/3295), so no new cross-scope wiring or interfaces.

Self-certified via /trivial-change.

## Test plan
- [x] ESLint: 0 errors (10 pre-existing complexity/inline-style warnings, unchanged)
- [x] Renderer tsc: no new errors
- [x] Vitest: 96/96 tests pass in `src/renderer/components/debate/`
- [ ] Manual: open New Debate dialog with no API key configured → confirm inline hint appears and the Settings link opens API Keys

Note: could not visually smoke-test in a running Electron instance against this worktree's build (port 5173 already serves another session's dev server; swapping it risked disrupting unrelated work). Confidence is based on: the change reuses an already-shipped, already-visually-verified mechanism (`QuotaBanner`'s identical `useSettingsDialog('apiKeys')` call), plus clean lint/tsc/tests.

Closes t/3437

🤖 Generated with [Claude Code](https://claude.com/claude-code)
