### PR TITLE
fix(deps): remove ineffective adm-zip override from pnpm-workspace.yaml (t/3442 condition-2)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,6 @@ settings:
 
 overrides:
   axios: '>=1.8.4'
-  adm-zip: '>=0.6.0'
   brace-expansion: '>=2.0.2'
   sharp: '>=0.35.4 <0.36'
   fast-xml-parser: '>=5.10.1'
@@ -2767,6 +2766,10 @@ packages:
     resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  adm-zip@0.5.18:
+    resolution: {integrity: sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==}
+    engines: {node: '>=12.0'}
 
   adm-zip@0.6.0:
     resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
@@ -9056,6 +9059,8 @@ snapshots:
 
   acorn@8.18.0: {}
 
+  adm-zip@0.5.18: {}
+
   adm-zip@0.6.0: {}
 
   agent-base@6.0.2(supports-color@10.2.2):
@@ -11672,7 +11677,7 @@ snapshots:
 
   onnxruntime-node@1.24.3:
     dependencies:
-      adm-zip: 0.6.0
+      adm-zip: 0.5.18
       global-agent: 3.0.0
       onnxruntime-common: 1.24.3
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,6 @@ packages:
 
 overrides:
   axios: ">=1.8.4"
-  adm-zip: ">=0.6.0"
   brace-expansion: ">=2.0.2"
   sharp: ">=0.35.4 <0.36"
   fast-xml-parser: ">=5.10.1"

--- a/taxonomy-editor/THIRD-PARTY-NOTICES.txt
+++ b/taxonomy-editor/THIRD-PARTY-NOTICES.txt
@@ -1060,11 +1060,12 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following npm packages may be included in this product:
 
+ - adm-zip@0.5.18
  - adm-zip@0.6.0
 
-This package contains the following license:
+These packages each contain the following license:
 
 MIT License
 

--- a/taxonomy-editor/pnpm-lock.yaml
+++ b/taxonomy-editor/pnpm-lock.yaml
@@ -6,7 +6,6 @@ settings:
 
 overrides:
   axios: '>=1.8.4'
-  adm-zip: '>=0.6.0'
   brace-expansion: '>=2.0.2'
   sharp: '>=0.35.4 <0.36'
   fast-xml-parser: '>=5.10.1'
@@ -2254,6 +2253,10 @@ packages:
     resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  adm-zip@0.5.18:
+    resolution: {integrity: sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==}
+    engines: {node: '>=12.0'}
 
   adm-zip@0.6.0:
     resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
@@ -8134,6 +8137,8 @@ snapshots:
 
   acorn@8.18.0: {}
 
+  adm-zip@0.5.18: {}
+
   adm-zip@0.6.0: {}
 
   agent-base@6.0.2(supports-color@10.2.2):
@@ -10584,7 +10589,7 @@ snapshots:
 
   onnxruntime-node@1.24.3:
     dependencies:
-      adm-zip: 0.6.0
+      adm-zip: 0.5.18
       global-agent: 3.0.0
       onnxruntime-common: 1.24.3
 

--- a/taxonomy-editor/src/renderer/data/oss-licenses.json
+++ b/taxonomy-editor/src/renderer/data/oss-licenses.json
@@ -412,6 +412,11 @@
     },
     {
       "name": "adm-zip",
+      "version": "0.5.18",
+      "license": "MIT"
+    },
+    {
+      "name": "adm-zip",
       "version": "0.6.0",
       "license": "MIT"
     },
@@ -2116,6 +2121,10 @@
     },
     {
       "packages": [
+        {
+          "name": "adm-zip",
+          "version": "0.5.18"
+        },
         {
           "name": "adm-zip",
           "version": "0.6.0"


### PR DESCRIPTION
Completes t/3442 condition-2 (TL p/455#214) at the **real SSOT**. Security — adm-zip accept-with-rationale.

## Why
The earlier package.json removals (#2147/#2144) were **inert** — pnpm honors overrides only from `pnpm-workspace.yaml` (t/3440 lesson). The effective `adm-zip: ">=0.6.0"` override still lived there; a `>=` pin resolving to the vulnerable 0.6.0 reads like a mitigation but is none — the exact false-comfort condition-2 forbids.

## Change
Removed `adm-zip` from `pnpm-workspace.yaml`; regenerated root lockfile + standalone (`sync-standalone-lockfile.mjs`). `lockfile-overrides-check` passes (15 entries; adm-zip gone from both override blocks).

## Resolution after removal (dismissal record, per TL)
adm-zip now resolves to **two** versions, both still in-range (the override had collapsed them to one 0.6.0):
- `adm-zip@0.5.18` ← onnxruntime-node@1.24.3 ← @huggingface/transformers
- `adm-zip@0.6.0` ← onnxruntime-node@1.29.0 (direct + via taxonomy-editor)

**Both trace to onnxruntime-node only** (install-time postinstall extracting its own official ONNX binary). Zero first-party/runtime use → the non-reachability rationale holds for both. Per TL: resolving back into the vulnerable range is fine; rationale rests on non-reachability, not version.

## Next
On merge: dismiss alerts #344/#345 with the approved rationale + re-open triggers, close t/3442.

Self-cert `/trivial-change`. CI Node-22 authoritative.