### PR TITLE
feat(synthetic): add Get-SyntheticStatement — read synthetic statements for a BDI element

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -113,6 +113,7 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | `Invoke-VernacularBatch` | Generate vernacular descriptions |
 | `Invoke-AphorismBatch` | Backfill camp-voiced sober aphorisms (~3-8 words) on POV nodes — presentational only, never a scoring input; skips pillars/deprecated (t/1550) |
 | `New-SyntheticCorpus` | Generate synthetic training data |
+| `Get-SyntheticStatement` | Get the synthetic statements generated for a BDI element (node id); reads synthetic/corpus_<pov>.json, excludes pruned by default (-IncludePruned to include) |
 
 ### AI Call Log (t/3235)
 | Cmdlet | Use when |

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -133,6 +133,7 @@
         'New-SyntheticCorpus'
         'Update-SyntheticCorpus'
         'Sync-SyntheticCorpus'
+        'Get-SyntheticStatement'
         'Export-SyntheticEmbeddings'
         'Test-SynthesisCompleteness'
         'Get-ImportReport'

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -897,6 +897,7 @@ Export-ModuleMember -Function @(
     'New-SyntheticCorpus'
     'Update-SyntheticCorpus'
     'Sync-SyntheticCorpus'
+    'Get-SyntheticStatement'
     'Export-SyntheticEmbeddings'
     'Test-SynthesisCompleteness'
     'Get-ImportReport'

--- a/scripts/AITriad/Public/Get-SyntheticStatement.ps1
+++ b/scripts/AITriad/Public/Get-SyntheticStatement.ps1
@@ -1,0 +1,121 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Get-SyntheticStatement {
+    <#
+    .SYNOPSIS
+        Get the synthetic statements generated for a BDI taxonomy element (node).
+    .DESCRIPTION
+        Reads the synthetic corpus (written by New-SyntheticCorpus) and returns the statement
+        entries for a given BDI element — a taxonomy node id shaped {acc|saf|skp}-{category}-NNN.
+
+        The corpus is stored per-POV at <taxonomy>/synthetic/corpus_<pov>.json; the POV is derived
+        from the node id prefix, so only the one relevant corpus file is read. Each returned entry
+        carries the statement text plus its provenance (archetype, audience, model, timestamps).
+
+        By default PRUNED entries are excluded (matching what Export-SyntheticEmbeddings embeds) —
+        pass -IncludePruned to return them too. A node with no generated corpus returns nothing
+        (with a verbose note); a POV whose corpus file is absent emits a WARNING and returns nothing.
+    .PARAMETER NodeId
+        The BDI element / taxonomy node id (e.g. 'acc-beliefs-003'). Accepts pipeline input and binds
+        by the 'Id' property so taxonomy nodes can be piped in (e.g. Get-Tax -POV acc | Get-SyntheticStatement).
+    .PARAMETER IncludePruned
+        Also return entries marked pruned = true (excluded by default).
+    .PARAMETER CorpusPath
+        Override the synthetic corpus directory. Defaults to <taxonomy>/synthetic/.
+    .OUTPUTS
+        [PSCustomObject] one per matching corpus entry: node_id, statement, archetype, audience, model,
+        generation_timestamp, rationale, pruned, prune_reason (and any other fields present on disk).
+    .EXAMPLE
+        Get-SyntheticStatement -NodeId acc-beliefs-003
+        # All non-pruned synthetic statements for that Belief node.
+    .EXAMPLE
+        Get-SyntheticStatement acc-beliefs-003 | Select-Object -ExpandProperty statement
+        # Just the statement text.
+    .EXAMPLE
+        Get-Tax -POV saf | Get-SyntheticStatement -IncludePruned
+        # Every synthetic statement (incl. pruned) for all safetyist nodes.
+    .LINK
+        Show-AITriadHelp
+    .LINK
+        New-SyntheticCorpus
+    .LINK
+        Sync-SyntheticCorpus
+    .LINK
+        Export-SyntheticEmbeddings
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName, Position = 0)]
+        [Alias('Id')]
+        [ValidateNotNullOrEmpty()]
+        [string]$NodeId,
+
+        [switch]$IncludePruned,
+
+        [string]$CorpusPath
+    )
+
+    begin {
+        Set-StrictMode -Version Latest
+        $ErrorActionPreference = 'Stop'
+
+        if (-not $CorpusPath) { $CorpusPath = Join-Path (Get-TaxonomyDir) 'synthetic' }
+        # Cache loaded POV corpora across pipeline items so piping many node ids reads each file once.
+        $povCache  = @{}   # pov -> @(entries) | $null when the corpus file is absent
+        $warnedPov = [System.Collections.Generic.HashSet[string]]::new()
+
+        function Get-PovEntries {
+            param([string]$Pov)
+            if ($povCache.ContainsKey($Pov)) { return $povCache[$Pov] }
+            $file = Join-Path $CorpusPath "corpus_$Pov.json"
+            if (-not (Test-Path -LiteralPath $file)) {
+                # Fallback-path logging (docs/error-handling.md): a requested node's corpus file is absent —
+                # surface it once per POV rather than silently returning empty.
+                if (-not $warnedPov.Contains($Pov)) {
+                    Write-Warning "No synthetic corpus for POV '$Pov' at $file — run New-SyntheticCorpus first."
+                    [void]$warnedPov.Add($Pov)
+                }
+                $povCache[$Pov] = $null
+                return $null
+            }
+            try {
+                $doc = Get-Content -Raw -LiteralPath $file | ConvertFrom-Json
+            }
+            catch {
+                throw (New-ActionableError `
+                        -Goal     'Read synthetic statements for a BDI element' `
+                        -Problem  "Synthetic corpus is not valid JSON: $file — $($_.Exception.Message)" `
+                        -Location 'Get-SyntheticStatement' `
+                        -NextSteps @("Inspect $file", 'Regenerate it with New-SyntheticCorpus, or repair the JSON.'))
+            }
+            $entries = if ($doc.PSObject.Properties['entries']) { @($doc.entries) } else { @() }
+            $povCache[$Pov] = $entries
+            return $entries
+        }
+    }
+
+    process {
+        $id = $NodeId.Trim()
+        $pov = $id.Split('-')[0]
+        if ([string]::IsNullOrWhiteSpace($pov) -or $pov -eq $id) {
+            Write-Warning "Node id '$id' has no POV prefix ({acc|saf|skp}-…) — cannot locate its synthetic corpus."
+            return
+        }
+
+        $entries = Get-PovEntries -Pov $pov
+        if ($null -eq $entries) { return }   # corpus file absent (already warned)
+
+        $matched = @($entries | Where-Object {
+                $_.PSObject.Properties['node_id'] -and $_.node_id -eq $id -and
+                ($IncludePruned -or -not ($_.PSObject.Properties['pruned'] -and $_.pruned))
+            })
+
+        if ($matched.Count -eq 0) {
+            Write-Verbose "No synthetic statements for '$id' (pruned excluded: $(-not $IncludePruned))."
+            return
+        }
+        $matched
+    }
+}

