### PR TITLE
fix(licenses): regenerate notices for sharp 0.35.4/libvips bump — unblock main (t/3443, P1)

### DIFF
--- a/taxonomy-editor/THIRD-PARTY-NOTICES.txt
+++ b/taxonomy-editor/THIRD-PARTY-NOTICES.txt
@@ -510,22 +510,22 @@ The following npm packages may be included in this product:
 
  - @huggingface/tokenizers@0.1.3
  - @huggingface/transformers@4.2.0
- - @img/sharp-darwin-arm64@0.35.3
- - @img/sharp-darwin-x64@0.35.3
- - @img/sharp-freebsd-wasm32@0.35.3
- - @img/sharp-linux-arm@0.35.3
- - @img/sharp-linux-arm64@0.35.3
- - @img/sharp-linux-ppc64@0.35.3
- - @img/sharp-linux-riscv64@0.35.3
- - @img/sharp-linux-s390x@0.35.3
- - @img/sharp-linux-x64@0.35.3
- - @img/sharp-linuxmusl-arm64@0.35.3
- - @img/sharp-linuxmusl-x64@0.35.3
- - @img/sharp-wasm32@0.35.3
- - @img/sharp-webcontainers-wasm32@0.35.3
- - @img/sharp-win32-arm64@0.35.3
- - @img/sharp-win32-ia32@0.35.3
- - @img/sharp-win32-x64@0.35.3
+ - @img/sharp-darwin-arm64@0.35.4
+ - @img/sharp-darwin-x64@0.35.4
+ - @img/sharp-freebsd-wasm32@0.35.4
+ - @img/sharp-linux-arm@0.35.4
+ - @img/sharp-linux-arm64@0.35.4
+ - @img/sharp-linux-ppc64@0.35.4
+ - @img/sharp-linux-riscv64@0.35.4
+ - @img/sharp-linux-s390x@0.35.4
+ - @img/sharp-linux-x64@0.35.4
+ - @img/sharp-linuxmusl-arm64@0.35.4
+ - @img/sharp-linuxmusl-x64@0.35.4
+ - @img/sharp-wasm32@0.35.4
+ - @img/sharp-webcontainers-wasm32@0.35.4
+ - @img/sharp-win32-arm64@0.35.4
+ - @img/sharp-win32-ia32@0.35.4
+ - @img/sharp-win32-x64@0.35.4
  - flatbuffers@25.9.23
  - long@5.3.2
 
@@ -828,16 +828,16 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 The following npm packages may be included in this product:
 
- - @img/sharp-libvips-darwin-arm64@1.3.2
- - @img/sharp-libvips-darwin-x64@1.3.2
- - @img/sharp-libvips-linux-arm@1.3.2
- - @img/sharp-libvips-linux-arm64@1.3.2
- - @img/sharp-libvips-linux-ppc64@1.3.2
- - @img/sharp-libvips-linux-riscv64@1.3.2
- - @img/sharp-libvips-linux-s390x@1.3.2
- - @img/sharp-libvips-linux-x64@1.3.2
- - @img/sharp-libvips-linuxmusl-arm64@1.3.2
- - @img/sharp-libvips-linuxmusl-x64@1.3.2
+ - @img/sharp-libvips-darwin-arm64@1.3.3
+ - @img/sharp-libvips-darwin-x64@1.3.3
+ - @img/sharp-libvips-linux-arm@1.3.3
+ - @img/sharp-libvips-linux-arm64@1.3.3
+ - @img/sharp-libvips-linux-ppc64@1.3.3
+ - @img/sharp-libvips-linux-riscv64@1.3.3
+ - @img/sharp-libvips-linux-s390x@1.3.3
+ - @img/sharp-libvips-linux-x64@1.3.3
+ - @img/sharp-libvips-linuxmusl-arm64@1.3.3
+ - @img/sharp-libvips-linuxmusl-x64@1.3.3
 
 These packages each contain the following license:
 
@@ -4794,7 +4794,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 The following npm package may be included in this product:
 
- - sharp@0.35.3
+ - sharp@0.35.4
 
 This package contains the following license:
 

