### PR TITLE
fix(ci): add root pnpm-lock.yaml to electron paths-filter — license gate must fire pre-merge (t/3443)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,15 @@ jobs:
               - 'ai-models.json'
               - '.github/workflows/ci.yml'
               - 'scripts/AITriad/Prompts/**'  # promptCatalog.lint validates this dir; must re-run when prompts change here (t/2915)
+              # root pnpm-lock.yaml — the license-notices staleness gate (t/2918) lives INSIDE
+              # this job and reads the @img/sharp-* set directly from the ROOT lockfile
+              # (generate-notices.cjs:224 → path.resolve('..','pnpm-lock.yaml')). A root-lock-only
+              # dep bump (e.g. sharp 0.35.3→0.35.4, #2145) shifts the notices content but matched
+              # NO electron path → test-electron skipped on the PR → the REQUIRED license gate
+              # false-greened (ci-gate treats a skipped gated job as satisfied; t/2094/t/2025
+              # soundness rule) → reds post-merge on main's unconditional run. Include the root
+              # lockfile so the gate fires pre-merge on any dep bump that can shift notices (t/3443).
+              - 'pnpm-lock.yaml'
             debate:
               - 'lib/debate/**'
               - 'evals/**'


### PR DESCRIPTION
**Prevention arm for t/3443** (TL-routed, p/320#18 / t/3443#2). Held **draft** for TL Gate-Verification (gate-touching prevention).

## Root cause (grounded)
The t/2918 license-notices staleness gate runs **inside `test-electron`** and reads the `@img/sharp-*` set directly from the **root** `pnpm-lock.yaml` — `generate-notices.cjs:224` → `path.resolve('..','pnpm-lock.yaml')`. The `electron` paths-filter did **not** list root `pnpm-lock.yaml`, so #2145's root-lock-only sharp bump (0.35.3→0.35.4) shifted notices content yet matched no electron path → `test-electron` **skipped on the PR** → the **required** license gate was false-greened (ci-gate treats a skipped gated job as satisfied — t/2094/t/2025 soundness rule) → red post-merge on main's unconditional run.

## Fix
Add `pnpm-lock.yaml` (root) to the `electron` filter, so any root-lockfile dep bump that can shift notices fires `test-electron` + the license gate **pre-merge**. Same soundness reasoning already applied to the `embeddings` filter (root-adjacent `taxonomy-editor/pnpm-lock.yaml`, ci.yml:139) and `container` (root `pnpm-lock.yaml`, ci.yml:186).

## Gate-Verification (both arms)
- **Arm A (gate now catches):** with root `pnpm-lock.yaml` in the filter, a root-lock sharp bump matches `electron` → `test-electron` runs → license gate regenerates + diffs → **reds** on stale notices (the #2145 scenario now caught pre-merge).
- **Arm B (no false-fire):** when notices are up to date the gate passes. Proven live on **this PR** — it touches `ci.yml` (already in the `electron` filter) so `test-electron` runs here; its license step must be green.
- **No promotion:** `test-electron` is already a required blocking job; this only broadens *when* it triggers. Not advisory→blocking, no new required check.

Closes the prevention follow-up on t/3443.