--- a/tests/Get-SyntheticStatement.Tests.ps1
+++ b/tests/Get-SyntheticStatement.Tests.ps1
@@ -1,0 +1,103 @@
+# Tag: synthetic (Get-SyntheticStatement)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+# Unit tests for Get-SyntheticStatement. Get-SyntheticStatement is a public cmdlet, so it is called
+# directly and Get-TaxonomyDir is mocked with -ModuleName AITriad (no InModuleScope needed). A TestDrive
+# corpus exercises pov-derivation, pruned filtering, -IncludePruned, pipeline binding, and the
+# absent-corpus WARNING path.
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1') -Force -WarningAction SilentlyContinue
+
+    function New-TestCorpus {
+        param([string]$Dir)
+        $syn = Join-Path $Dir 'synthetic'
+        New-Item -ItemType Directory -Path $syn -Force | Out-Null
+        function New-Entry ($n, $s, $pruned) {
+            [ordered]@{ node_id = $n; statement = $s; archetype = 'plain'; audience = 'general'
+                model = 'gemini-2.5-flash'; generation_timestamp = '2026-09-12T00:00:00Z'
+                prompt_hash = 'h1'; description_hash = 'd1'; rationale = $null
+                pruned = $pruned; prune_reason = $(if ($pruned) { 'near-dup' } else { $null }) }
+        }
+        $acc = [ordered]@{
+            pov = 'acc'; generated_at = '2026-09-12T00:00:00Z'; node_count = 2; entry_count = 4
+            models = @('gemini-2.5-flash'); temperature = 1.0
+            entries = @(
+                (New-Entry 'acc-beliefs-003' 'Scaling is destiny.' $false)
+                (New-Entry 'acc-beliefs-003' 'Compute compounds.'  $false)
+                (New-Entry 'acc-beliefs-003' 'A near-duplicate.'    $true)
+                (New-Entry 'acc-beliefs-004' 'Regulation lags.'     $false)
+            )
+        }
+        $acc | ConvertTo-Json -Depth 10 | Set-Content -Path (Join-Path $syn 'corpus_acc.json') -Encoding utf8
+    }
+}
+
+Describe 'Get-SyntheticStatement' -Tag 'synthetic' {
+
+    It 'is exported from the module' {
+        Get-Command -Module AITriad -Name 'Get-SyntheticStatement' | Should -Not -BeNullOrEmpty
+    }
+
+    It 'returns the non-pruned statements for a BDI element (pov derived from the id prefix)' {
+        $TempDir = Join-Path ([System.IO.Path]::GetTempPath()) "getsynth-$(Get-Random)"
+        New-TestCorpus -Dir $TempDir
+        try {
+            Mock Get-TaxonomyDir { $TempDir } -ModuleName AITriad
+            $r = @(Get-SyntheticStatement -NodeId 'acc-beliefs-003')
+            $r.Count | Should -Be 2                                        # pruned entry excluded by default
+            @($r.statement) | Should -Contain 'Scaling is destiny.'
+            @($r.statement) | Should -Contain 'Compute compounds.'
+            @($r.statement) | Should -Not -Contain 'A near-duplicate.'
+            @($r | Where-Object { $_.node_id -ne 'acc-beliefs-003' }).Count | Should -Be 0
+        } finally { Remove-Item $TempDir -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+
+    It '-IncludePruned also returns pruned entries' {
+        $TempDir = Join-Path ([System.IO.Path]::GetTempPath()) "getsynth-$(Get-Random)"
+        New-TestCorpus -Dir $TempDir
+        try {
+            Mock Get-TaxonomyDir { $TempDir } -ModuleName AITriad
+            $r = @(Get-SyntheticStatement -NodeId 'acc-beliefs-003' -IncludePruned)
+            $r.Count | Should -Be 3
+            @($r.statement) | Should -Contain 'A near-duplicate.'
+        } finally { Remove-Item $TempDir -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'returns nothing for a node with no corpus entries' {
+        $TempDir = Join-Path ([System.IO.Path]::GetTempPath()) "getsynth-$(Get-Random)"
+        New-TestCorpus -Dir $TempDir
+        try {
+            Mock Get-TaxonomyDir { $TempDir } -ModuleName AITriad
+            @(Get-SyntheticStatement -NodeId 'acc-beliefs-999').Count | Should -Be 0
+        } finally { Remove-Item $TempDir -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'warns and returns nothing when the POV corpus file is absent' {
+        $TempDir = Join-Path ([System.IO.Path]::GetTempPath()) "getsynth-$(Get-Random)"
+        New-Item -ItemType Directory -Path (Join-Path $TempDir 'synthetic') -Force | Out-Null   # dir exists, no corpus_saf.json
+        try {
+            Mock Get-TaxonomyDir { $TempDir } -ModuleName AITriad
+            $warn = @()
+            $r = @(Get-SyntheticStatement -NodeId 'saf-beliefs-001' -WarningVariable warn -WarningAction SilentlyContinue)
+            $r.Count | Should -Be 0
+            ($warn -join ' ') | Should -Match 'No synthetic corpus for POV'
+        } finally { Remove-Item $TempDir -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'accepts the node id from the pipeline and binds by the Id property' {
+        $TempDir = Join-Path ([System.IO.Path]::GetTempPath()) "getsynth-$(Get-Random)"
+        New-TestCorpus -Dir $TempDir
+        try {
+            Mock Get-TaxonomyDir { $TempDir } -ModuleName AITriad
+            # bare-string pipeline
+            ('acc-beliefs-004' | Get-SyntheticStatement).statement | Should -Be 'Regulation lags.'
+            # by Id property (mirrors piping taxonomy nodes)
+            $node = [pscustomobject]@{ Id = 'acc-beliefs-003' }
+            @($node | Get-SyntheticStatement).Count | Should -Be 2
+        } finally { Remove-Item $TempDir -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+}


### PR DESCRIPTION
**Request (PI, direct):** a cmdlet to get the synthetic statements for a BDI element.

New public cmdlet **`Get-SyntheticStatement`**. Given a BDI taxonomy node id (`{acc|saf|skp}-{category}-NNN`), it reads the synthetic corpus written by `New-SyntheticCorpus` (`<taxonomy>/synthetic/corpus_<pov>.json`) and returns that node's statement entries.

- **POV-scoped read:** derives the POV from the id prefix → reads only the one corpus file, cached across pipeline items.
- **Pruned filtering:** excludes `pruned` entries by default (matches what `Export-SyntheticEmbeddings` embeds); `-IncludePruned` to include them.
- **Pipeline-friendly:** binds `NodeId` by the `Id` property, so `Get-Tax -POV acc | Get-SyntheticStatement` works; also accepts bare-string pipeline.
- **Error handling:** absent corpus file → `WARNING` + empty (fallback-path logged); malformed corpus JSON → `New-ActionableError`.
- **Output:** the full entry objects (`.statement` + provenance: archetype, audience, model, timestamps, pruned/prune_reason).

**/add-ps-cmdlet self-cert:** exported in both `AITriad.psd1` (`FunctionsToExport`) and `AITriad.psm1` (`Export-ModuleMember`); catalog entry added to `docs/cmdlet-reference.md`; `[CmdletBinding()]` + `[OutputType]`; approved verb `Get`; StrictMode-safe (guarded property access, `@()` wraps); uses `Get-TaxonomyDir`. 6 Pester tests (pov derivation, pruned filter, `-IncludePruned`, empty node, absent-corpus warn, pipeline/Id binding) — manifest valid, 6/6 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)