### PR TITLE
fix(debate): distinguish unsupported-model from no-API-key in Start button feedback (t/3436)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate/NewDebateDialog.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/NewDebateDialog.tsx
@@ -24,7 +24,7 @@ import { useSettingsDialog } from '../../hooks/useSettingsDialog';
 import { GeminiOnboardingModal } from '../settings/GeminiOnboardingModal';
 import { buildDebateOptions } from './newDebateOptions';
 
-const DEBATE_EXCLUDED_BACKENDS = new Set(['ollama']);
+const DEBATE_EXCLUDED_BACKENDS = new Set(['ollama']); // can't reliably produce structured JSON for debates — capability gap, not an oversight
 
 export type DialecticalStyle = 'adversarial' | 'deliberative' | 'integrative';
 
@@ -1426,7 +1426,7 @@ export function NewDebateDialog({ onClose, onAtCap }: NewDebateDialogProps) {
                   className="btn btn-primary ndd-start-btn"
                   onClick={handleStart}
                   disabled={!canStart || creating}
-                  title={!hasSource ? 'Enter a topic to start' : !activeModelHasKey ? 'No API key configured' : undefined}
+                  title={!hasSource ? 'Enter a topic to start' : activeModelExcluded ? 'This model is not supported for debates' : !activeModelHasKey ? 'No API key configured' : undefined}
                 >
                   {creating ? 'Starting…' : 'Start debate'}
                 </button>
@@ -1456,7 +1456,7 @@ export function NewDebateDialog({ onClose, onAtCap }: NewDebateDialogProps) {
               </div>
             </div>
           </div>
-          {!canStart && !creating && hasSource && selected.size >= 1 && (multiProvider ? <p className="ndd-start-hint" role="status">Select at least 2 active backends with an API key for multi-provider mode.</p> : <p className="ndd-start-hint" role="status">No API key for this model — <button type="button" className="ndd-start-hint-link" onClick={() => useSettingsDialog.getState().open('apiKeys')}>add one in Settings</button></p>)}
+          {!canStart && !creating && hasSource && selected.size >= 1 && (multiProvider ? <p className="ndd-start-hint" role="status">Select at least 2 active backends with an API key for multi-provider mode.</p> : activeModelExcluded ? <p className="ndd-start-hint" role="status">This model is not supported for debates — pick a different model.</p> : <p className="ndd-start-hint" role="status">No API key for this model — <button type="button" className="ndd-start-hint-link" onClick={() => useSettingsDialog.getState().open('apiKeys')}>add one in Settings</button></p>)}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
Follow-up to t/3437 (#2135). Forwarded UX bug (DebateTool → ElectronMain → DebateUI, p/294#10): `DEBATE_EXCLUDED_BACKENDS = new Set(['ollama'])` made `activeModelHasKey` false for Ollama models, so both the `title` tooltip and t/3437's inline hint showed "No API key configured" — misleading, since Ollama needs no key and is simply unsupported for the debate pipeline (can't reliably produce structured JSON).

- Added a third case, checked before the no-key case: when `activeModelExcluded`, show "This model is not supported for debates" (both in the `title` tooltip and the inline hint added by t/3437)
- Restored the code comment on `DEBATE_EXCLUDED_BACKENDS` explaining why Ollama is excluded (had been silently dropped in an earlier edit) so a future reviewer doesn't mistake the exclusion for a bug

Self-certified via /trivial-change — same pattern/file as t/3437, one file, no new interfaces.

## Test plan
- [x] ESLint: 0 errors (10 pre-existing complexity/inline-style warnings, unchanged in kind)
- [x] Renderer tsc: no new errors
- [x] Vitest: 96/96 tests pass in `src/renderer/components/debate/`
- [ ] Manual: select a local Ollama model in New Debate dialog → confirm "not supported for debates" message instead of the misleading API-key message

Closes t/3436

🤖 Generated with [Claude Code](https://claude.com/claude-code)
