### PR TITLE
fix(debate): default Invoke-DebateGroundingBatch to flash-lite + MaxTokens 512 (t/3438#6)

### DIFF
--- a/scripts/AITriad/Public/Invoke-DebateGroundingBatch.ps1
+++ b/scripts/AITriad/Public/Invoke-DebateGroundingBatch.ps1
@@ -20,7 +20,9 @@
 .PARAMETER TaxonomyPath
     Path to the taxonomy directory containing POV JSON files. Defaults to Get-TaxonomyDir.
 .PARAMETER Model
-    AI model. Default: gemini-3.5-flash (first-person prose quality; CL recommendation).
+    AI model. Default: gemini-3.5-flash-lite. NOTE: do NOT use a thinking model (e.g. gemini-3.5-flash)
+    here — it spends the token budget on internal reasoning and truncates the statement mid-word, leaking
+    reasoning-trace fragments (t/3438#6). flash-lite emits the full statement.
 .PARAMETER Concurrency
     Parallel AI calls. Default: 10.
 .PARAMETER Force
@@ -45,7 +47,7 @@ function Invoke-DebateGroundingBatch {
     [OutputType([PSCustomObject])]
     param(
         [Parameter()][string]$TaxonomyPath,
-        [Parameter()][string]$Model = 'gemini-3.5-flash',
+        [Parameter()][string]$Model = 'gemini-3.5-flash-lite',
         [Parameter()][ValidateRange(1, 50)][int]$Concurrency = 10,
         [switch]$Force,
         [Parameter()]
@@ -149,7 +151,9 @@ function Invoke-DebateGroundingBatch {
         $CompRef = $using:Completed; $TotalCount = $using:Total; $ProgId = $using:ProgressId
 
         try {
-            $AIResult = Invoke-AIApi -Prompt $Item.Prompt -Model $using:Model -Temperature 0.3 -MaxTokens 256
+            # MaxTokens 512: flash-lite's longest 9-node sample output was ~401 chars (~100 tokens); 512 is
+            # safe headroom. The old 256 truncated even clean output (t/3438#6).
+            $AIResult = Invoke-AIApi -Prompt $Item.Prompt -Model $using:Model -Temperature 0.3 -MaxTokens 512
             if ($null -ne $AIResult -and -not [string]::IsNullOrWhiteSpace($AIResult.Text)) {
                 $Text = $AIResult.Text.Trim()
                 $FileDict = $ResultsDict.GetOrAdd($Item.FilePath, [System.Collections.Concurrent.ConcurrentDictionary[string, string]]::new())

--- a/taxonomy-editor/src/renderer/data/promptCatalog.ts
+++ b/taxonomy-editor/src/renderer/data/promptCatalog.ts
@@ -605,7 +605,7 @@ export const PROMPT_CATALOG: PromptCatalogEntry[] = [
     applicableDataSources: ['taxonomyNodes'],
     promptFiles: ['debate-grounding'],
     psParameters: [
-      { name: '-Model', type: 'string', default: 'gemini-3.5-flash', description: 'AI model for generation' },
+      { name: '-Model', type: 'string', default: 'gemini-3.5-flash-lite', description: 'AI model for generation (NOT a thinking model — those truncate; t/3438#6)' },
       { name: '-Concurrency', type: 'number', default: '10', description: 'Parallel AI calls' },
       { name: '-Force', type: 'switch', default: 'false', description: 'Regenerate even nodes that already have debate_grounding' },
       { name: '-Id', type: 'string[]', default: '(all POV nodes)', description: 'Process only the specified node ID(s)' },


### PR DESCRIPTION
**Blocker found in CL spot-check (t/3438#6).** Every debate_grounding output truncated mid-word at ~30-60 chars — `gemini-3.5-flash` is a **thinking model**: it spends the token budget on internal reasoning and truncates the answer (leaking reasoning-trace fragments), even at MaxTokens 1024. `flash-lite` doesn't think and emits the full statement.

**CL A/B evidence:** flash@256 → truncated ~30 chars (prompt-echo); flash@1024 → still truncated ~250 chars; **flash-lite@1024 → 9/9 complete, clean, register-correct.**

**Fix (config only, 2 lines):**
- default `-Model`: `gemini-3.5-flash` → **`gemini-3.5-flash-lite`**
- per-call `-MaxTokens`: `256` → **`512`** (flash-lite's longest 9-node sample ≈ 401 chars ≈ ~100 tokens; 512 is safe headroom)
- promptCatalog `-Model` default synced + both spots documented ("not a thinking model").

Prompt is **unchanged** (CL-validated 9/9). Cmdlet tests 4/4 green.

**Self-cert /trivial-change** — config-only; the behavioral fix is verified by CL's live 9-node sample (not unit-testable without paid AI). My earlier flash default came from the (now-corrected) t/3366#11 recommendation.

On merge, CL re-spot-checks, then the PI-authorized ~916-node /data-mutation backfill proceeds (TL second counter). Does NOT authorize the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)