### PR TITLE
fix(policy): Update-PolicyRegistry -Fix re-adds missing-from-registry ids from node action (t/3435)

### DIFF
--- a/scripts/AITriad/Public/Update-PolicyRegistry.ps1
+++ b/scripts/AITriad/Public/Update-PolicyRegistry.ps1
@@ -89,9 +89,13 @@ function Update-PolicyRegistry {
                 if (-not $ReferencedIds.ContainsKey($Pid)) {
                     $ReferencedIds[$Pid] = [System.Collections.Generic.List[object]]::new()
                 }
+                # Capture action/framing too (t/3435): needed to RE-ADD a referenced-but-unregistered
+                # id back into the registry (Missing set) — the node is the only place its action lives.
                 $ReferencedIds[$Pid].Add([PSCustomObject]@{
-                    NodeId = $Node.id
-                    POV    = $PovKey
+                    NodeId  = $Node.id
+                    POV     = $PovKey
+                    Action  = if ($PA.PSObject.Properties['action']) { $PA.action } else { $null }
+                    Framing = if ($PA.PSObject.Properties['framing']) { $PA.framing } else { $null }
                 })
             }
         }
@@ -202,6 +206,39 @@ function Update-PolicyRegistry {
                 }
                 $FileData | ConvertTo-Json -Depth 20 | Write-Utf8NoBom -Path $FilePath
             }
+        }
+
+        # Re-add "missing from registry" ids — referenced-but-unregistered (t/3435). A prior partial run
+        # wrote pol-NNNN onto nodes without persisting the registry (e.g. pol-3368/3369); the id then
+        # lives ONLY on the node. Recreate the registry entry from the referencing node's action —
+        # registry-only change (nodes already carry the id → no POV-file write). member_count/source_povs
+        # are corrected by the re-scan below. Idempotent: once added, a re-run reports Missing 0.
+        if ($Missing.Count -gt 0 -and $PSCmdlet.ShouldProcess("$($Missing.Count) missing-from-registry ids", 'Re-add to registry')) {
+            $ReAdded = 0
+            foreach ($Mid in $Missing) {
+                $refs = @($ReferencedIds[$Mid])
+                $withAction = @($refs | Where-Object { $_.PSObject.Properties['Action'] -and -not [string]::IsNullOrWhiteSpace([string]$_.Action) })
+                if ($withAction.Count -eq 0) {
+                    # Fallback-path logging (docs/error-handling.md): referenced id with no recoverable
+                    # action text — cannot faithfully reconstruct the registry entry, so skip + surface.
+                    Write-Warning "  $Mid referenced but no action text on any node — skipping re-add (t/3435)."
+                    continue
+                }
+                $first = $withAction[0]
+                $povs  = @($refs | ForEach-Object { $_.POV } | Sort-Object -Unique)
+                $ExistingPolicies[$Mid] = [PSCustomObject]@{
+                    id           = $Mid
+                    action       = [string]$first.Action
+                    source_povs  = $povs
+                    member_count = $refs.Count
+                    status       = 'active'
+                }
+                $ReAdded++
+                $prev = [string]$first.Action
+                $prev = $prev.Substring(0, [Math]::Min(50, $prev.Length))
+                Write-Info "  Re-added $Mid from $($first.NodeId)`: $prev"
+            }
+            Write-OK "Re-added $ReAdded missing policies to registry"
         }
 
         # Rebuild member_count and source_povs

--- a/tests/Update-PolicyRegistry.Tests.ps1
+++ b/tests/Update-PolicyRegistry.Tests.ps1
@@ -142,4 +142,44 @@ Describe 'Update-PolicyRegistry -Fix (t/3431 batched write + idempotent MaxId)' 
             }
         }
     }
+
+    It 're-adds a "missing from registry" id from the node action; registry-only; idempotent (t/3435)' {
+        InModuleScope AITriad {
+            $TempDir = Join-Path ([System.IO.Path]::GetTempPath()) "polreg-missing-$(Get-Random)"
+            New-Item -ItemType Directory -Path $TempDir -Force | Out-Null
+            try {
+                # sit-A references pol-005, which a prior partial run wrote onto the node but NEVER persisted
+                # to the registry (the pol-3368/9 class). sit-keep references pol-001 so it survives orphan removal.
+                @{ _schema_version = '1.0.0'; nodes = @(
+                        @{ id = 'sit-keep'; graph_attributes = @{ policy_actions = @(
+                                    @{ action = 'kept'; framing = 'f'; policy_id = 'pol-001' }
+                                ) } }
+                        @{ id = 'sit-A'; graph_attributes = @{ policy_actions = @(
+                                    @{ action = 'Orphaned reference action'; framing = 'fx'; policy_id = 'pol-005' }
+                                ) } }
+                    ) } | ConvertTo-Json -Depth 20 | Set-Content -Path (Join-Path $TempDir 'situations.json')
+                @{ _schema_version = '1.0.0'; _doc = 'x'; policy_count = 1; policies = @(
+                        @{ id = 'pol-001'; action = 'kept'; source_povs = @('situations'); member_count = 1; status = 'active' }
+                    ) } | ConvertTo-Json -Depth 20 | Set-Content -Path (Join-Path $TempDir 'policy_actions.json')
+
+                Mock Get-TaxonomyDir { $TempDir }
+                Mock Write-Utf8NoBom { Set-Content -Path $Path -Value $Value -Encoding utf8 }
+
+                { Update-PolicyRegistry -Fix } | Should -Not -Throw
+                $reg = Get-Content -Raw (Join-Path $TempDir 'policy_actions.json') | ConvertFrom-Json
+                $readded = $reg.policies | Where-Object { $_.id -eq 'pol-005' }
+                $readded | Should -Not -BeNullOrEmpty                             # re-added to the registry
+                $readded.action | Should -Be 'Orphaned reference action'         # action sourced from the node
+                @($readded.source_povs) | Should -Contain 'situations'
+                # Registry-only: the node already carries pol-005, so no POV-file rewrite.
+                Should -Invoke Write-Utf8NoBom -Times 0 -Exactly -ParameterFilter { $Path -like '*situations.json' }
+
+                # Idempotent: a second -Fix now reports Missing 0.
+                $r2 = Update-PolicyRegistry -Fix -PassThru
+                $r2.Missing | Should -Be 0
+            } finally {
+                Remove-Item $TempDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
 }


### PR DESCRIPTION
**Follow-up to t/3431** (TL-endorsed split, p/360#364). t/3431 made `-Fix` collision-proof against referenced-but-unregistered ids but did NOT reconcile the "Missing from registry" set — ids that nodes reference but that are absent from `policy_actions.json` (the pol-3368/9 artifact from an earlier partial run). `-Fix` reported `Missing from registry: N` every run without repairing it.

**Fix.** The scan now captures `action`/`framing` per referenced id (the node is the only place a missing id's action lives). `-Fix` recreates each Missing registry entry from the referencing node's action; `member_count`/`source_povs` are corrected by the existing post-fix re-scan. **Registry-only** change — the nodes already carry the id, so no POV-file rewrite. Idempotent: a second `-Fix` reports `Missing: 0`.

**Test.** New Pester arm: a node references `pol-005` absent from the registry → `-Fix` re-adds it (action sourced from the node), no situations.json write, and a second `-Fix` reports Missing 0. Full file 4/4 green.

**Self-cert:** /add-test + /trivial-change (single-file, existing pattern; ticket created by me from the t/3431 split — no design gate). Not a schema change → no SO.

**Live reconciliation** of pol-3368/9 remains an owner-run `-Fix` under /data-mutation (same discipline as t/3431's landing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)