### PR TITLE
fix(deps): reinstate adm-zip >=0.6.0 override — closes HIGH DoS #303/#307 (t/3442)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   '@opentelemetry/core': '>=2.8.0'
   js-yaml: '>=4.3.1'
   image-size: '>=1.2.2'
+  adm-zip: '>=0.6.0'
   fast-uri: '>=3.1.6 <4'
   '@xmldom/xmldom': '>=0.8.15 <0.9'
   browserslist: '>=4.28.7'
@@ -2766,10 +2767,6 @@ packages:
     resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-
-  adm-zip@0.5.18:
-    resolution: {integrity: sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==}
-    engines: {node: '>=12.0'}
 
   adm-zip@0.6.0:
     resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
@@ -9059,8 +9056,6 @@ snapshots:
 
   acorn@8.18.0: {}
 
-  adm-zip@0.5.18: {}
-
   adm-zip@0.6.0: {}
 
   agent-base@6.0.2(supports-color@10.2.2):
@@ -11677,7 +11672,7 @@ snapshots:
 
   onnxruntime-node@1.24.3:
     dependencies:
-      adm-zip: 0.5.18
+      adm-zip: 0.6.0
       global-agent: 3.0.0
       onnxruntime-common: 1.24.3
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,14 @@ overrides:
   "@opentelemetry/core": ">=2.8.0"
   js-yaml: ">=4.3.1"
   image-size: ">=1.2.2"
+  # adm-zip pinned >=0.6.0 — this CLOSES the HIGH 4GB-alloc DoS (Dependabot #303/#307, range <0.6.0,
+  # fixed in 0.6.0). Real security value — without it the graph regresses to 0.5.18 (onnxruntime-node
+  # 1.24.3) and reopens the HIGH — that regression is exactly what t/3442 round 2 hit. It does NOT
+  # mitigate the separate symlink-follow MEDIUM (#344/#345, affects <=0.6.0 incl 0.6.0, no patch
+  # exists) — that advisory is accepted as non-reachable per t/3442 (adm-zip is onnxruntime-node
+  # postinstall-only, zero first-party/runtime use). Keep this pin. Comment lines here must stay
+  # colon-space-free (check-lockfile-overrides.mjs is a line parser, t/3440).
+  adm-zip: ">=0.6.0"
   # Security bumps (t/3283, Dependabot #338-341/#336/#326). Capped to the patched line, NOT
   # bare ">=", so (a) the fix stays minimal-blast-radius — fast-uri <4 avoids a major-version
   # jump, @xmldom <0.9 stays in the 0.8 line — and (b) the root and standalone lockfiles

--- a/taxonomy-editor/THIRD-PARTY-NOTICES.txt
+++ b/taxonomy-editor/THIRD-PARTY-NOTICES.txt
@@ -1060,12 +1060,11 @@ THE SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following npm package may be included in this product:
 
- - adm-zip@0.5.18
  - adm-zip@0.6.0
 
-These packages each contain the following license:
+This package contains the following license:
 
 MIT License
 

--- a/taxonomy-editor/pnpm-lock.yaml
+++ b/taxonomy-editor/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   '@opentelemetry/core': '>=2.8.0'
   js-yaml: '>=4.3.1'
   image-size: '>=1.2.2'
+  adm-zip: '>=0.6.0'
   fast-uri: '>=3.1.6 <4'
   '@xmldom/xmldom': '>=0.8.15 <0.9'
   browserslist: '>=4.28.7'
@@ -2253,10 +2254,6 @@ packages:
     resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-
-  adm-zip@0.5.18:
-    resolution: {integrity: sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==}
-    engines: {node: '>=12.0'}
 
   adm-zip@0.6.0:
     resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
@@ -8137,8 +8134,6 @@ snapshots:
 
   acorn@8.18.0: {}
 
-  adm-zip@0.5.18: {}
-
   adm-zip@0.6.0: {}
 
   agent-base@6.0.2(supports-color@10.2.2):
@@ -10589,7 +10584,7 @@ snapshots:
 
   onnxruntime-node@1.24.3:
     dependencies:
-      adm-zip: 0.5.18
+      adm-zip: 0.6.0
       global-agent: 3.0.0
       onnxruntime-common: 1.24.3
 

--- a/taxonomy-editor/src/renderer/data/oss-licenses.json
+++ b/taxonomy-editor/src/renderer/data/oss-licenses.json
@@ -412,11 +412,6 @@
     },
     {
       "name": "adm-zip",
-      "version": "0.5.18",
-      "license": "MIT"
-    },
-    {
-      "name": "adm-zip",
       "version": "0.6.0",
       "license": "MIT"
     },
@@ -2121,10 +2116,6 @@
     },
     {
       "packages": [
-        {
-          "name": "adm-zip",
-          "version": "0.5.18"
-        },
         {
           "name": "adm-zip",
           "version": "0.6.0"


### PR DESCRIPTION
**Reverses #2154.** Security — reinstates a HIGH-closing override that #2154 wrongly removed as "false comfort" (TL correction p/455#217 / t/3442#6).

## Why
adm-zip has **two** advisories; `>=0.6.0` legitimately closes one:
- **HIGH 4GB-alloc DoS (#303/#307):** range `<0.6.0`, **fixed in 0.6.0** → the pin forces 0.6.0 and closes it. Removing it regressed the graph to `adm-zip@0.5.18` (onnxruntime-node@1.24.3) and **reopened both HIGHs**.
- **Symlink-follow MEDIUM (#344/#345):** range `<=0.6.0` (incl 0.6.0), **no patch** → not mitigated by the pin; accepted as non-reachable (onnxruntime-node postinstall-only). **Those dismissals stand.**

## Change
Reinstated `adm-zip: ">=0.6.0"` in `pnpm-workspace.yaml` **with a co-located comment** documenting what it does/doesn't cover (so it isn't removed a third time). Both lockfiles regenerated → adm-zip back to a single **0.6.0** (0.5.18 gone); `lockfile-overrides-check` green (16 entries); license notices regenerated (326 pkgs). Comment kept colon-space-free (line-parser trap, t/3440).

## Verify on merge
#303/#307 close; #344/#345 stay dismissed. Self-cert `/trivial-change`.