### PR TITLE
fix(deps): remove false-comfort adm-zip override from root package.json (t/3442)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,5 @@
     "jszip": "^3.10.2",
     "onnxruntime-node": "^1.29.0",
     "zod": "^4.5.4"
-  },
-  "overrides": {
-    "adm-zip": ">=0.6.0"
   }
 }


### PR DESCRIPTION
Part of t/3442 (adm-zip accept-with-rationale, TL-approved p/455#207 / t/3442#2). **Condition 2** of the sign-off: remove the false-comfort override.

## What
Removes `overrides: { "adm-zip": ">=0.6.0" }` from root `package.json`. That entry resolved to **0.6.0 — inside the vulnerable range** (`>=0.5.9 <=0.6.0`), so it mitigated nothing while reading as if it did, contradicting the accept-with-rationale disposition (Gate Co-Location: config must not imply a different disposition).

## Zero resolution impact
`pnpm install --lockfile-only` after removal → **`pnpm-lock.yaml` UNCHANGED**; adm-zip still resolves to a single `0.6.0` via onnxruntime-node's own constraint. The override was purely redundant. **Only `package.json` changes.**

## Disposition context
adm-zip CVE (symlink-follow extraction, no patched version) is accept-with-rationale: sole consumer is onnxruntime-node's install-time postinstall extracting its own official binary archive; zero first-party usage; not attacker-reachable (full trace t/3442#1, TL sign-off #2). Alerts #344/#345 will be dismissed once this + the taxonomy-editor twin (Rosetta, rides t/3441) land.

Self-cert `/trivial-change` (config-only, no resolution/behavior change).