### PR TITLE
feat(debate): useDebateGrounding flag — wire debate_grounding into grounding block (t/3366)

### DIFF
--- a/lib/debate/debateEngine/internals.ts
+++ b/lib/debate/debateEngine/internals.ts
@@ -107,6 +107,8 @@ export interface DebateConfig {
   /** Replace description grounding text with the node's synthetic_phrase nearest the description embedding (t/3367).
    *  Off by default. Requires adapter.computeQueryEmbedding; WARN-falls back to description when unavailable. */
   useSyntheticPhraseGrounding?: boolean;
+  /** Use debate_grounding register text instead of description when present on a node (t/3366). Off by default. Falls back to description per node when field absent. Lower priority than useSyntheticPhraseGrounding. */
+  useDebateGrounding?: boolean;
   /** Rank situation selection by weighted breadth score (relevance + freshness + bdi_entropy via PRE_DEBATE_WEIGHTS) instead of pure relevance (t/3411 experiment). Off by default. */
   breadthAwareSituationSelection?: boolean;
   /** Enable over-generate/select/rewrite pipeline: N=3 drafts, dedup, greedy top-K, rewrite, coherence gate (t/1581). */

--- a/lib/debate/debateEngine/taxonomyContext.ts
+++ b/lib/debate/debateEngine/taxonomyContext.ts
@@ -518,9 +518,22 @@ export async function getRelevantTaxonomyContext(engine: DebateEngineInternals, 
     }
   }
 
+  let debateGroundingOverrides: Map<string, string> | undefined;
+  if (engine.config.useDebateGrounding) {
+    debateGroundingOverrides = new Map<string, string>();
+    for (const n of filteredCtx.povNodes) {
+      const grounding = n.graph_attributes?.debate_grounding;
+      if (grounding) debateGroundingOverrides.set(n.id, grounding);
+    }
+    if (debateGroundingOverrides.size === 0) {
+      getGlobalRecorder()?.record({ type: 'system.error', component: 'debate-engine', level: 'warn', debate_id: engine.session?.id, message: 'useDebateGrounding: no injected nodes have debate_grounding populated — falling back to description for all nodes' });
+    }
+  }
+
   return formatTaxonomyContext(filteredCtx, pov, undefined, {
     ...(situationStatements ? { situationStatements } : undefined),
     ...(syntheticPhraseOverrides ? { syntheticPhraseOverrides } : undefined),
+    ...(debateGroundingOverrides ? { debateGroundingOverrides } : undefined),
   });
 }
 

--- a/lib/debate/taxonomyContext.ts
+++ b/lib/debate/taxonomyContext.ts
@@ -125,6 +125,12 @@ export interface FormatContextConfig {
    * Computed engine-side before formatTaxonomyContext; absent = feature off.
    */
   syntheticPhraseOverrides?: Map<string, string>;
+  /**
+   * debate_grounding register text per node ID (t/3366, useDebateGrounding).
+   * When present for a node, replaces description as grounding text (priority below syntheticPhraseOverrides).
+   * Computed engine-side; absent = feature off.
+   */
+  debateGroundingOverrides?: Map<string, string>;
 }
 
 /** Generate per-node inline guidance lines from metadata.
@@ -309,7 +315,7 @@ export function formatTaxonomyContext(ctx: TaxonomyContext, pov: string, maxNode
       if (isPrimary) {
         const weightLabel = nodeWeightLabel(n, cat);
         lines.push(`${prefix}[${n.id}]${weightLabel}`);
-        lines.push(`  "${n.label}" — ${stripExcludes(cfg.syntheticPhraseOverrides?.get(n.id) ?? n.description)}`);
+        lines.push(`  "${n.label}" — ${stripExcludes(cfg.syntheticPhraseOverrides?.get(n.id) ?? cfg.debateGroundingOverrides?.get(n.id) ?? n.description)}`);
         const sv = n.graph_attributes?.steelman_vulnerability;
         if (sv) {
           const svText = typeof sv === 'string' ? sv : Object.values(sv).filter(Boolean).join(' | ');


### PR DESCRIPTION
Wires the `debate_grounding` node field (pre-staged in taxonomyTypes.ts:48 under t/3367) into the debater grounding block, behind a `useDebateGrounding` flag (default off).

## Changes
- **`internals.ts`**: `useDebateGrounding?: boolean` flag — mirrors `useSyntheticPhraseGrounding`
- **`taxonomyContext.ts`**: `debateGroundingOverrides?: Map<string, string>` in `FormatTaxonomyContextOptions`; priority chain `syntheticPhraseOverrides > debateGroundingOverrides > description` at the grounding line
- **`debateEngine/taxonomyContext.ts`**: when flag on, builds `debateGroundingOverrides` from `graph_attributes.debate_grounding` on injected POV nodes; WARN-logs when 0 nodes have the field (0%-populated corpus → safe fallback)

No async, no embeddings — simpler than `useSyntheticPhraseGrounding`. Per-node fallback to description when field absent.

Self-cert /trivial-change — 3 files, single-scope, no new exports, no interface changes outside lib/debate. 52/52 tests pass at 12408b74.

Closes t/3366 wiring phase. CL owns data generation.