--- a/taxonomy-editor/src/renderer/data/oss-licenses.json
+++ b/taxonomy-editor/src/renderer/data/oss-licenses.json
@@ -142,132 +142,132 @@
     },
     {
       "name": "@img/sharp-darwin-arm64",
-      "version": "0.35.3",
+      "version": "0.35.4",
       "license": "Apache-2.0"
     },
     {
       "name": "@img/sharp-darwin-x64",
-      "version": "0.35.3",
+      "version": "0.35.4",
       "license": "Apache-2.0"
     },
     {
       "name": "@img/sharp-freebsd-wasm32",
-      "version": "0.35.3",
+      "version": "0.35.4",
       "license": "Apache-2.0"
     },
     {
       "name": "@img/sharp-libvips-darwin-arm64",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "LGPL-3.0-or-later"
     },
     {
       "name": "@img/sharp-libvips-darwin-x64",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "LGPL-3.0-or-later"
     },
     {
       "name": "@img/sharp-libvips-linux-arm",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "LGPL-3.0-or-later"
     },
     {
       "name": "@img/sharp-libvips-linux-arm64",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "LGPL-3.0-or-later"
     },
     {
       "name": "@img/sharp-libvips-linux-ppc64",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "LGPL-3.0-or-later"
     },
     {
       "name": "@img/sharp-libvips-linux-riscv64",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "LGPL-3.0-or-later"
     },
     {
       "name": "@img/sharp-libvips-linux-s390x",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "LGPL-3.0-or-later"
     },
     {
       "name": "@img/sharp-libvips-linux-x64",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "LGPL-3.0-or-later"
     },
     {
       "name": "@img/sharp-libvips-linuxmusl-arm64",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "LGPL-3.0-or-later"
     },
     {
       "name": "@img/sharp-libvips-linuxmusl-x64",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "LGPL-3.0-or-later"
     },
     {
       "name": "@img/sharp-linux-arm",
-      "version": "0.35.3",
+      "version": "0.35.4",
       "license": "Apache-2.0"
     },
     {
       "name": "@img/sharp-linux-arm64",
-      "version": "0.35.3",
+      "version": "0.35.4",
       "license": "Apache-2.0"
     },
     {
       "name": "@img/sharp-linux-ppc64",
-      "version": "0.35.3",
+      "version": "0.35.4",
       "license": "Apache-2.0"
     },
     {
       "name": "@img/sharp-linux-riscv64",
-      "version": "0.35.3",
+      "version": "0.35.4",
       "license": "Apache-2.0"
     },
     {
       "name": "@img/sharp-linux-s390x",
-      "version": "0.35.3",
+      "version": "0.35.4",
       "license": "Apache-2.0"
     },
     {
       "name": "@img/sharp-linux-x64",
-      "version": "0.35.3",
+      "version": "0.35.4",
       "license": "Apache-2.0"
     },
     {
       "name": "@img/sharp-linuxmusl-arm64",
-      "version": "0.35.3",
+      "version": "0.35.4",
       "license": "Apache-2.0"
     },
     {
       "name": "@img/sharp-linuxmusl-x64",
-      "version": "0.35.3",
+      "version": "0.35.4",
       "license": "Apache-2.0"
     },
     {
       "name": "@img/sharp-wasm32",
-      "version": "0.35.3",
+      "version": "0.35.4",
       "license": "Apache-2.0"
     },
     {
       "name": "@img/sharp-webcontainers-wasm32",
-      "version": "0.35.3",
+      "version": "0.35.4",
       "license": "Apache-2.0"
     },
     {
       "name": "@img/sharp-win32-arm64",
-      "version": "0.35.3",
+      "version": "0.35.4",
       "license": "Apache-2.0"
     },
     {
       "name": "@img/sharp-win32-ia32",
-      "version": "0.35.3",
+      "version": "0.35.4",
       "license": "Apache-2.0"
     },
     {
       "name": "@img/sharp-win32-x64",
-      "version": "0.35.3",
+      "version": "0.35.4",
       "license": "Apache-2.0"
     },
     {
@@ -1412,7 +1412,7 @@
     },
     {
       "name": "sharp",
-      "version": "0.35.3",
+      "version": "0.35.4",
       "license": "Apache-2.0"
     },
     {
@@ -1792,67 +1792,67 @@
         },
         {
           "name": "@img/sharp-darwin-arm64",
-          "version": "0.35.3"
+          "version": "0.35.4"
         },
         {
           "name": "@img/sharp-darwin-x64",
-          "version": "0.35.3"
+          "version": "0.35.4"
         },
         {
           "name": "@img/sharp-freebsd-wasm32",
-          "version": "0.35.3"
+          "version": "0.35.4"
         },
         {
           "name": "@img/sharp-linux-arm",
-          "version": "0.35.3"
+          "version": "0.35.4"
         },
         {
           "name": "@img/sharp-linux-arm64",
-          "version": "0.35.3"
+          "version": "0.35.4"
         },
         {
           "name": "@img/sharp-linux-ppc64",
-          "version": "0.35.3"
+          "version": "0.35.4"
         },
         {
           "name": "@img/sharp-linux-riscv64",
-          "version": "0.35.3"
+          "version": "0.35.4"
         },
         {
           "name": "@img/sharp-linux-s390x",
-          "version": "0.35.3"
+          "version": "0.35.4"
         },
         {
           "name": "@img/sharp-linux-x64",
-          "version": "0.35.3"
+          "version": "0.35.4"
         },
         {
           "name": "@img/sharp-linuxmusl-arm64",
-          "version": "0.35.3"
+          "version": "0.35.4"
         },
         {
           "name": "@img/sharp-linuxmusl-x64",
-          "version": "0.35.3"
+          "version": "0.35.4"
         },
         {
           "name": "@img/sharp-wasm32",
-          "version": "0.35.3"
+          "version": "0.35.4"
         },
         {
           "name": "@img/sharp-webcontainers-wasm32",
-          "version": "0.35.3"
+          "version": "0.35.4"
         },
         {
           "name": "@img/sharp-win32-arm64",
-          "version": "0.35.3"
+          "version": "0.35.4"
         },
         {
           "name": "@img/sharp-win32-ia32",
-          "version": "0.35.3"
+          "version": "0.35.4"
         },
         {
           "name": "@img/sharp-win32-x64",
-          "version": "0.35.3"
+          "version": "0.35.4"
         },
         {
           "name": "flatbuffers",
@@ -1880,43 +1880,43 @@
       "packages": [
         {
           "name": "@img/sharp-libvips-darwin-arm64",
-          "version": "1.3.2"
+          "version": "1.3.3"
         },
         {
           "name": "@img/sharp-libvips-darwin-x64",
-          "version": "1.3.2"
+          "version": "1.3.3"
         },
         {
           "name": "@img/sharp-libvips-linux-arm",
-          "version": "1.3.2"
+          "version": "1.3.3"
         },
         {
           "name": "@img/sharp-libvips-linux-arm64",
-          "version": "1.3.2"
+          "version": "1.3.3"
         },
         {
           "name": "@img/sharp-libvips-linux-ppc64",
-          "version": "1.3.2"
+          "version": "1.3.3"
         },
         {
           "name": "@img/sharp-libvips-linux-riscv64",
-          "version": "1.3.2"
+          "version": "1.3.3"
         },
         {
           "name": "@img/sharp-libvips-linux-s390x",
-          "version": "1.3.2"
+          "version": "1.3.3"
         },
         {
           "name": "@img/sharp-libvips-linux-x64",
-          "version": "1.3.2"
+          "version": "1.3.3"
         },
         {
           "name": "@img/sharp-libvips-linuxmusl-arm64",
-          "version": "1.3.2"
+          "version": "1.3.3"
         },
         {
           "name": "@img/sharp-libvips-linuxmusl-x64",
-          "version": "1.3.2"
+          "version": "1.3.3"
         }
       ],
       "licenseType": "LGPL-3.0-or-later",
@@ -3474,7 +3474,7 @@
       "packages": [
         {
           "name": "sharp",
-          "version": "0.35.3"
+          "version": "0.35.4"
         }
       ],
       "licenseType": "Apache-2.0",


### PR DESCRIPTION
**P1 — restores main** (RED at 73525d0e). Anchor t/3443.

## Cause
My #2145 (t/3440) bumped sharp 0.35.3→0.35.4 without regenerating license notices, so the **t/2918 license-staleness gate** fails every PR's `ci-gate`.

## Fix
Ran `npm run licenses` (generate-notices.cjs + parse-licenses.cjs) against the current workspace — root `pnpm-lock.yaml` carries sharp 0.35.4 + its `@img/sharp-*` set. Regenerated:
- `THIRD-PARTY-NOTICES.txt`
- `src/renderer/data/oss-licenses.json`

Diff = the `@img/sharp-*@0.35.3` notice rows update to **0.35.4** (27/27 + 54/54 lines). 324 packages, 128 blocks.

Causer-executed per TL (Rosetta heads-up given — their files). **Merge on green** (P1).

Follow-up (on t/3443, not blocking): #2145's PR CI was GREEN on identical content yet main's ci-gate is RED — the PR-vs-main license-gate discrepancy.